### PR TITLE
Add basic CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+on: [push, pull_request]
+
+env:
+  BUILD_PROFILE: Release
+
+jobs:
+  build:
+    runs-on: windows-2022
+    steps:
+      # Download repo source code
+      - name: Checkout
+        uses: actions/checkout@v3
+      # Setup msbuild toolchain
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+      # Compile code base
+      - name: Build
+        run: msbuild /p:Configuration=${{ env.BUILD_PROFILE }}
+      # Upload resulting binaries
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          # Upload all files from `game/` directory
+          path: |
+            game/*.*


### PR DESCRIPTION
This adds a basic GitHub Actions config that simply builds the binaries from scratch on commit push and pull requests, and uploads the resulting build artifacts.
A sample run can be seen here: https://github.com/GeckoEidechse/r5sdk/actions/runs/4084653963

Note that in terms of CI/CD this is rather bare bones as all it does is it simply builds the package to ensure no compilation errors and uploads the resulting binaries as artifacts which can then be used by playtesters.

GitHub generally only allows logged in users to download CI artifacts but you can sidestep that using a service like https://nightly.link/ which means that anyone can test pull requests without having to locally compile the PR or needing a GitHub account for download.

For reference [I wrote a development tool for Northstar](https://github.com/GeckoEidechse/northstar_dev_testing_helper_tool) that makes use of CI build artifacts and nightly.link to 1-click download and install development builds for rapid PR testing. Adding basic CI/CD and publishing resulting build artifacts would enable similar tooling for r5sdk.