### PR TITLE
Cmdline export

### DIFF
--- a/r5dev/core/dllmain.cpp
+++ b/r5dev/core/dllmain.cpp
@@ -76,6 +76,11 @@ void Tier0_Init()
 
     g_pCmdLine->CreateCmdLine(GetCommandLineA());
     g_CrashHandler->SetCrashCallback(&Crash_Callback);
+
+    // This prevents the game from recreating it,
+    // see 'CCommandLine::StaticCreateCmdLine' for
+    // more information.
+    g_bCommandLineCreated = true;
 }
 
 void SDK_Init()

--- a/r5dev/core/dllmain.cpp
+++ b/r5dev/core/dllmain.cpp
@@ -124,16 +124,15 @@ void SDK_Init()
 
 void SDK_Shutdown()
 {
-    static bool bShutDown = false;
-    assert(!bShutDown);
+    assert(g_bSdkInitialized);
 
-    if (bShutDown)
+    if (!g_bSdkInitialized)
     {
         spdlog::error("Recursive shutdown!\n");
         return;
     }
 
-    bShutDown = true;
+    g_bSdkInitialized = false;
     spdlog::info("Shutdown GameSDK\n");
 
     curl_global_cleanup();

--- a/r5dev/core/init.cpp
+++ b/r5dev/core/init.cpp
@@ -149,7 +149,7 @@
 
 void Systems_Init()
 {
-	spdlog::info("+-------------------------------------------------------------+\n");
+	DevMsg(eDLL_T::NONE, "+-------------------------------------------------------------+\n");
 	QuerySystemInfo();
 
 	DetourRegister();
@@ -159,8 +159,8 @@ void Systems_Init()
 	DetourInit();
 	initTimer.End();
 
-	spdlog::info("+-------------------------------------------------------------+\n");
-	spdlog::info("{:16s} '{:10.6f}' seconds ('{:12d}' clocks)\n", "Detour->InitDB()",
+	DevMsg(eDLL_T::NONE, "+-------------------------------------------------------------+\n");
+	DevMsg(eDLL_T::NONE, "%-16s '%10.6f' seconds ('%12lu' clocks)\n", "Detour->InitDB()",
 		initTimer.GetDuration().GetSeconds(), initTimer.GetDuration().GetCycles());
 
 	initTimer.Start();
@@ -187,9 +187,9 @@ void Systems_Init()
 	}
 
 	initTimer.End();
-	spdlog::info("{:16s} '{:10.6f}' seconds ('{:12d}' clocks)\n", "Detour->Attach()",
+	DevMsg(eDLL_T::NONE, "%-16s '%10.6f' seconds ('%12lu' clocks)\n", "Detour->Attach()",
 		initTimer.GetDuration().GetSeconds(), initTimer.GetDuration().GetCycles());
-	spdlog::info("+-------------------------------------------------------------+\n");
+	DevMsg(eDLL_T::NONE, "+-------------------------------------------------------------+\n");
 
 	ConVar_StaticInit();
 }
@@ -224,9 +224,9 @@ void Systems_Shutdown()
 	DetourTransactionCommit();
 
 	shutdownTimer.End();
-	spdlog::info("{:16s} '{:10.6f}' seconds ('{:12d}' clocks)\n", "Detour->Detach()",
+	DevMsg(eDLL_T::NONE, "%-16s '%10.6f' seconds ('%12lu' clocks)\n", "Detour->Detach()",
 		shutdownTimer.GetDuration().GetSeconds(), shutdownTimer.GetDuration().GetCycles());
-	spdlog::info("+-------------------------------------------------------------+\n");
+	DevMsg(eDLL_T::NONE, "+-------------------------------------------------------------+\n");
 }
 
 /////////////////////////////////////////////////////
@@ -275,20 +275,20 @@ void QuerySystemInfo()
 		{
 			char szDeviceName[128];
 			wcstombs(szDeviceName, dd.DeviceString, sizeof(szDeviceName));
-			spdlog::info("{:25s}: '{:s}'\n", "GPU model identifier", szDeviceName);
+			DevMsg(eDLL_T::NONE, "%-25s: '%s'\n", "GPU model identifier", szDeviceName);
 		}
 	}
 #endif // !DEDICATED
 
 	const CPUInformation& pi = GetCPUInformation();
 
-	spdlog::info("{:25s}: '{:s}'\n","CPU model identifier", pi.m_szProcessorBrand);
-	spdlog::info("{:25s}: '{:s}'\n","CPU vendor tag", pi.m_szProcessorID);
-	spdlog::info("{:25s}: '{:12d}' ('{:2d}' {:s})\n", "CPU core count", pi.m_nPhysicalProcessors, pi.m_nLogicalProcessors, "logical");
-	spdlog::info("{:25s}: '{:12d}' ({:12s})\n", "CPU core speed", pi.m_Speed, "Cycles");
-	spdlog::info("{:20s}{:s}: '{:12d}' (0x{:<10X})\n", "L1 cache", "(KiB)", pi.m_nL1CacheSizeKb, pi.m_nL1CacheDesc);
-	spdlog::info("{:20s}{:s}: '{:12d}' (0x{:<10X})\n", "L2 cache", "(KiB)", pi.m_nL2CacheSizeKb, pi.m_nL2CacheDesc);
-	spdlog::info("{:20s}{:s}: '{:12d}' (0x{:<10X})\n", "L3 cache", "(KiB)", pi.m_nL3CacheSizeKb, pi.m_nL3CacheDesc);
+	DevMsg(eDLL_T::NONE, "%-25s: '%s'\n","CPU model identifier", pi.m_szProcessorBrand);
+	DevMsg(eDLL_T::NONE, "%-25s: '%s'\n","CPU vendor tag", pi.m_szProcessorID);
+	DevMsg(eDLL_T::NONE, "%-25s: '%12hhu' ('%2hhu' %s)\n", "CPU core count", pi.m_nPhysicalProcessors, pi.m_nLogicalProcessors, "logical");
+	DevMsg(eDLL_T::NONE, "%-25s: '%12lld' (%-12s)\n", "CPU core speed", pi.m_Speed, "Cycles");
+	DevMsg(eDLL_T::NONE, "%-20s%s: '%12lu' (0x%-10X)\n", "L1 cache", "(KiB)", pi.m_nL1CacheSizeKb, pi.m_nL1CacheDesc);
+	DevMsg(eDLL_T::NONE, "%-20s%s: '%12lu' (0x%-10X)\n", "L2 cache", "(KiB)", pi.m_nL2CacheSizeKb, pi.m_nL2CacheDesc);
+	DevMsg(eDLL_T::NONE, "%-20s%s: '%12lu' (0x%-10X)\n", "L3 cache", "(KiB)", pi.m_nL3CacheSizeKb, pi.m_nL3CacheDesc);
 
 	MEMORYSTATUSEX statex{};
 	statex.dwLength = sizeof(statex);
@@ -301,13 +301,13 @@ void QuerySystemInfo()
 		DWORDLONG availPhysical = (statex.ullAvailPhys / 1024) / 1024;
 		DWORDLONG availVirtual = (statex.ullAvailVirtual / 1024) / 1024;
 
-		spdlog::info("{:20s}{:s}: '{:12d}' ('{:9d}' {:s})\n", "Total system memory", "(MiB)", totalPhysical, totalVirtual, "virtual");
-		spdlog::info("{:20s}{:s}: '{:12d}' ('{:9d}' {:s})\n", "Avail system memory", "(MiB)", availPhysical, availVirtual, "virtual");
+		DevMsg(eDLL_T::NONE, "%-20s%s: '%12llu' ('%9llu' %s)\n", "Total system memory", "(MiB)", totalPhysical, totalVirtual, "virtual");
+		DevMsg(eDLL_T::NONE, "%-20s%s: '%12llu' ('%9llu' %s)\n", "Avail system memory", "(MiB)", availPhysical, availVirtual, "virtual");
 	}
 	else
 	{
-		spdlog::error("Unable to retrieve system memory information: {:s}\n", 
-			std::system_category().message(static_cast<int>(::GetLastError())));
+		Error(eDLL_T::COMMON, NO_ERROR, "Unable to retrieve system memory information: %s\n",
+			std::system_category().message(static_cast<int>(::GetLastError())).c_str());
 	}
 }
 
@@ -337,12 +337,11 @@ void CheckCPU() // Respawn's engine and our SDK utilize POPCNT, SSE3 and SSSE3 (
 
 void DetourInit() // Run the sigscan
 {
-	LPSTR pCommandLine = GetCommandLineA();
-
-	bool bLogAdr = (strstr(pCommandLine, "-sig_toconsole") != nullptr);
+	const bool bLogAdr = CommandLine()->CheckParm("-sig_toconsole") ? true : false;
+	const bool bNoSmap = CommandLine()->CheckParm("-nosmap") ? true : false;
 	bool bInitDivider = false;
 
-	g_SigCache.SetDisabled((strstr(pCommandLine, "-nosmap") != nullptr));
+	g_SigCache.SetDisabled(bNoSmap);
 	g_SigCache.LoadCache(SIGDB_FILE);
 
 	for (const IDetour* pDetour : g_DetourVector)

--- a/r5dev/core/init.h
+++ b/r5dev/core/init.h
@@ -14,3 +14,5 @@ void CheckCPU();
 void DetourInit();
 void DetourAddress();
 void DetourRegister();
+
+extern bool g_bSdkInitialized;

--- a/r5dev/core/logdef.cpp
+++ b/r5dev/core/logdef.cpp
@@ -10,7 +10,7 @@ std::shared_ptr<spdlog::sinks::ostream_sink_st> g_LogSink;
 //#############################################################################
 // SPDLOG INIT
 //#############################################################################
-void SpdLog_Init(void)
+void SpdLog_Init(const bool bAnsiColor)
 {
 	static bool bInitialized = false;
 
@@ -30,7 +30,7 @@ void SpdLog_Init(void)
 		g_LogSink = std::make_shared<spdlog::sinks::ostream_sink_st>(g_LogStream);
 		g_ImGuiLogger = std::make_shared<spdlog::logger>("game_console", g_LogSink);
 		spdlog::register_logger(g_ImGuiLogger); // in-game console logger.
-		g_ImGuiLogger->set_pattern("[0.000] %v");
+		g_ImGuiLogger->set_pattern("%v");
 		g_ImGuiLogger->set_level(spdlog::level::trace);
 	}
 #endif // !NETCONSOLE
@@ -45,14 +45,14 @@ void SpdLog_Init(void)
 #endif // NETCONSOLE
 
 		// Determine if user wants ansi-color logging in the terminal.
-		if (g_svCmdLine.find("-ansicolor") != string::npos)
+		if (bAnsiColor)
 		{
-			g_TermLogger->set_pattern("[0.000] %v\u001b[0m");
+			g_TermLogger->set_pattern("%v\u001b[0m");
 			g_bSpdLog_UseAnsiClr = true;
 		}
 		else
 		{
-			g_TermLogger->set_pattern("[0.000] %v");
+			g_TermLogger->set_pattern("%v");
 		}
 		//g_TermLogger->set_level(spdlog::level::trace);
 	}
@@ -89,25 +89,6 @@ void SpdLog_Create()
 #endif // !DEDICATED
 	spdlog::rotating_logger_mt<spdlog::synchronous_factory>("filesystem"
 		, fmt::format("{:s}\\{:s}", g_LogSessionDirectory, "filesystem.log"), SPDLOG_MAX_SIZE, SPDLOG_NUM_FILE)->set_pattern("[%Y-%m-%d %H:%M:%S.%e] %v");
-}
-
-//#############################################################################
-// SPDLOG POST INIT
-//#############################################################################
-void SpdLog_PostInit()
-{
-#ifndef NETCONSOLE
-	spdlog::flush_every(std::chrono::seconds(5)); // Flush buffers every 5 seconds for every logger.
-	g_ImGuiLogger->set_pattern("%v");
-#endif // !NETCONSOLE
-
-	if (g_svCmdLine.find("-ansicolor") != string::npos)
-	{
-		g_TermLogger->set_pattern("%v\u001b[0m");
-		g_bSpdLog_UseAnsiClr = true;
-	}
-	else { g_TermLogger->set_pattern("%v"); }
-	g_bSpdLog_PostInit = true;
 }
 
 //#############################################################################

--- a/r5dev/core/logdef.h
+++ b/r5dev/core/logdef.h
@@ -14,7 +14,6 @@ constexpr int SPDLOG_MAX_SIZE = 10 * 1024 * 1024; // Sets number of bytes before
 constexpr int SPDLOG_NUM_FILE = 512; // Sets number of files to rotate to.
 
 inline bool g_bSpdLog_UseAnsiClr = false;
-inline bool g_bSpdLog_PostInit = false;
 
 extern std::shared_ptr<spdlog::logger> g_TermLogger;
 extern std::shared_ptr<spdlog::logger> g_ImGuiLogger;
@@ -24,7 +23,6 @@ extern std::shared_ptr<spdlog::logger> g_ImGuiLogger;
 extern std::ostringstream g_LogStream;
 extern std::shared_ptr<spdlog::sinks::ostream_sink_st> g_LogSink;
 
-void SpdLog_Init(void);
+void SpdLog_Init(const bool bAnsiColor);
 void SpdLog_Create(void);
-void SpdLog_PostInit(void);
 void SpdLog_Shutdown(void);

--- a/r5dev/core/r5dev.h
+++ b/r5dev/core/r5dev.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
-// Windows Header Files
-#include <windows.h>
-
 __declspec(dllexport) void DummyExport()
 {
     // Required for detours.

--- a/r5dev/core/termutil.cpp
+++ b/r5dev/core/termutil.cpp
@@ -15,8 +15,6 @@ const char* g_svYellowB = "";
 
 const char* g_svReset   = "";
 
-std::string g_svCmdLine;
-
 //-----------------------------------------------------------------------------
 // Purpose: sets the global ansi escape sequences.
 // If '-ansicolor' has not been passed to the sdk the char will be empty.

--- a/r5dev/core/termutil.h
+++ b/r5dev/core/termutil.h
@@ -13,6 +13,4 @@ extern const char* g_svYellowB;
 
 extern const char* g_svReset;
 
-extern std::string g_svCmdLine;
-
 void AnsiColors_Init();

--- a/r5dev/launcher/launcher.h
+++ b/r5dev/launcher/launcher.h
@@ -13,8 +13,6 @@ inline auto v_RemoveSpuriousGameParameters = p_RemoveSpuriousGameParameters.RCas
 #endif // !GAMEDLL_S0 || !GAMEDLL_S1
 
 void AppendSDKParametersPreInit();
-string LoadConfigFile(const char* svConfig);
-void ParseAndApplyConfigFile(const string& svConfig);
 const char* ExitCodeToString(int nCode);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/r5dev/netconsole/netconsole.cpp
+++ b/r5dev/netconsole/netconsole.cpp
@@ -101,11 +101,11 @@ bool CNetCon::Shutdown(void)
 //-----------------------------------------------------------------------------
 void CNetCon::TermSetup(void)
 {
-	g_svCmdLine = GetCommandLineA();
+	const char* pszCommandLine = GetCommandLineA();
+	const bool bEnableColor = strstr("-ansicolor", pszCommandLine) != nullptr;
 
-	SpdLog_Init();
-	SpdLog_PostInit();
-	Console_Init();
+	SpdLog_Init(bEnableColor);
+	Console_Init(bEnableColor);
 }
 
 //-----------------------------------------------------------------------------

--- a/r5dev/public/tier0/dbg.h
+++ b/r5dev/public/tier0/dbg.h
@@ -66,9 +66,11 @@ enum class LogLevel_t
 	LEVEL_NOTIFY   // Emit to in-game mini console
 };
 //-----------------------------------------------------------------------------
-constexpr const char s_CommonAnsiColor[] = "\033[38;2;255;204;153m";
-constexpr const char s_DefaultAnsiColor[]= "\033[38;2;204;204;204m";
-constexpr const char* s_DllAnsiColor[12] =
+constexpr const char s_CommonAnsiColor[]  = "\033[38;2;255;204;153m";
+constexpr const char s_WarningAnsiColor[] = "\033[38;2;255;255;000m";
+constexpr const char s_ErrorAnsiColor[]   = "\033[38;2;255;000;000m";
+constexpr const char s_DefaultAnsiColor[] = "\033[38;2;204;204;204m";
+constexpr const char* s_DllAnsiColor[14]  =
 {
 	"\033[38;2;059;120;218mNative(S):",
 	"\033[38;2;118;118;118mNative(C):",
@@ -81,6 +83,8 @@ constexpr const char* s_DllAnsiColor[12] =
 	"\033[38;2;185;000;235mNative(V):",
 	"\033[38;2;204;204;204mNetcon(X):",
 	s_CommonAnsiColor,
+	s_WarningAnsiColor,
+	s_ErrorAnsiColor,
 	s_DefaultAnsiColor
 };
 //-----------------------------------------------------------------------------

--- a/r5dev/tier0/commandline.cpp
+++ b/r5dev/tier0/commandline.cpp
@@ -5,6 +5,25 @@
 //=============================================================================//
 #include "tier0/commandline.h"
 
+bool g_bCommandLineCreated = false;
+
+//-----------------------------------------------------------------------------
+// Purpose: Create a command line from the passed in string
+//  Note that if you pass in a @filename, then the routine will read settings
+//  from a file instead of the command line
+//-----------------------------------------------------------------------------
+void CCommandLine::StaticCreateCmdLine(CCommandLine* thisptr, const char* pszCommandLine)
+{
+	// The SDK creates the cmdline instead, when loaded. We hook this
+	// function, and skip the actual creation of subsequent calls.
+	// This is required as otherwise our own appended parameters will
+	// get lost when the game recreates it in 'LauncherMain'.
+	if (!g_bCommandLineCreated)
+	{
+		v_CCommandLine__CreateCmdLine(thisptr, pszCommandLine);
+	}
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: parses a text file and appends its parameters/values
 //-----------------------------------------------------------------------------
@@ -60,7 +79,7 @@ void CCommandLine::AppendParametersFromFile(const char* const pszConfig)
 			pArgValue = pArg;
 		}
 
-		CommandLine()->AppendParm(szTextBuf, pArgValue);
+		AppendParm(szTextBuf, pArgValue);
 	}
 
 	fclose(pFile);
@@ -68,3 +87,14 @@ void CCommandLine::AppendParametersFromFile(const char* const pszConfig)
 
 ///////////////////////////////////////////////////////////////////////////////
 CCommandLine* g_pCmdLine = nullptr;
+
+
+void VCommandLine::Attach() const
+{
+	DetourAttach(&v_CCommandLine__CreateCmdLine, &CCommandLine::StaticCreateCmdLine);
+}
+
+void VCommandLine::Detach() const
+{
+	DetourDetach(&v_CCommandLine__CreateCmdLine, &CCommandLine::StaticCreateCmdLine);
+}

--- a/r5dev/tier0/commandline.cpp
+++ b/r5dev/tier0/commandline.cpp
@@ -10,15 +10,22 @@
 //-----------------------------------------------------------------------------
 void CCommandLine::AppendParametersFromFile(const char* const pszConfig)
 {
-	FILE* const pFile = fopen(pszConfig, "r");
+	char szTextBuf[2048];
+	FILE* pFile = fopen(pszConfig, "r");
+
 	if (!pFile)
 	{
-		printf("%s: '%s' does not exist!\n",
-			__FUNCTION__, pszConfig);
-		return;
-	}
+		// Try the 'PLATFORM' folder.
+		snprintf(szTextBuf, sizeof(szTextBuf), "platform/%s", pszConfig);
+		pFile = fopen(szTextBuf, "r");
 
-	char szTextBuf[2048];
+		if (!pFile)
+		{
+			printf("%s: '%s' does not exist!\n",
+				__FUNCTION__, pszConfig);
+			return;
+		}
+	}
 
 	while (fgets(szTextBuf, sizeof(szTextBuf), pFile))
 	{

--- a/r5dev/windows/console.cpp
+++ b/r5dev/windows/console.cpp
@@ -67,8 +67,9 @@ void FlashConsoleBackground(int nFlashCount, int nFlashInterval, COLORREF color)
 
 //-----------------------------------------------------------------------------
 // Purpose: terminal window setup
+// Input  : bAnsiColor - 
 //-----------------------------------------------------------------------------
-void Console_Init()
+void Console_Init(const bool bAnsiColor)
 {
 #ifndef NETCONSOLE
 	///////////////////////////////////////////////////////////////////////////
@@ -102,7 +103,7 @@ void Console_Init()
 	HANDLE hOutput = GetStdHandle(STD_OUTPUT_HANDLE);
 	DWORD dwMode = NULL;
 
-	if (g_svCmdLine.find("-ansicolor") != string::npos)
+	if (bAnsiColor)
 	{
 		GetConsoleMode(hOutput, &dwMode);
 		dwMode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;

--- a/r5dev/windows/console.h
+++ b/r5dev/windows/console.h
@@ -3,5 +3,5 @@
 void SetConsoleBackgroundColor(COLORREF color);
 void FlashConsoleBackground(int nFlashCount, int nFlashInterval, COLORREF color);
 
-void Console_Init();
+void Console_Init(const bool bAnsiColor);
 void Console_Shutdown();


### PR DESCRIPTION
Before, we had to do a hack of capturing the command line using GetCommandLineA, and then checking if a certain argument is present. This was required due to how early the GameSDK dll was loaded (the g_CmdLine object was far from initialized in the engine). Due to the loader refactor, the commandline can be used directly after creation in the game's entry point (which is the time the SDK is getting loaded). Therefore, no copies of the command line are required anymore.
This pull request contains the following changes:

- Correctly ordered the initialization, and deinitialization of systems (first init = last shutdown).
- Factored out command line string copy in favor of game's implementation.
- Factored the R5Reloaded emblem print into its own function.
- Removed 'SpdLog_PostInit()', we can now directly call DevMsg() once SpdLog_Init() has been called, the logger callback sink deals with the formatting of the output.
- Fixed a bug where the logger did not print the correct color for 'SYSTEM_WARNING' and 'SYSTEM_ERROR' in the external console.
- Fixed a bug where the command line did not work when the game wasn't launched with the '-launcher' parameter.
- Logs now equally appear on the external, and in-game console windows.

NOTE: this pull request requires a new executable with the 'g_pCmdLine' symbol exported!