### PR TITLE
Globally reduce the use of auto for function pointer declarations

### DIFF
--- a/r5dev/codecs/Miles/miles_impl.h
+++ b/r5dev/codecs/Miles/miles_impl.h
@@ -3,16 +3,16 @@
 
 /* ==== WASAPI THREAD SERVICE =========================================================================================================================================== */
 inline CMemory p_AIL_LogFunc;
-inline auto v_AIL_LogFunc = p_AIL_LogFunc.RCast<void(*)(int64_t nLogLevel, const char* pszMessage)>();
+inline void(*v_AIL_LogFunc)(int64_t nLogLevel, const char* pszMessage);
 
 inline CMemory p_Miles_Initialize;
-inline auto v_Miles_Initialize = p_Miles_Initialize.RCast<bool(*)()>();
+inline bool(*v_Miles_Initialize)();
 
 inline CMemory p_MilesQueueEventRun;
-inline auto v_MilesQueueEventRun = p_MilesQueueEventRun.RCast<void(*)(Miles::Queue*, const char*)>();
+inline void(*v_MilesQueueEventRun)(Miles::Queue*, const char*);
 
 inline CMemory p_MilesBankPatch;
-inline auto v_MilesBankPatch = p_MilesBankPatch.RCast<void(*)(Miles::Bank*, char*, char*)>();
+inline void(*v_MilesBankPatch)(Miles::Bank*, char*, char*);
 
 ///////////////////////////////////////////////////////////////////////////////
 class MilesCore : public IDetour

--- a/r5dev/codecs/bink/bink_impl.h
+++ b/r5dev/codecs/bink/bink_impl.h
@@ -1,10 +1,10 @@
 #pragma once
 
 inline CMemory p_BinkOpen;
-inline auto v_BinkOpen = p_BinkOpen.RCast<void*(*)(HANDLE hBinkFile, UINT32 nFlags)>();
+inline void*(*v_BinkOpen)(HANDLE hBinkFile, UINT32 nFlags);
 
 inline CMemory p_BinkClose;
-inline auto v_BinkClose = p_BinkClose.RCast<void(*)(HANDLE hBinkFile)>();
+inline void(*v_BinkClose)(HANDLE hBinkFile);
 
 inline CMemory p_BinkGetError;
 inline auto v_BinkGetError = p_BinkGetError.RCast<const char*(*)(void)>();

--- a/r5dev/common/callback.h
+++ b/r5dev/common/callback.h
@@ -1,11 +1,11 @@
 #pragma once
 
 inline CMemory p_SetupGamemode;
-inline auto SetupGamemode = p_SetupGamemode.RCast<bool(*)(const char* pszPlayList)>();
+inline bool(*SetupGamemode)(const char* pszPlayList);
 
 /* ==== CONCOMMANDCALLBACK ============================================================================================================================================== */
 inline CMemory p_DownloadPlaylists_f;
-inline auto _DownloadPlaylists_f = p_DownloadPlaylists_f.RCast<void(*)(void)>();
+inline void(*_DownloadPlaylists_f)(void);
 
 ///////////////////////////////////////////////////////////////////////////////
 void MP_GameMode_Changed_f(IConVar* pConVar, const char* pOldString, float flOldValue);

--- a/r5dev/datacache/mdlcache.h
+++ b/r5dev/datacache/mdlcache.h
@@ -109,22 +109,22 @@ private:
 };
 
 inline CMemory p_CMDLCache__FindMDL;
-inline auto v_CMDLCache__FindMDL = p_CMDLCache__FindMDL.RCast<studiohdr_t* (*)(CMDLCache* pCache, void* a2, void* a3)>();
+inline studiohdr_t*(*v_CMDLCache__FindMDL)(CMDLCache* pCache, void* a2, void* a3);
 #if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
 inline CMemory p_CMDLCache__FindCachedMDL;
-inline auto v_CMDLCache__FindCachedMDL = p_CMDLCache__FindCachedMDL.RCast<void(*)(CMDLCache* pCache, void* a2, void* a3)>();
+inline void(*v_CMDLCache__FindCachedMDL)(CMDLCache* pCache, void* a2, void* a3);
 
 inline CMemory p_CMDLCache__FindUncachedMDL;
-inline auto v_CMDLCache__FindUncachedMDL = p_CMDLCache__FindUncachedMDL.RCast<studiohdr_t* (*)(CMDLCache* pCache, MDLHandle_t handle, void* a3, void* a4)>();
+inline studiohdr_t*(*v_CMDLCache__FindUncachedMDL)(CMDLCache* pCache, MDLHandle_t handle, void* a3, void* a4);
 #endif
 inline CMemory p_CMDLCache__GetStudioHDR;
-inline auto v_CMDLCache__GetStudioHDR = p_CMDLCache__GetStudioHDR.RCast<studiohdr_t* (*)(CMDLCache* pCache, MDLHandle_t handle)>();
+inline studiohdr_t*(*v_CMDLCache__GetStudioHDR)(CMDLCache* pCache, MDLHandle_t handle);
 
 inline CMemory p_CMDLCache__GetHardwareData;
-inline auto v_CMDLCache__GetHardwareData = p_CMDLCache__GetHardwareData.RCast<studiohwdata_t* (*)(CMDLCache* pCache, MDLHandle_t handle)>();
+inline studiohwdata_t*(*v_CMDLCache__GetHardwareData)(CMDLCache* pCache, MDLHandle_t handle);
 #if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
 inline CMemory p_CStudioHWDataRef__SetFlags; // Probably incorrect.
-inline auto v_CStudioHWDataRef__SetFlags = p_CStudioHWDataRef__SetFlags.RCast<bool (*)(CStudioHWDataRef* ref, int64_t flags)>();
+inline bool(*v_CStudioHWDataRef__SetFlags)(CStudioHWDataRef* ref, int64_t flags);
 #endif
 inline CMDLCache* g_pMDLCache = nullptr;
 inline PSRWLOCK* g_pMDLLock = nullptr; // Possibly a member? research required.

--- a/r5dev/ebisusdk/EbisuSDK.h
+++ b/r5dev/ebisusdk/EbisuSDK.h
@@ -1,13 +1,13 @@
 #pragma once
 
 inline CMemory p_EbisuSDK_Tier0_Init;
-inline auto EbisuSDK_Tier0_Init = p_EbisuSDK_Tier0_Init.RCast<void(*)(void)>();
+inline void(*EbisuSDK_Tier0_Init)(void);
 
 inline CMemory p_EbisuSDK_CVar_Init;
-inline auto EbisuSDK_CVar_Init = p_EbisuSDK_CVar_Init.RCast<void(*)(void)>();
+inline void(*EbisuSDK_CVar_Init)(void);
 
 inline CMemory p_EbisuSDK_SetState;
-inline auto EbisuSDK_SetState = p_EbisuSDK_SetState.RCast<void(*)(void)>();
+inline void(*EbisuSDK_SetState)(void);
 
 inline uint64_t* g_NucleusID = nullptr;
 inline char* g_NucleusToken = nullptr; /*SIZE = 1024*/

--- a/r5dev/engine/client/cdll_engine_int.h
+++ b/r5dev/engine/client/cdll_engine_int.h
@@ -52,19 +52,19 @@ public:
 /* ==== CHLCLIENT ======================================================================================================================================================= */
 #ifndef DEDICATED
 inline CMemory p_CHLClient_PostInit;
-inline auto CHLClient_PostInit = p_CHLClient_PostInit.RCast<void*(*)(void)>();
+inline void*(*CHLClient_PostInit)(void);
 
 inline CMemory p_CHLClient_LevelShutdown;
-inline auto CHLClient_LevelShutdown = p_CHLClient_LevelShutdown.RCast<void* (*)(CHLClient* thisptr)>();
+inline void*(*CHLClient_LevelShutdown)(CHLClient* thisptr);
 
 inline CMemory p_CHLClient_HudProcessInput;
-inline auto CHLClient_HudProcessInput = p_CHLClient_HudProcessInput.RCast<void(*)(CHLClient* thisptr, bool bActive)>();
+inline void(*CHLClient_HudProcessInput)(CHLClient* thisptr, bool bActive);
 
 inline CMemory p_CHLClient_FrameStageNotify;
-inline auto CHLClient_FrameStageNotify = p_CHLClient_FrameStageNotify.RCast<void(*)(CHLClient* thisptr, ClientFrameStage_t frameStage)>();
+inline void(*CHLClient_FrameStageNotify)(CHLClient* thisptr, ClientFrameStage_t frameStage);
 
 inline CMemory p_CHLClient_GetAllClasses;
-inline auto CHLClient_GetAllClasses = p_CHLClient_GetAllClasses.RCast<ClientClass*(*)()>();
+inline ClientClass*(*CHLClient_GetAllClasses)();
 #endif // !DEDICATED
 
 inline CHLClient* g_pHLClient = nullptr;

--- a/r5dev/engine/client/cl_ents_parse.h
+++ b/r5dev/engine/client/cl_ents_parse.h
@@ -2,7 +2,7 @@
 #define CL_ENTS_PARSE_H
 
 inline CMemory p_CL_CopyExistingEntity;
-inline auto v_CL_CopyExistingEntity = p_CL_CopyExistingEntity.RCast<bool (*)(__int64 a1, unsigned int* a2, char* a3)>();
+inline bool(*v_CL_CopyExistingEntity)(__int64 a1, unsigned int* a2, char* a3);
 
 bool CL_CopyExistingEntity(__int64 a1, unsigned int* a2, char* a3);
 ///////////////////////////////////////////////////////////////////////////////

--- a/r5dev/engine/client/cl_main.h
+++ b/r5dev/engine/client/cl_main.h
@@ -1,19 +1,19 @@
 #pragma once
 
 inline CMemory p_CL_Move;
-inline auto CL_Move = p_CL_Move.RCast<void(*)(void)>();
+inline void(*CL_Move)(void);
 
 inline CMemory p_CL_SendMove;
-inline auto CL_SendMove = p_CL_SendMove.RCast<void(*)(void)>();
+inline void(*CL_SendMove)(void);
 
 inline CMemory p_CL_EndMovie;
-inline auto CL_EndMovie = p_CL_EndMovie.RCast<int(*)(void)>();
+inline int(*CL_EndMovie)(void);
 
 inline CMemory p_CL_ClearState;
-inline auto CL_ClearState = p_CL_ClearState.RCast<int(*)(void)>();
+inline int(*CL_ClearState)(void);
 
 inline CMemory p_CL_RunPrediction;
-inline auto CL_RunPrediction = p_CL_RunPrediction.RCast<void(*)(void)>();
+inline void(*CL_RunPrediction)(void);
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/r5dev/engine/client/client.h
+++ b/r5dev/engine/client/client.h
@@ -161,28 +161,28 @@ static_assert(sizeof(CClient) == 0x4A4C0);
 
 /* ==== CBASECLIENT ===================================================================================================================================================== */
 inline CMemory p_CClient_Connect;
-inline auto v_CClient_Connect = p_CClient_Connect.RCast<bool (*)(CClient* pClient, const char* szName, void* pNetChannel, bool bFakePlayer, void* a5, char* szMessage, int nMessageSize)>();
+inline bool(*v_CClient_Connect)(CClient* pClient, const char* szName, void* pNetChannel, bool bFakePlayer, void* a5, char* szMessage, int nMessageSize);
 
 inline CMemory p_CClient_Disconnect;
-inline auto v_CClient_Disconnect = p_CClient_Disconnect.RCast<bool (*)(CClient* pClient, const Reputation_t nRepLvl, const char* szReason, ...)>();
+inline bool(*v_CClient_Disconnect)(CClient* pClient, const Reputation_t nRepLvl, const char* szReason, ...);
 
 inline CMemory p_CClient_Clear;
-inline auto v_CClient_Clear = p_CClient_Clear.RCast<void (*)(CClient* pClient)>();
+inline void(*v_CClient_Clear)(CClient* pClient);
 
 inline CMemory p_CClient_ActivatePlayer;
-inline auto v_CClient_ActivatePlayer = p_CClient_ActivatePlayer.RCast<void (*)(CClient* pClient)>();
+inline void(*v_CClient_ActivatePlayer)(CClient* pClient);
 
 inline CMemory p_CClient_ProcessStringCmd;
-inline auto v_CClient_ProcessStringCmd = p_CClient_ProcessStringCmd.RCast<bool (*)(CClient* pClient, NET_StringCmd* pMsg)>();
+inline bool(*v_CClient_ProcessStringCmd)(CClient* pClient, NET_StringCmd* pMsg);
 
 inline CMemory p_CClient_SetSignonState;
-inline auto v_CClient_SetSignonState = p_CClient_SetSignonState.RCast<bool (*)(CClient* pClient, SIGNONSTATE signon)>();
+inline bool(*v_CClient_SetSignonState)(CClient* pClient, SIGNONSTATE signon);
 
 inline CMemory p_CClient_SendNetMsgEx;
-inline auto v_CClient_SendNetMsgEx = p_CClient_SendNetMsgEx.RCast<bool (*)(CClient* pClient, CNetMessage* pMsg, bool bLocal, bool bForceReliable, bool bVoice)>();
+inline bool(*v_CClient_SendNetMsgEx)(CClient* pClient, CNetMessage* pMsg, bool bLocal, bool bForceReliable, bool bVoice);
 
 inline CMemory p_CClient_SendSnapshot;
-inline auto v_CClient_SendSnapshot = p_CClient_SendSnapshot.RCast<void* (*)(CClient* pClient, CClientFrame* pFrame, int nTick, int nTickAck)>();
+inline void*(*v_CClient_SendSnapshot)(CClient* pClient, CClientFrame* pFrame, int nTick, int nTickAck);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VClient : public IDetour

--- a/r5dev/engine/client/clientstate.h
+++ b/r5dev/engine/client/clientstate.h
@@ -202,16 +202,16 @@ extern CClientState** g_pClientState_Shifted; // Shifted by 0x10 forward!
 
 /* ==== CCLIENTSTATE ==================================================================================================================================================== */
 inline CMemory p_CClientState__RunFrame;
-inline auto CClientState__RunFrame = p_CClientState__RunFrame.RCast<void(*)(CClientState* thisptr)>();
+inline void(*CClientState__RunFrame)(CClientState* thisptr);
 
 inline CMemory p_CClientState__Disconnect;
-inline auto CClientState__Disconnect = p_CClientState__Disconnect.RCast<void(*)(CClientState* thisptr, bool bSendTrackingContext)>();
+inline void(*CClientState__Disconnect)(CClientState* thisptr, bool bSendTrackingContext);
 
 inline CMemory p_CClientState__ConnectionClosing;
-inline auto CClientState__ConnectionClosing = p_CClientState__ConnectionClosing.RCast<void(*)(CClientState* thisptr, const char* szReason)>();
+inline void(*CClientState__ConnectionClosing)(CClientState* thisptr, const char* szReason);
 
 inline CMemory p_CClientState__ProcessServerTick;
-inline auto CClientState__ProcessServerTick = p_CClientState__ProcessServerTick.RCast<bool(*)(CClientState* thisptr, SVC_ServerTick* msg)>();
+inline bool(*CClientState__ProcessServerTick)(CClientState* thisptr, SVC_ServerTick* msg);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VClientState : public IDetour

--- a/r5dev/engine/client/datablock_receiver.h
+++ b/r5dev/engine/client/datablock_receiver.h
@@ -28,10 +28,10 @@ protected:
 };
 
 inline CMemory p_ClientDataBlockReceiver__Destructor;
-inline auto v_ClientDataBlockReceiver__Destructor = p_ClientDataBlockReceiver__Destructor.RCast<void* (*)(ClientDataBlockReceiver* thisptr)>();
+inline void*(*v_ClientDataBlockReceiver__Destructor)(ClientDataBlockReceiver* thisptr);
 
 inline CMemory p_ClientDataBlockReceiver__AcknowledgeTransmission;
-inline auto v_ClientDataBlockReceiver__AcknowledgeTransmission = p_ClientDataBlockReceiver__AcknowledgeTransmission.RCast<void* (*)(ClientDataBlockReceiver* thisptr)>();
+inline void*(*v_ClientDataBlockReceiver__AcknowledgeTransmission)(ClientDataBlockReceiver* thisptr);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VClientDataBlockReceiver : public IDetour

--- a/r5dev/engine/cmd.h
+++ b/r5dev/engine/cmd.h
@@ -5,13 +5,13 @@ ECommandTarget_t Cbuf_GetCurrentPlayer(void);
 
 /* ==== COMMAND_BUFFER ================================================================================================================================================== */
 inline CMemory p_Cbuf_AddText;
-inline auto Cbuf_AddText = p_Cbuf_AddText.RCast<void (*)(ECommandTarget_t eTarget, const char* pText, cmd_source_t cmdSource)>();
+inline void(*Cbuf_AddText)(ECommandTarget_t eTarget, const char* pText, cmd_source_t cmdSource);
 
 inline CMemory p_Cbuf_Execute;
-inline auto Cbuf_Execute = p_Cbuf_Execute.RCast<void (*)(void)>();
+inline void(*Cbuf_Execute)(void);
 
 inline CMemory p_Cmd_ForwardToServer;
-inline auto v_Cmd_ForwardToServer = p_Cmd_ForwardToServer.RCast<bool (*)(const CCommand* args)>();
+inline bool(*v_Cmd_ForwardToServer)(const CCommand* args);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VCmd : public IDetour

--- a/r5dev/engine/cmodel_bsp.h
+++ b/r5dev/engine/cmodel_bsp.h
@@ -7,10 +7,10 @@
 class KeyValues;
 
 inline CMemory p_Mod_LoadPakForMap;
-inline auto v_Mod_LoadPakForMap = p_Mod_LoadPakForMap.RCast<void(*)(const char* szLevelName)>();
+inline void(*v_Mod_LoadPakForMap)(const char* szLevelName);
 
 inline CMemory p_Mod_ProcessPakQueue;
-inline auto v_Mod_ProcessPakQueue = p_Mod_ProcessPakQueue.RCast<void(*)(void)>();
+inline void(*v_Mod_ProcessPakQueue)(void);
 
 inline float* dword_14B383420;
 inline int32_t * dword_1634F445C;
@@ -24,7 +24,7 @@ inline int64_t* qword_167ED7BC0;
 
 inline auto sub_14045BAC0 = p_Mod_ProcessPakQueue.RCast<__int64(*)(__int64(__fastcall* a1)(__int64, _DWORD*, __int64, _QWORD*), JobFifoLock_s* pFifoLock, __int64 a3, __int64 a4)>();
 inline auto sub_14045A1D0 = p_Mod_ProcessPakQueue.RCast<__int64(*)(unsigned __int8(__fastcall* a1)(_QWORD), JobFifoLock_s* pFifoLock, __int64 a3, __int64 a4, volatile signed __int64* a5, char a6)>();
-inline auto sub_140441220 = p_Mod_ProcessPakQueue.RCast<void(*)(__int64 a1, __int64 a2)>();
+inline void(*sub_140441220)(__int64 a1, __int64 a2);
 
 extern bool s_bBasePaksInitialized;
 extern vector<string> g_InstalledMaps;

--- a/r5dev/engine/common.h
+++ b/r5dev/engine/common.h
@@ -2,10 +2,10 @@
 
 /* ==== COMMON ========================================================================================================================================================== */
 inline CMemory p_COM_InitFilesystem;
-inline auto COM_InitFilesystem = p_COM_InitFilesystem.RCast<void* (*)(const char* pFullModPath)>();
+inline void*(*COM_InitFilesystem)(const char* pFullModPath);
 
 inline CMemory p_COM_ExplainDisconnection;
-inline auto COM_ExplainDisconnection = p_COM_ExplainDisconnection.RCast<void* (*)(uint64_t level, const char* fmt, ...)>();
+inline void*(*COM_ExplainDisconnection)(uint64_t level, const char* fmt, ...);
 
 const char* COM_FormatSeconds(int seconds);
 ///////////////////////////////////////////////////////////////////////////////

--- a/r5dev/engine/debugoverlay.h
+++ b/r5dev/engine/debugoverlay.h
@@ -160,19 +160,19 @@ void DestroyOverlay(OverlayBase_t* pOverlay);
 void DrawOverlay(OverlayBase_t* pOverlay);
 
 inline CMemory p_DrawAllOverlays;
-inline auto v_DrawAllOverlays = p_DrawAllOverlays.RCast<void (*)(bool bDraw)>();
+inline void(*v_DrawAllOverlays)(bool bDraw);
 
 inline CMemory p_DestroyOverlay;
-inline auto v_DestroyOverlay = p_DestroyOverlay.RCast<void (*)(OverlayBase_t* pOverlay)>();
+inline void(*v_DestroyOverlay)(OverlayBase_t* pOverlay);
 
 inline CMemory p_RenderLine;
-inline auto v_RenderLine = p_RenderLine.RCast<void* (*)(const Vector3D& vOrigin, const Vector3D& vDest, Color color, bool bZBuffer)>();
+inline void*(*v_RenderLine)(const Vector3D& vOrigin, const Vector3D& vDest, Color color, bool bZBuffer);
 
 inline CMemory p_RenderBox;
-inline auto v_RenderBox = p_RenderBox.RCast<void* (*)(const matrix3x4_t& vTransforms, const Vector3D& vMins, const Vector3D& vMaxs, Color color, bool bZBuffer)>();
+inline void*(*v_RenderBox)(const matrix3x4_t& vTransforms, const Vector3D& vMins, const Vector3D& vMaxs, Color color, bool bZBuffer);
 
 inline CMemory p_RenderWireframeSphere;
-inline auto v_RenderWireframeSphere = p_RenderWireframeSphere.RCast<void* (*)(const Vector3D& vCenter, float flRadius, int nTheta, int nPhi, Color color, bool bZBuffer)>();
+inline void*(*v_RenderWireframeSphere)(const Vector3D& vCenter, float flRadius, int nTheta, int nPhi, Color color, bool bZBuffer);
 
 inline OverlayBase_t** s_pOverlays = nullptr;
 inline LPCRITICAL_SECTION s_OverlayMutex = nullptr;

--- a/r5dev/engine/gl_matsysiface.h
+++ b/r5dev/engine/gl_matsysiface.h
@@ -2,7 +2,7 @@
 
 /* ==== MATSYSIFACE ===================================================================================================================================================== */
 inline CMemory p_InitMaterialSystem;
-inline auto v_InitMaterialSystem = p_InitMaterialSystem.RCast<void* (*)(void)>();
+inline void*(*v_InitMaterialSystem)(void);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VGL_MatSysIFace : public IDetour

--- a/r5dev/engine/gl_rsurf.h
+++ b/r5dev/engine/gl_rsurf.h
@@ -2,13 +2,13 @@
 #include "public/ivrenderview.h"
 
 inline CMemory P_DrawWorldMeshes;
-inline auto V_DrawWorldMeshes = P_DrawWorldMeshes.RCast<void* (*)(void* baseEntity, void* renderContext, DrawWorldLists_t worldLists)>();
+inline void*(*V_DrawWorldMeshes)(void* baseEntity, void* renderContext, DrawWorldLists_t worldLists);
 
 inline CMemory P_DrawWorldMeshesDepthOnly;
-inline auto V_DrawWorldMeshesDepthOnly = P_DrawWorldMeshesDepthOnly.RCast<void*(*)(void* renderContext, DrawWorldLists_t worldLists)>();
+inline void*(*V_DrawWorldMeshesDepthOnly)(void* renderContext, DrawWorldLists_t worldLists);
 
 inline CMemory P_DrawWorldMeshesDepthAtTheEnd;
-inline auto V_DrawWorldMeshesDepthAtTheEnd = P_DrawWorldMeshesDepthAtTheEnd.RCast<void* (*)(void* ptr1, void* ptr2, void* ptr3, DrawWorldLists_t worldLists)>();
+inline void*(*V_DrawWorldMeshesDepthAtTheEnd)(void* ptr1, void* ptr2, void* ptr3, DrawWorldLists_t worldLists);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VGL_RSurf : public IDetour

--- a/r5dev/engine/host.h
+++ b/r5dev/engine/host.h
@@ -1,19 +1,19 @@
 #pragma once
 
 inline CMemory p_Host_RunFrame;
-inline auto v_Host_RunFrame = p_Host_RunFrame.RCast<void(*)(void* unused, float time)>();
+inline void(*v_Host_RunFrame)(void* unused, float time);
 
 //inline CMemory p_Host_RunFrame_Render; // DEDICATED PATCH!
-//inline auto v_Host_RunFrame_Render = p_Host_RunFrame_Render.RCast<void(*)(void)>();
+//inline void(*v_Host_RunFrame_Render)(void);
 
 inline CMemory p_Host_ShouldRun;
-inline auto v_Host_ShouldRun = p_Host_ShouldRun.RCast<bool(*)()>();
+inline bool(*v_Host_ShouldRun)();
 
 inline CMemory p_Host_Error;
-inline auto v_Host_Error = p_Host_Error.RCast<void(*)(const char* error, ...)>();
+inline void(*v_Host_Error)(const char* error, ...);
 
 //inline CMemory p_VCR_EnterPausedState; // DEDICATED PATCH!
-//inline auto v_VCR_EnterPausedState = p_VCR_EnterPausedState.RCast<void(*)(void)>();
+//inline void(*v_VCR_EnterPausedState)(void);
 
 inline bool* g_bAbortServerSet = nullptr;
 inline float* interval_per_tick = nullptr;

--- a/r5dev/engine/host_cmd.h
+++ b/r5dev/engine/host_cmd.h
@@ -19,29 +19,29 @@ extern EngineParms_t* g_pEngineParms;
 
 /* ==== HOST ============================================================================================================================================================ */
 inline CMemory p_Host_Init;
-inline auto v_Host_Init = p_Host_Init.RCast<void* (*)(bool* bDedicated)>();
+inline void*(*v_Host_Init)(bool* bDedicated);
 
 inline CMemory p_Host_Shutdown;
-inline auto v_Host_Shutdown = p_Host_Shutdown.RCast<void (*)()>();
+inline void(*v_Host_Shutdown)();
 
 inline CMemory p_Host_NewGame;
-inline auto v_Host_NewGame = p_Host_NewGame.RCast<bool (*)(char* pszMapName, char* pszMapGroup, bool bLoadGame, char bBackground, LARGE_INTEGER PerformanceCount)>();
+inline bool(*v_Host_NewGame)(char* pszMapName, char* pszMapGroup, bool bLoadGame, char bBackground, LARGE_INTEGER PerformanceCount);
 
 inline CMemory p_Host_Disconnect;
-inline auto v_Host_Disconnect = p_Host_Disconnect.RCast<void (*)(bool bShowMainMenu)>();
+inline void(*v_Host_Disconnect)(bool bShowMainMenu);
 
 inline CMemory p_Host_ChangeLevel;
-inline auto v_Host_ChangeLevel = p_Host_ChangeLevel.RCast<bool (*)(bool bLoadFromSavedGame, const char* pszMapName, const char* pszMapGroup)>();
+inline bool(*v_Host_ChangeLevel)(bool bLoadFromSavedGame, const char* pszMapName, const char* pszMapGroup);
 
 inline CMemory p_Host_Status_PrintClient;
 inline auto v_Host_Status_PrintClient = p_Host_Status_PrintClient.RCast<void (*)(CClient* client, bool bShowAddress, void (*print) (const char* fmt, ...))>();
 
 inline CMemory p_SetLaunchOptions;
-inline auto v_SetLaunchOptions = p_SetLaunchOptions.RCast<int (*)(const CCommand& args)>();
+inline int(*v_SetLaunchOptions)(const CCommand& args);
 
 #if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
 inline CMemory p_DFS_InitializeFeatureFlagDefinitions;
-inline auto v_DFS_InitializeFeatureFlagDefinitions = p_DFS_InitializeFeatureFlagDefinitions.RCast<bool (*)(const char* pszFeatureFlags)>();
+inline bool(*v_DFS_InitializeFeatureFlagDefinitions)(const char* pszFeatureFlags);
 #endif // !(GAMEDLL_S0) || !(GAMEDLL_S1) || !(GAMEDLL_S2)
 
 extern EngineParms_t* g_pEngineParms;

--- a/r5dev/engine/host_state.h
+++ b/r5dev/engine/host_state.h
@@ -51,16 +51,16 @@ public:
 
 /* ==== CHOSTSTATE ====================================================================================================================================================== */
 inline CMemory p_CHostState_FrameUpdate;
-inline auto CHostState_FrameUpdate = p_CHostState_FrameUpdate.RCast<void(*)(CHostState* pHostState, double flCurrentTime, float flFrameTime)>();
+inline void(*CHostState_FrameUpdate)(CHostState* pHostState, double flCurrentTime, float flFrameTime);
 
 inline CMemory p_CHostState_State_Run;
-inline auto CHostState_State_Run = p_CHostState_State_Run.RCast<void(*)(HostStates_t* pState, double flCurrentTime, float flFrameTime)>();
+inline void(*CHostState_State_Run)(HostStates_t* pState, double flCurrentTime, float flFrameTime);
 
 inline CMemory p_CHostState_State_GameShutDown;
-inline auto CHostState_State_GameShutDown = p_CHostState_State_GameShutDown.RCast<void(*)(CHostState* thisptr)>();
+inline void(*CHostState_State_GameShutDown)(CHostState* thisptr);
 
 inline CMemory p_HostState_ChangeLevelMP;
-inline auto v_HostState_ChangeLevelMP = p_HostState_ChangeLevelMP.RCast<void(*)(char const* pNewLevel, char const* pLandmarkName)>();
+inline void(*v_HostState_ChangeLevelMP)(char const* pNewLevel, char const* pLandmarkName);
 
 ///////////////////////////////////////////////////////////////////////////////
 extern CHostState* g_pHostState;

--- a/r5dev/engine/matsys_interface.h
+++ b/r5dev/engine/matsys_interface.h
@@ -12,7 +12,7 @@ inline CMemory p_HandleConfigFile;
 inline CMemory p_ResetPreviousGameState;
 inline CMemory p_LoadPlayerConfig;
 
-inline auto v_UpdateCurrentVideoConfig = p_UpdateCurrentVideoConfig.RCast<bool (*)(MaterialSystem_Config_t* pConfig)>();
+inline bool(*v_UpdateCurrentVideoConfig)(MaterialSystem_Config_t* pConfig);
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/r5dev/engine/modelloader.h
+++ b/r5dev/engine/modelloader.h
@@ -72,22 +72,22 @@ public:
 };
 
 inline CMemory p_CModelLoader__FindModel;
-inline auto CModelLoader__FindModel = p_CModelLoader__FindModel.RCast<void* (*)(CModelLoader* loader, const char* pszModelName)>();
+inline void*(*CModelLoader__FindModel)(CModelLoader* loader, const char* pszModelName);
 
 inline CMemory p_CModelLoader__LoadModel;
-inline auto CModelLoader__LoadModel = p_CModelLoader__LoadModel.RCast<void(*)(CModelLoader* loader, model_t* model)>();
+inline void(*CModelLoader__LoadModel)(CModelLoader* loader, model_t* model);
 
 inline CMemory p_CModelLoader__UnloadModel;
-inline auto CModelLoader__UnloadModel = p_CModelLoader__UnloadModel.RCast<uint64_t(*)(CModelLoader* loader, model_t* model)>();
+inline uint64_t(*CModelLoader__UnloadModel)(CModelLoader* loader, model_t* model);
 
 inline CMemory p_CModelLoader__Studio_LoadModel;
-inline auto CModelLoader__Studio_LoadModel = p_CModelLoader__Studio_LoadModel.RCast<void* (*)(CModelLoader* loader)>();
+inline void*(*CModelLoader__Studio_LoadModel)(CModelLoader* loader);
 
 inline CMemory p_CModelLoader__Map_LoadModelGuts;
-inline auto CModelLoader__Map_LoadModelGuts = p_CModelLoader__Map_LoadModelGuts.RCast<uint64_t(*)(CModelLoader* loader, model_t* model)>();
+inline uint64_t(*CModelLoader__Map_LoadModelGuts)(CModelLoader* loader, model_t* model);
 
 inline CMemory p_CModelLoader__Map_IsValid;
-inline auto CModelLoader__Map_IsValid = p_CModelLoader__Map_IsValid.RCast<bool(*)(CModelLoader* loader, const char* pszMapName)>();
+inline bool(*CModelLoader__Map_IsValid)(CModelLoader* loader, const char* pszMapName);
 
 inline CMemory p_CMapLoadHelper__CMapLoadHelper;
 inline auto CMapLoadHelper__CMapLoadHelper = p_CMapLoadHelper__CMapLoadHelper.RCast<void(__fastcall*)(CMapLoadHelper * helper, int lumpToLoad)>();
@@ -99,10 +99,10 @@ inline CMemory p_Map_LoadModel;
 inline auto v_Map_LoadModel = p_Map_LoadModel.RCast<void(__fastcall*)(void)>();
 
 //inline CMemory p_GetSpriteInfo; // DEDICATED PATCH!
-//inline auto GetSpriteInfo = p_GetSpriteInfo.RCast<void* (*)(const char* pName, bool bIsAVI, bool bIsBIK, int& nWidth, int& nHeight, int& nFrameCount, void* a7)>();
+//inline void*(*GetSpriteInfo)(const char* pName, bool bIsAVI, bool bIsBIK, int& nWidth, int& nHeight, int& nFrameCount, void* a7);
 
 //inline CMemory p_BuildSpriteLoadName; // DEDICATED PATCH!
-//inline auto BuildSpriteLoadName = p_BuildSpriteLoadName.RCast<void* (*)(const char* pName, char* pOut, int outLen, bool& bIsAVI, bool& bIsBIK)>();
+//inline void*(*BuildSpriteLoadName)(const char* pName, char* pOut, int outLen, bool& bIsAVI, bool& bIsBIK);
 
 inline CModelLoader* g_pModelLoader;
 inline FileHandle_t* s_MapFileHandle;

--- a/r5dev/engine/net.h
+++ b/r5dev/engine/net.h
@@ -20,25 +20,25 @@ constexpr const char* DEFAULT_NET_ENCRYPTION_KEY = "WDNWLmJYQ2ZlM0VoTid3Yg==";
 
 /* ==== CNETCHAN ======================================================================================================================================================== */
 inline CMemory p_NET_Init;
-inline auto v_NET_Init = p_NET_Init.RCast<void* (*)(bool bDeveloper)>();
+inline void*(*v_NET_Init)(bool bDeveloper);
 
 inline CMemory p_NET_SetKey;
-inline auto v_NET_SetKey = p_NET_SetKey.RCast<void (*)(netkey_t* pKey, const char* szHash)>();
+inline void(*v_NET_SetKey)(netkey_t* pKey, const char* szHash);
 
 inline CMemory p_NET_Config;
-inline auto v_NET_Config = p_NET_Config.RCast<void (*)(void)>();
+inline void(*v_NET_Config)(void);
 
 inline CMemory p_NET_ReceiveDatagram;
-inline auto v_NET_ReceiveDatagram = p_NET_ReceiveDatagram.RCast<bool (*)(int iSocket, netpacket_s* pInpacket, bool bRaw)>();
+inline bool(*v_NET_ReceiveDatagram)(int iSocket, netpacket_s* pInpacket, bool bRaw);
 
 inline CMemory p_NET_SendDatagram;
-inline auto v_NET_SendDatagram = p_NET_SendDatagram.RCast<int (*)(SOCKET s, void* pPayload, int iLenght, netadr_t* pAdr, bool bEncrypted)>();
+inline int(*v_NET_SendDatagram)(SOCKET s, void* pPayload, int iLenght, netadr_t* pAdr, bool bEncrypted);
 
 inline CMemory p_NET_Decompress;
-inline auto v_NET_Decompress = p_NET_Decompress.RCast<int (*)(CLZSS* lzss, unsigned char* pInput, unsigned char* pOutput, unsigned int unBufSize)>();
+inline int(*v_NET_Decompress)(CLZSS* lzss, unsigned char* pInput, unsigned char* pOutput, unsigned int unBufSize);
 
 inline CMemory p_NET_PrintFunc;
-inline auto v_NET_PrintFunc = p_NET_PrintFunc.RCast<void(*)(const char* fmt)>();
+inline void(*v_NET_PrintFunc)(const char* fmt);
 
 ///////////////////////////////////////////////////////////////////////////////
 bool NET_ReceiveDatagram(int iSocket, netpacket_s* pInpacket, bool bRaw);

--- a/r5dev/engine/net_chan.h
+++ b/r5dev/engine/net_chan.h
@@ -79,19 +79,19 @@ enum EBufType
 };
 
 inline CMemory p_NetChan_Clear;
-inline auto v_NetChan_Clear = p_NetChan_Clear.RCast<void (*)(CNetChan* pChan, bool bStopProcessing)>();
+inline void(*v_NetChan_Clear)(CNetChan* pChan, bool bStopProcessing);
 
 inline CMemory p_NetChan_Shutdown;
-inline auto v_NetChan_Shutdown = p_NetChan_Shutdown.RCast<void (*)(CNetChan* pChan, const char* szReason, uint8_t bBadRep, bool bRemoveNow)>();
+inline void(*v_NetChan_Shutdown)(CNetChan* pChan, const char* szReason, uint8_t bBadRep, bool bRemoveNow);
 
 inline CMemory p_NetChan_CanPacket;
-inline auto v_NetChan_CanPacket = p_NetChan_CanPacket.RCast<bool (*)(const CNetChan* pChan)>();
+inline bool(*v_NetChan_CanPacket)(const CNetChan* pChan);
 
 inline CMemory p_NetChan_SendDatagram;
-inline auto v_NetChan_SendDatagram = p_NetChan_SendDatagram.RCast<int (*)(CNetChan* pChan, bf_write* pMsg)>();
+inline int(*v_NetChan_SendDatagram)(CNetChan* pChan, bf_write* pMsg);
 
 inline CMemory p_NetChan_ProcessMessages;
-inline auto v_NetChan_ProcessMessages = p_NetChan_ProcessMessages.RCast<bool (*)(CNetChan* pChan, bf_read* pMsg)>();
+inline bool(*v_NetChan_ProcessMessages)(CNetChan* pChan, bf_read* pMsg);
 
 //-----------------------------------------------------------------------------
 class CNetChan

--- a/r5dev/engine/server/datablock_sender.h
+++ b/r5dev/engine/server/datablock_sender.h
@@ -53,7 +53,7 @@ struct ServerDataBlock
 };
 
 inline CMemory p_ServerDataBlockSender__Destructor;
-inline auto v_ServerDataBlockSender__Destructor = p_ServerDataBlockSender__Destructor.RCast<void*(*)(ServerDataBlockSender* thisptr)>();
+inline void*(*v_ServerDataBlockSender__Destructor)(ServerDataBlockSender* thisptr);
 
 inline CMemory p_ServerDataBlockSender__SendDataBlock;
 inline auto v_ServerDataBlockSender__SendDataBlock = p_ServerDataBlockSender__SendDataBlock.RCast<void* (*)(ServerDataBlockSender* thisptr,

--- a/r5dev/engine/server/persistence.h
+++ b/r5dev/engine/server/persistence.h
@@ -3,7 +3,7 @@
 
 #if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
 inline CMemory p_Persistence_SetXP;
-inline auto v_Persistence_SetXP = p_Persistence_SetXP.RCast<bool (*)(int a1, int* a2)>();
+inline bool(*v_Persistence_SetXP)(int a1, int* a2);
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/r5dev/engine/server/server.h
+++ b/r5dev/engine/server/server.h
@@ -93,16 +93,16 @@ extern CServer* g_pServer;
 
 /* ==== CSERVER ========================================================================================================================================================= */
 inline CMemory p_CServer_FrameJob;
-inline auto v_CServer_FrameJob = p_CServer_FrameJob.RCast<void (*)(double flFrameTime, bool bRunOverlays, bool bUniformSnapshotInterval)>();
+inline void(*v_CServer_FrameJob)(double flFrameTime, bool bRunOverlays, bool bUniformSnapshotInterval);
 
 inline CMemory p_CServer_RunFrame;
-inline auto v_CServer_RunFrame = p_CServer_RunFrame.RCast<void (*)(CServer* pServer)>();
+inline void(*v_CServer_RunFrame)(CServer* pServer);
 
 inline CMemory p_CServer_ConnectClient;
-inline auto v_CServer_ConnectClient = p_CServer_ConnectClient.RCast<CClient* (*)(CServer* pServer, user_creds_s* pCreds)>();
+inline CClient*(*v_CServer_ConnectClient)(CServer* pServer, user_creds_s* pCreds);
 
 inline CMemory p_CServer_RejectConnection;
-inline auto v_CServer_RejectConnection = p_CServer_RejectConnection.RCast<void* (*)(CServer* pServer, int iSocket, netadr_t* pNetAdr, const char* szMessage)>();
+inline void*(*v_CServer_RejectConnection)(CServer* pServer, int iSocket, netadr_t* pNetAdr, const char* szMessage);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VServer : public IDetour

--- a/r5dev/engine/server/sv_main.h
+++ b/r5dev/engine/server/sv_main.h
@@ -9,19 +9,19 @@ class CClient;
 
 /* ==== SV_MAIN ======================================================================================================================================================= */
 inline CMemory p_SV_InitGameDLL;
-inline auto v_SV_InitGameDLL = p_SV_InitGameDLL.RCast<void(*)(void)>();
+inline void(*v_SV_InitGameDLL)(void);
 
 inline CMemory p_SV_ShutdownGameDLL;
-inline auto v_SV_ShutdownGameDLL = p_SV_ShutdownGameDLL.RCast<void(*)(void)>();
+inline void(*v_SV_ShutdownGameDLL)(void);
 
 inline CMemory p_SV_ActivateServer;
-inline auto v_SV_ActivateServer = p_SV_ActivateServer.RCast<bool(*)(void)>();
+inline bool(*v_SV_ActivateServer)(void);
 
 inline CMemory p_SV_CreateBaseline;
-inline auto v_SV_CreateBaseline = p_SV_CreateBaseline.RCast<bool(*)(void)>();
+inline bool(*v_SV_CreateBaseline)(void);
 
 inline CMemory p_CGameServer__SpawnServer;
-inline auto CGameServer__SpawnServer = p_CGameServer__SpawnServer.RCast<bool(*)(void* thisptr, const char* pszMapName, const char* pszMapGroupName)>();
+inline bool(*CGameServer__SpawnServer)(void* thisptr, const char* pszMapName, const char* pszMapGroupName);
 
 inline CMemory p_SV_BroadcastVoiceData;
 inline auto v_SV_BroadcastVoiceData = p_SV_BroadcastVoiceData.RCast<void(__fastcall*)(CClient* cl, int nBytes, char* data)>();

--- a/r5dev/engine/server/vengineserver_impl.h
+++ b/r5dev/engine/server/vengineserver_impl.h
@@ -4,7 +4,7 @@
 
 /* ==== CVENGINESERVER ================================================================================================================================================== */
 inline CMemory p_IVEngineServer__PersistenceAvailable;
-inline auto IVEngineServer__PersistenceAvailable = p_IVEngineServer__PersistenceAvailable.RCast<bool (*)(void* entidx, int clientidx)>();
+inline bool(*IVEngineServer__PersistenceAvailable)(void* entidx, int clientidx);
 
 inline bool* m_bIsDedicated = nullptr;
 

--- a/r5dev/engine/staticpropmgr.h
+++ b/r5dev/engine/staticpropmgr.h
@@ -2,7 +2,7 @@
 #include "public/gamebspfile.h"
 
 inline CMemory p_CStaticProp_Init;
-inline auto v_CStaticProp_Init = p_CStaticProp_Init.RCast<void*(*)(int64_t thisptr, int64_t a2, unsigned int idx, unsigned int a4, StaticPropLump_t* lump, int64_t a6, int64_t a7)>();
+inline void*(*v_CStaticProp_Init)(int64_t thisptr, int64_t a2, unsigned int idx, unsigned int a4, StaticPropLump_t* lump, int64_t a6, int64_t a7);
 
 void* __fastcall CStaticProp_Init(int64_t thisptr, int64_t a2, unsigned int idx, unsigned int a4, StaticPropLump_t* lump, int64_t a6, int64_t a7);
 

--- a/r5dev/engine/sys_dll.h
+++ b/r5dev/engine/sys_dll.h
@@ -41,22 +41,22 @@ private:
 
 /* ==== CAPPSYSTEMGROUP ================================================================================================================================================= */
 inline CMemory p_CModAppSystemGroup_Main;
-inline auto CModAppSystemGroup_Main = p_CModAppSystemGroup_Main.RCast<int(*)(CModAppSystemGroup* pModAppSystemGroup)>();
+inline int(*CModAppSystemGroup_Main)(CModAppSystemGroup* pModAppSystemGroup);
 
 inline CMemory p_CModAppSystemGroup_Create;
-inline auto CModAppSystemGroup_Create = p_CModAppSystemGroup_Create.RCast<bool(*)(CModAppSystemGroup* pModAppSystemGroup)>();
+inline bool(*CModAppSystemGroup_Create)(CModAppSystemGroup* pModAppSystemGroup);
 
 inline CMemory p_CSourceAppSystemGroup__PreInit;
-inline auto CSourceAppSystemGroup__PreInit = p_CSourceAppSystemGroup__PreInit.RCast<bool(*)(CSourceAppSystemGroup* pModAppSystemGroup)>();
+inline bool(*CSourceAppSystemGroup__PreInit)(CSourceAppSystemGroup* pModAppSystemGroup);
 
 inline CMemory p_CSourceAppSystemGroup__Create;
-inline auto CSourceAppSystemGroup__Create = p_CSourceAppSystemGroup__Create.RCast<bool(*)(CSourceAppSystemGroup* pModAppSystemGroup)>();
+inline bool(*CSourceAppSystemGroup__Create)(CSourceAppSystemGroup* pModAppSystemGroup);
 
 inline bool g_bAppSystemInit = false;
 
 /* ==== UTILITY ========================================================================================================================================================= */
 inline CMemory p_Sys_Error_Internal;
-inline auto Sys_Error_Internal = p_Sys_Error_Internal.RCast<int (*)(char* fmt, va_list args)>();
+inline int(*Sys_Error_Internal)(char* fmt, va_list args);
 
 inline bool* gfExtendedError = nullptr;
 

--- a/r5dev/engine/sys_dll2.h
+++ b/r5dev/engine/sys_dll2.h
@@ -40,28 +40,28 @@ public:
 };
 
 inline CMemory p_CEngineAPI_Init;
-inline auto CEngineAPI_Init = p_CEngineAPI_Init.RCast<InitReturnVal_t(*)(CEngineAPI* thisp)>();
+inline InitReturnVal_t(*CEngineAPI_Init)(CEngineAPI* thisp);
 
 inline CMemory p_CEngineAPI_Shutdown;
-inline auto CEngineAPI_Shutdown = p_CEngineAPI_Shutdown.RCast<void (*)(void)>();
+inline void(*CEngineAPI_Shutdown)(void);
 
 inline CMemory p_CEngineAPI_Connect;
-inline auto CEngineAPI_Connect = p_CEngineAPI_Connect.RCast<bool (*)(CEngineAPI* thisptr, CreateInterfaceFn factory)>();
+inline bool(*CEngineAPI_Connect)(CEngineAPI* thisptr, CreateInterfaceFn factory);
 
 inline CMemory p_CEngineAPI_ModInit;
-inline auto CEngineAPI_ModInit = p_CEngineAPI_ModInit.RCast<bool (*)(CEngineAPI* pEngineAPI, const char* pModName, const char* pGameDir)>();
+inline bool(*CEngineAPI_ModInit)(CEngineAPI* pEngineAPI, const char* pModName, const char* pGameDir);
 
 inline CMemory p_CEngineAPI_MainLoop;
-inline auto CEngineAPI_MainLoop = p_CEngineAPI_MainLoop.RCast<bool(*)(void)>();
+inline bool(*CEngineAPI_MainLoop)(void);
 
 inline CMemory p_CEngineAPI_SetStartupInfo;
-inline auto v_CEngineAPI_SetStartupInfo = p_CEngineAPI_SetStartupInfo.RCast<void (*)(CEngineAPI* pEngineAPI, StartupInfo_t* pStartupInfo)>();
+inline void(*v_CEngineAPI_SetStartupInfo)(CEngineAPI* pEngineAPI, StartupInfo_t* pStartupInfo);
 
 inline CMemory p_ResetMTVFTaskItem;
-inline auto v_ResetMTVFTaskItem = p_ResetMTVFTaskItem.RCast<void*(*)(void)>();
+inline void*(*v_ResetMTVFTaskItem)(void);
 
 inline CMemory p_PakFile_Init;
-inline auto PakFile_Init = p_PakFile_Init.RCast<void (*)(char* buffer, char* source, char vpk_file)>();
+inline void(*PakFile_Init)(char* buffer, char* source, char vpk_file);
 
 inline bool* g_bTextMode = nullptr;
 inline char* g_szBaseDir = nullptr; // static size = 260

--- a/r5dev/engine/sys_engine.h
+++ b/r5dev/engine/sys_engine.h
@@ -22,7 +22,7 @@ private:
 
 /* ==== CENGINE ======================================================================================================================================================= */
 inline CMemory p_CEngine_Frame;
-inline auto v_CEngine_Frame = p_CEngine_Frame.RCast<bool(*)(CEngine* thisp)>();
+inline bool(*v_CEngine_Frame)(CEngine* thisp);
 
 extern CEngine* g_pEngine;
 

--- a/r5dev/engine/sys_getmodes.h
+++ b/r5dev/engine/sys_getmodes.h
@@ -4,10 +4,10 @@
 // CGAME
 //-------------------------------------------------------------------------
 inline CMemory p_CVideoMode_Common__CreateGameWindow;
-inline auto CVideoMode_Common__CreateGameWindow = p_CVideoMode_Common__CreateGameWindow.RCast<bool (*)(int* pnRect)>();
+inline bool(*CVideoMode_Common__CreateGameWindow)(int* pnRect);
 
 inline CMemory p_CVideoMode_Common__CreateWindowClass;
-inline auto CVideoMode_Common__CreateWindowClass = p_CVideoMode_Common__CreateWindowClass.RCast<HWND(*)(vrect_t* pnRect)>();
+inline HWND(*CVideoMode_Common__CreateWindowClass)(vrect_t* pnRect);
 
 ///////////////////////////////////////////////////////////////////////////////
 class HVideoMode_Common : public IDetour

--- a/r5dev/engine/sys_mainwind.h
+++ b/r5dev/engine/sys_mainwind.h
@@ -11,10 +11,10 @@ inline CMemory p_CGame__AttachToWindow;
 inline auto v_CGame__AttachToWindow= p_CGame__AttachToWindow.RCast<void (*)(void)>();
 
 inline CMemory p_CGame__PlayStartupVideos;
-inline auto v_CGame__PlayStartupVideos = p_CGame__PlayStartupVideos.RCast<void (*)(void)>();
+inline void(*v_CGame__PlayStartupVideos)(void);
 
 inline CMemory p_CGame__WindowProc;
-inline auto v_CGame__WindowProc = p_CGame__WindowProc.RCast<int (*)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)>();
+inline int(*v_CGame__WindowProc)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 //-----------------------------------------------------------------------------
 // Purpose: Main game interface, including message pump and window creation
 //-----------------------------------------------------------------------------

--- a/r5dev/engine/sys_utils.h
+++ b/r5dev/engine/sys_utils.h
@@ -2,16 +2,16 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 inline CMemory p_Error;
-inline auto v_Error = p_Error.RCast<void (*)(const char* fmt, ...)>();
+inline void(*v_Error)(const char* fmt, ...);
 
 inline CMemory p_Warning;
-inline auto v_Warning = p_Warning.RCast<void (*)(int, const char* fmt, ...)>(); 
+inline void(*v_Warning)(int, const char* fmt, ...); 
 
 inline CMemory p_Sys_GetProcessUpTime;
-inline auto v_Sys_GetProcessUpTime = p_Sys_GetProcessUpTime.RCast<int (*)(char* szBuffer)>();
+inline int(*v_Sys_GetProcessUpTime)(char* szBuffer);
 #ifndef DEDICATED
 inline CMemory p_Con_NPrintf;
-inline auto v_Con_NPrintf = p_Con_NPrintf.RCast<void (*)(int pos, const char* fmt, ...)>();
+inline void(*v_Con_NPrintf)(int pos, const char* fmt, ...);
 #endif // !DEDICATED
 /* ==== ------- ========================================================================================================================================================= */
 

--- a/r5dev/engine/traceinit.h
+++ b/r5dev/engine/traceinit.h
@@ -2,7 +2,7 @@
 #define TRACEINIT_H
 
 inline CMemory p_TRACEINIT;
-inline auto v_TRACEINIT = p_TRACEINIT.RCast<void(*)(void* undef, const char* initfunc, const char* shutdownfunc)>();
+inline void(*v_TRACEINIT)(void* undef, const char* initfunc, const char* shutdownfunc);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VTraceInit : public IDetour

--- a/r5dev/filesystem/basefilesystem.h
+++ b/r5dev/filesystem/basefilesystem.h
@@ -44,25 +44,25 @@ protected:
 
 /* ==== CBASEFILESYSTEM ================================================================================================================================================= */
 inline CMemory p_CBaseFileSystem_Warning;
-inline auto v_CBaseFileSystem_Warning = p_CBaseFileSystem_Warning.RCast<void(*)(CBaseFileSystem* pFileSystem, FileWarningLevel_t level, const char* fmt, ...)>();
+inline void(*v_CBaseFileSystem_Warning)(CBaseFileSystem* pFileSystem, FileWarningLevel_t level, const char* fmt, ...);
 
 inline CMemory p_CBaseFileSystem_LoadFromVPK;
-inline auto v_CBaseFileSystem_LoadFromVPK = p_CBaseFileSystem_LoadFromVPK.RCast<FileHandle_t(*)(CBaseFileSystem* pFileSystem, FileHandle_t pResults, const char* pszAssetName)>();
+inline FileHandle_t(*v_CBaseFileSystem_LoadFromVPK)(CBaseFileSystem* pFileSystem, FileHandle_t pResults, const char* pszAssetName);
 
 inline CMemory p_CBaseFileSystem_LoadFromCache;
-inline auto v_CBaseFileSystem_LoadFromCache = p_CBaseFileSystem_LoadFromCache.RCast<bool(*)(CBaseFileSystem* pFileSystem, const char* pszAssetName, FileSystemCache* pCache)>();
+inline bool(*v_CBaseFileSystem_LoadFromCache)(CBaseFileSystem* pFileSystem, const char* pszAssetName, FileSystemCache* pCache);
 
 inline CMemory p_CBaseFileSystem_AddMapPackFile;
-inline auto v_CBaseFileSystem_AddMapPackFile = p_CBaseFileSystem_AddMapPackFile.RCast<void (*)(CBaseFileSystem* pFileSystem, const char* pPath, const char* pPathID, SearchPathAdd_t addType)>();
+inline void(*v_CBaseFileSystem_AddMapPackFile)(CBaseFileSystem* pFileSystem, const char* pPath, const char* pPathID, SearchPathAdd_t addType);
 
 inline CMemory p_CBaseFileSystem_MountVPKFile;
-inline auto v_CBaseFileSystem_MountVPKFile = p_CBaseFileSystem_MountVPKFile.RCast<VPKData_t* (*)(CBaseFileSystem* pFileSystem, const char* pszVpkPath)>();
+inline VPKData_t*(*v_CBaseFileSystem_MountVPKFile)(CBaseFileSystem* pFileSystem, const char* pszVpkPath);
 
 inline CMemory p_CBaseFileSystem_UnmountVPKFile;
 inline auto v_CBaseFileSystem_UnmountVPKFile = p_CBaseFileSystem_UnmountVPKFile.RCast<const char* (*)(CBaseFileSystem* pFileSystem, const char* pszVpkPath)>();
 
 inline CMemory p_CBaseFileSystem_GetMountedVPKHandle;
-inline auto v_CBaseFileSystem_GetMountedVPKHandle = p_CBaseFileSystem_GetMountedVPKHandle.RCast<int (*)(CBaseFileSystem* pFileSystem, const char* pszVpkPath)>();
+inline int(*v_CBaseFileSystem_GetMountedVPKHandle)(CBaseFileSystem* pFileSystem, const char* pszVpkPath);
 
 extern CBaseFileSystem* g_pFileSystem;
 

--- a/r5dev/game/client/input.h
+++ b/r5dev/game/client/input.h
@@ -10,7 +10,7 @@ private:
 };
 
 inline CMemory p_CInput__SetCustomWeaponActivity;
-inline auto v_CInput__SetCustomWeaponActivity = p_CInput__SetCustomWeaponActivity.RCast<void (*)(CInput* pInput, int weaponActivity)>();
+inline void(*v_CInput__SetCustomWeaponActivity)(CInput* pInput, int weaponActivity);
 
 inline IInput* g_pInput_VFTable = nullptr;
 inline CInput* g_pInput = nullptr;

--- a/r5dev/game/client/viewrender.h
+++ b/r5dev/game/client/viewrender.h
@@ -16,7 +16,7 @@ const Vector3D& MainViewOrigin();
 const QAngle& MainViewAngles();
 
 inline CMemory p_CViewRender_GetWorldMatrixForView;
-inline auto CViewRender_GetWorldMatrixForView = p_CViewRender_GetWorldMatrixForView.RCast<VMatrix*(*)(CViewRender*, int8_t)>();
+inline VMatrix*(*CViewRender_GetWorldMatrixForView)(CViewRender*, int8_t);
 
 inline Vector3D* g_vecRenderOrigin = nullptr;
 inline QAngle* g_vecRenderAngles = nullptr;

--- a/r5dev/game/server/ai_network.h
+++ b/r5dev/game/server/ai_network.h
@@ -46,7 +46,7 @@ public:
 inline CAI_Network** g_pAINetwork = nullptr;
 
 inline CMemory p_CAI_Network__DebugConnectMsg;
-inline auto v_CAI_Network__DebugConnectMsg = p_CAI_Network__DebugConnectMsg.RCast<void (*)(int node1, int node2, const char* pszformat, ...)>();
+inline void(*v_CAI_Network__DebugConnectMsg)(int node1, int node2, const char* pszformat, ...);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VAI_Network : public IDetour

--- a/r5dev/game/server/ai_networkmanager.h
+++ b/r5dev/game/server/ai_networkmanager.h
@@ -15,17 +15,17 @@ const int AINETWORK_OFFSET = 2840;
 
 /* ==== CAI_NETWORKMANAGER ============================================================================================================================================== */
 inline CMemory p_CAI_NetworkManager__ShouldRebuild = nullptr;
-inline auto CAI_NetworkManager__ShouldRebuild = p_CAI_NetworkManager__ShouldRebuild.RCast<void* (*)(void* thisptr, CAI_Network* pNetwork, void* a3, int a4)>();
+inline void*(*CAI_NetworkManager__ShouldRebuild)(void* thisptr, CAI_Network* pNetwork, void* a3, int a4);
 #if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
 inline CMemory p_CAI_NetworkManager__LoadNetworkGraph = nullptr;
-inline auto CAI_NetworkManager__LoadNetworkGraph = p_CAI_NetworkManager__LoadNetworkGraph.RCast<void* (*)(void* thisptr, void* pBuffer, const char* pszFileName, int a4)>();
+inline void*(*CAI_NetworkManager__LoadNetworkGraph)(void* thisptr, void* pBuffer, const char* pszFileName, int a4);
 #elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 inline CMemory p_CAI_NetworkManager__LoadNetworkGraph = nullptr;
-inline auto CAI_NetworkManager__LoadNetworkGraph = p_CAI_NetworkManager__LoadNetworkGraph.RCast<void* (*)(void* thisptr, void* pBuffer, const char* pszFileName)>();
+inline void*(*CAI_NetworkManager__LoadNetworkGraph)(void* thisptr, void* pBuffer, const char* pszFileName);
 #endif
 /* ==== CAI_NETWORKBUILDER ============================================================================================================================================== */
 inline CMemory p_CAI_NetworkBuilder__Build;
-inline auto CAI_NetworkBuilder__Build = p_CAI_NetworkBuilder__Build.RCast<void* (*)(void* thisptr, CAI_Network* pNetwork, void* a3, int a4)>();
+inline void*(*CAI_NetworkBuilder__Build)(void* thisptr, CAI_Network* pNetwork, void* a3, int a4);
 
 inline int                 * g_nAiNodeClusters       = nullptr;
 inline AINodeClusters    *** g_pppAiNodeClusters     = nullptr;

--- a/r5dev/game/server/baseanimating.h
+++ b/r5dev/game/server/baseanimating.h
@@ -136,7 +136,7 @@ protected:
 };
 
 inline CMemory p_CBaseAnimating__LockStudioHdr;
-inline auto v_CBaseAnimating__LockStudioHdr = p_CBaseAnimating__LockStudioHdr.RCast<CBaseAnimating* (*)(CBaseAnimating* thisp)>();
+inline CBaseAnimating*(*v_CBaseAnimating__LockStudioHdr)(CBaseAnimating* thisp);
 
 void BaseAnimating_Attach();
 void BaseAnimating_Detach();

--- a/r5dev/game/server/baseentity.h
+++ b/r5dev/game/server/baseentity.h
@@ -254,7 +254,7 @@ protected:
 };
 
 inline CMemory p_CBaseEntity__GetBaseEntity;
-inline auto v_CBaseEntity__GetBaseEntity = p_CBaseEntity__GetBaseEntity.RCast<CBaseEntity* (*)(CBaseEntity* thisp)>();
+inline CBaseEntity*(*v_CBaseEntity__GetBaseEntity)(CBaseEntity* thisp);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VBaseEntity : public IDetour

--- a/r5dev/game/server/detour_impl.h
+++ b/r5dev/game/server/detour_impl.h
@@ -7,19 +7,19 @@
 // RUNTIME: DETOUR
 //-------------------------------------------------------------------------
 inline CMemory p_Detour_LevelInit;
-inline auto v_Detour_LevelInit = p_Detour_LevelInit.RCast<void(*)(void)>();
+inline void(*v_Detour_LevelInit)(void);
 
 inline CMemory p_Detour_FreeNavMesh;
-inline auto v_Detour_FreeNavMesh = p_Detour_FreeNavMesh.RCast<void(*)(dtNavMesh* mesh)>();
+inline void(*v_Detour_FreeNavMesh)(dtNavMesh* mesh);
 
 inline CMemory p_dtNavMesh__Init;
-inline auto v_dtNavMesh__Init = p_dtNavMesh__Init.RCast<dtStatus(*)(dtNavMesh* thisptr, unsigned char* data, int flags)>();
+inline dtStatus(*v_dtNavMesh__Init)(dtNavMesh* thisptr, unsigned char* data, int flags);
 
 inline CMemory p_dtNavMesh__addTile;
-inline auto v_dtNavMesh__addTile = p_dtNavMesh__addTile.RCast<dtStatus(*)(dtNavMesh* thisptr, unsigned char* data, dtMeshHeader* header, int dataSize, int flags, dtTileRef lastRef)>();
+inline dtStatus(*v_dtNavMesh__addTile)(dtNavMesh* thisptr, unsigned char* data, dtMeshHeader* header, int dataSize, int flags, dtTileRef lastRef);
 
 inline CMemory p_dtNavMesh__isPolyReachable;
-inline auto v_dtNavMesh__isPolyReachable = p_dtNavMesh__isPolyReachable.RCast<bool(*)(dtNavMesh* thisptr, dtPolyRef poly_1, dtPolyRef poly_2, int hull_type)>();
+inline bool(*v_dtNavMesh__isPolyReachable)(dtNavMesh* thisptr, dtPolyRef poly_1, dtPolyRef poly_2, int hull_type);
 
 
 constexpr const char* NAVMESH_PATH = "maps/navmesh/";

--- a/r5dev/game/server/gameinterface.h
+++ b/r5dev/game/server/gameinterface.h
@@ -55,7 +55,7 @@ inline auto v_CServerGameClients__ProcessUserCmds = p_CServerGameClients__Proces
 	int numCmds, int totalCmds, int droppedPackets, bool ignore, bool paused)>();
 
 inline CMemory p_RunFrameServer;
-inline auto v_RunFrameServer = p_RunFrameServer.RCast<void(*)(double flFrameTime, bool bRunOverlays, bool bUniformUpdate)>();
+inline void(*v_RunFrameServer)(double flFrameTime, bool bRunOverlays, bool bUniformUpdate);
 
 extern CServerGameDLL* g_pServerGameDLL;
 extern CServerGameClients* g_pServerGameClients;

--- a/r5dev/game/server/physics_main.h
+++ b/r5dev/game/server/physics_main.h
@@ -8,7 +8,7 @@
 #define PHYSICS_MAIN_H
 
 inline CMemory p_Physics_RunThinkFunctions;
-inline auto v_Physics_RunThinkFunctions = p_Physics_RunThinkFunctions.RCast<void (*)(bool bSimulating)>();
+inline void(*v_Physics_RunThinkFunctions)(bool bSimulating);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VPhysics_Main : public IDetour

--- a/r5dev/game/server/player.h
+++ b/r5dev/game/server/player.h
@@ -792,10 +792,10 @@ private:
 static_assert(sizeof(CPlayer) == 0x7EF0); // !TODO: backwards compatibility.
 
 inline CMemory p_CPlayer__EyeAngles;
-inline auto v_CPlayer__EyeAngles = p_CPlayer__EyeAngles.RCast<QAngle* (*)(CPlayer* pPlayer, QAngle* pAngles)>();
+inline QAngle*(*v_CPlayer__EyeAngles)(CPlayer* pPlayer, QAngle* pAngles);
 
 inline CMemory p_CPlayer__PlayerRunCommand;
-inline auto v_CPlayer__PlayerRunCommand = p_CPlayer__PlayerRunCommand.RCast<void (*)(CPlayer* pPlayer, CUserCmd* pUserCmd, IMoveHelper* pMover)>();
+inline void(*v_CPlayer__PlayerRunCommand)(CPlayer* pPlayer, CUserCmd* pUserCmd, IMoveHelper* pMover);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VPlayer : public IDetour

--- a/r5dev/game/shared/animation.h
+++ b/r5dev/game/shared/animation.h
@@ -83,7 +83,7 @@ struct Player_AnimViewEntityData
 
 
 inline CMemory p_CStudioHdr__LookupSequence;
-inline auto v_CStudioHdr__LookupSequence = p_CStudioHdr__LookupSequence.RCast<int(*)(CStudioHdr* pStudio, const char* pszName)>();
+inline int(*v_CStudioHdr__LookupSequence)(CStudioHdr* pStudio, const char* pszName);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VAnimation : public IDetour

--- a/r5dev/game/shared/usercmd.h
+++ b/r5dev/game/shared/usercmd.h
@@ -19,16 +19,16 @@
 class CUserCmd;
 
 inline CMemory p_CUserCmd__CUserCmd;
-inline auto v_CUserCmd__CUserCmd = p_CUserCmd__CUserCmd.RCast<CUserCmd*(*)(CUserCmd* pUserCmd)>();
+inline CUserCmd*(*v_CUserCmd__CUserCmd)(CUserCmd* pUserCmd);
 
 inline CMemory p_CUserCmd__Reset;
-inline auto v_CUserCmd__Reset = p_CUserCmd__Reset.RCast<void(*)(CUserCmd* pUserCmd)>();
+inline void(*v_CUserCmd__Reset)(CUserCmd* pUserCmd);
 
 inline CMemory p_CUserCmd__Copy;
-inline auto v_CUserCmd__Copy = p_CUserCmd__Copy.RCast<CUserCmd*(*)(CUserCmd* pDest, CUserCmd* pSource)>();
+inline CUserCmd*(*v_CUserCmd__Copy)(CUserCmd* pDest, CUserCmd* pSource);
 
 inline CMemory p_ReadUserCmd;
-inline auto v_ReadUserCmd = p_ReadUserCmd.RCast<int (*)(bf_read* buf, CUserCmd* move, CUserCmd* from)>();
+inline int(*v_ReadUserCmd)(bf_read* buf, CUserCmd* move, CUserCmd* from);
 
 //-------------------------------------------------------------------------------------
 #pragma pack(push, 1)

--- a/r5dev/game/shared/vscript_shared.h
+++ b/r5dev/game/shared/vscript_shared.h
@@ -3,10 +3,10 @@
 #include "vscript/languages/squirrel_re/include/squirrel.h"
 
 inline CMemory p_Script_Remote_BeginRegisteringFunctions;
-inline auto Script_Remote_BeginRegisteringFunctions = p_Script_Remote_BeginRegisteringFunctions.RCast<void* (*)(void)>();
+inline void*(*Script_Remote_BeginRegisteringFunctions)(void);
 
 inline CMemory p_RestoreRemoteChecksumsFromSaveGame;
-inline auto RestoreRemoteChecksumsFromSaveGame = p_RestoreRemoteChecksumsFromSaveGame.RCast<void* (*)(void* a1, void* a2)>();
+inline void*(*RestoreRemoteChecksumsFromSaveGame)(void* a1, void* a2);
 
 #ifndef CLIENT_DLL
 inline uint32_t* g_nServerRemoteChecksum = nullptr;

--- a/r5dev/launcher/launcher.h
+++ b/r5dev/launcher/launcher.h
@@ -2,14 +2,14 @@
 #define LAUNCHER_H
 
 inline CMemory p_LauncherMain;
-inline auto v_LauncherMain = p_LauncherMain.RCast<int(*)(HINSTANCE hInstance)>();
+inline int(*v_LauncherMain)(HINSTANCE hInstance);
 
 inline CMemory p_TopLevelExceptionFilter;
-inline auto v_TopLevelExceptionFilter = p_TopLevelExceptionFilter.RCast<LONG(*)(EXCEPTION_POINTERS* pExceptionPointer)>();
+inline LONG(*v_TopLevelExceptionFilter)(EXCEPTION_POINTERS* pExceptionPointer);
 
 #if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
 inline CMemory p_RemoveSpuriousGameParameters;
-inline auto v_RemoveSpuriousGameParameters = p_RemoveSpuriousGameParameters.RCast<void* (*)(void)>();
+inline void*(*v_RemoveSpuriousGameParameters)(void);
 #endif // !GAMEDLL_S0 || !GAMEDLL_S1
 
 void AppendSDKParametersPreInit();

--- a/r5dev/launcher/prx.h
+++ b/r5dev/launcher/prx.h
@@ -2,7 +2,7 @@
 
 /* ==== PRX ============================================================================================================================================================= */
 inline CMemory p_exit_or_terminate_process;
-inline auto v_exit_or_terminate_process = p_exit_or_terminate_process.RCast<void(*)(UINT uExitCode)>();
+inline void(*v_exit_or_terminate_process)(UINT uExitCode);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VPRX : public IDetour

--- a/r5dev/materialsystem/cmaterialglue.h
+++ b/r5dev/materialsystem/cmaterialglue.h
@@ -69,7 +69,7 @@ inline void* g_pMaterialGlueVFTable = nullptr;
 /* ==== CMATERIALGLUE ================================================================================================================================================== */
 #ifndef DEDICATED
 inline CMemory p_GetMaterialAtCrossHair;
-inline auto GetMaterialAtCrossHair = p_GetMaterialAtCrossHair.RCast<CMaterialGlue* (*)(void)>();
+inline CMaterialGlue*(*GetMaterialAtCrossHair)(void);
 #endif // !DEDICATED
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/r5dev/materialsystem/cmaterialsystem.h
+++ b/r5dev/materialsystem/cmaterialsystem.h
@@ -15,26 +15,26 @@ public:
 
 /* ==== MATERIALSYSTEM ================================================================================================================================================== */
 inline CMemory p_CMaterialSystem__Init;
-inline auto CMaterialSystem__Init = p_CMaterialSystem__Init.RCast<void*(*)(CMaterialSystem* thisptr)>();
+inline void*(*CMaterialSystem__Init)(CMaterialSystem* thisptr);
 
 inline void* g_pMaterialSystem = nullptr;
 inline void* g_pMaterialVFTable = nullptr;
 #ifndef DEDICATED
 inline CMemory p_CMaterialSystem__FindMaterialEx;
-inline auto CMaterialSystem__FindMaterialEx = p_CMaterialSystem__FindMaterialEx.RCast<CMaterialGlue*(*)(CMaterialSystem* pMatSys, const char* pMaterialName, uint8_t nMaterialType, int nUnk, bool bComplain)>();
+inline CMaterialGlue*(*CMaterialSystem__FindMaterialEx)(CMaterialSystem* pMatSys, const char* pMaterialName, uint8_t nMaterialType, int nUnk, bool bComplain);
 
 inline CMemory p_CMaterialSystem_GetScreenSize;
-inline auto CMaterialSystem_GetScreenSize = p_CMaterialSystem_GetScreenSize.RCast<void(*)(CMaterialSystem* pMatSys, float* outX, float* outY)>();
+inline void(*CMaterialSystem_GetScreenSize)(CMaterialSystem* pMatSys, float* outX, float* outY);
 
 #if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
 inline CMemory p_DispatchDrawCall;
-inline auto v_DispatchDrawCall = p_DispatchDrawCall.RCast<void*(*)(int64_t a1, uint64_t a2, int a3, int a4, char a5, int a6, uint8_t a7, int64_t a8, uint32_t a9, uint32_t a10, __m128* a11, int a12)>();
+inline void*(*v_DispatchDrawCall)(int64_t a1, uint64_t a2, int a3, int a4, char a5, int a6, uint8_t a7, int64_t a8, uint32_t a9, uint32_t a10, __m128* a11, int a12);
 #elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 inline CMemory p_DispatchDrawCall;
-inline auto v_DispatchDrawCall = p_DispatchDrawCall.RCast<void*(*)(int64_t a1, uint64_t a2, int a3, int a4, int64_t a5, int a6, uint8_t a7, int64_t a8, uint32_t a9, uint32_t a10, int a11, __m128* a12, int a13, int64_t a14)>();
+inline void*(*v_DispatchDrawCall)(int64_t a1, uint64_t a2, int a3, int a4, int64_t a5, int a6, uint8_t a7, int64_t a8, uint32_t a9, uint32_t a10, int a11, __m128* a12, int a13, int64_t a14);
 #endif
 inline CMemory p_GetStreamOverlay;
-inline auto v_GetStreamOverlay = p_GetStreamOverlay.RCast<void(*)(const char* mode, char* buf, size_t bufSize)>();
+inline void(*v_GetStreamOverlay)(const char* mode, char* buf, size_t bufSize);
 
 inline CMemory p_DrawStreamOverlay;
 inline auto v_DrawStreamOverlay = p_DrawStreamOverlay.RCast<const char*(*)(void* thisptr, uint8_t* a2, void* unused, void* a4)>();

--- a/r5dev/public/appframework/IAppSystemGroup.h
+++ b/r5dev/public/appframework/IAppSystemGroup.h
@@ -94,7 +94,7 @@ protected:
 static_assert(sizeof(CAppSystemGroup) == 0xA8);
 
 inline CMemory p_CAppSystemGroup_Destroy;
-inline auto CAppSystemGroup_Destroy = p_CAppSystemGroup_Destroy.RCast<void(*)(CAppSystemGroup* pAppSystemGroup)>();
+inline void(*CAppSystemGroup_Destroy)(CAppSystemGroup* pAppSystemGroup);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VAppSystemGroup : public IDetour

--- a/r5dev/public/tier0/jobthread.h
+++ b/r5dev/public/tier0/jobthread.h
@@ -8,16 +8,16 @@ struct JobFifoLock_s
 typedef uint32_t JobID_t;
 
 inline CMemory p_JT_ParallelCall;
-inline auto JT_ParallelCall = p_JT_ParallelCall.RCast<void (*)(void)>();
+inline void(*JT_ParallelCall)(void);
 
 inline CMemory p_JT_HelpWithAnything;
-inline auto JT_HelpWithAnything = p_JT_HelpWithAnything.RCast<void* (*)(bool bShouldLoadPak)>();
+inline void*(*JT_HelpWithAnything)(bool bShouldLoadPak);
 
 inline CMemory p_JT_AcquireFifoLock;
-inline auto JT_AcquireFifoLock = p_JT_AcquireFifoLock.RCast<bool (*)(struct JobFifoLock_s* pFifo)>();
+inline bool(*JT_AcquireFifoLock)(struct JobFifoLock_s* pFifo);
 
 inline CMemory p_JT_ReleaseFifoLock;
-inline auto JT_ReleaseFifoLock = p_JT_ReleaseFifoLock.RCast<void (*)(struct JobFifoLock_s* pFifo)>();
+inline void(*JT_ReleaseFifoLock)(struct JobFifoLock_s* pFifo);
 
 void JT_Attach();
 void JT_Detach();

--- a/r5dev/public/tier0/platform_internal.h
+++ b/r5dev/public/tier0/platform_internal.h
@@ -2,10 +2,10 @@
 #define PLATFORM_INTERNAL_H
 
 inline CMemory p_Plat_FloatTime;
-inline auto v_Plat_FloatTime = p_Plat_FloatTime.RCast<double(*)(void)>();
+inline double(*v_Plat_FloatTime)(void);
 
 inline CMemory p_Plat_MSTime;
-inline auto v_Plat_MSTime = p_Plat_MSTime.RCast<uint64_t(*)(void)>();
+inline uint64_t(*v_Plat_MSTime)(void);
 
 inline double* g_flErrorTimeStamp = nullptr;
 ///////////////////////////////////////////////////////////////////////////////

--- a/r5dev/public/tier0/threadtools.h
+++ b/r5dev/public/tier0/threadtools.h
@@ -261,7 +261,7 @@ typedef CInterlockedIntT<unsigned> CInterlockedUInt;
 #ifndef BUILDING_MATHLIB
 //=============================================================================
 inline CMemory p_DeclareCurrentThreadIsMainThread;
-inline auto v_DeclareCurrentThreadIsMainThread = p_DeclareCurrentThreadIsMainThread.RCast<ThreadId_t (*)(void)>();
+inline ThreadId_t(*v_DeclareCurrentThreadIsMainThread)(void);
 
 #endif // !BUILDING_MATHLIB
 

--- a/r5dev/public/tier1/cmd.h
+++ b/r5dev/public/tier1/cmd.h
@@ -180,13 +180,13 @@ public:
 
 /* ==== CONCOMMAND ====================================================================================================================================================== */
 inline CMemory p_ConCommand_AutoCompleteSuggest;
-inline auto ConCommand_AutoCompleteSuggest = p_ConCommand_AutoCompleteSuggest.RCast<bool (*)(ConCommand* pCommand, const char* partial, CUtlVector< CUtlString >& commands)>();
+inline bool(*ConCommand_AutoCompleteSuggest)(ConCommand* pCommand, const char* partial, CUtlVector< CUtlString >& commands);
 
 inline CMemory p_ConCommandBase_IsFlagSet;
-inline auto ConCommandBase_IsFlagSet = p_ConCommandBase_IsFlagSet.RCast<bool (*)(ConCommandBase* pCommand, int nFlag)>();
+inline bool(*ConCommandBase_IsFlagSet)(ConCommandBase* pCommand, int nFlag);
 
 inline CMemory p_NullSub;
-inline auto NullSub = p_NullSub.RCast<void(*)(void)>();
+inline void(*NullSub)(void);
 
 inline CMemory p_CallbackStub;
 inline FnCommandCompletionCallback CallbackStub = p_CallbackStub.RCast<FnCommandCompletionCallback>();

--- a/r5dev/public/tier1/cvar.h
+++ b/r5dev/public/tier1/cvar.h
@@ -302,16 +302,16 @@ void ConVar_PrintDescription(ConCommandBase* pVar);
 
 /* ==== CONVAR ========================================================================================================================================================== */
 inline CMemory p_ConVar_Register;
-inline auto v_ConVar_Register = p_ConVar_Register.RCast<void* (*)(ConVar* thisptr, const char* szName, const char* szDefaultValue, int nFlags, const char* szHelpString, bool bMin, float fMin, bool bMax, float fMax, FnChangeCallback_t pCallback, const char* pszUsageString)>();
+inline void*(*v_ConVar_Register)(ConVar* thisptr, const char* szName, const char* szDefaultValue, int nFlags, const char* szHelpString, bool bMin, float fMin, bool bMax, float fMax, FnChangeCallback_t pCallback, const char* pszUsageString);
 
 inline CMemory p_ConVar_Unregister;
-inline auto v_ConVar_Unregister = p_ConVar_Unregister.RCast<void (*)(ConVar* thisptr)>();
+inline void(*v_ConVar_Unregister)(ConVar* thisptr);
 
 inline CMemory p_ConVar_IsFlagSet;
-inline auto v_ConVar_IsFlagSet = p_ConVar_IsFlagSet.RCast<bool (*)(ConVar* pConVar, int nFlag)>();
+inline bool(*v_ConVar_IsFlagSet)(ConVar* pConVar, int nFlag);
 
 inline CMemory p_ConVar_PrintDescription;
-inline auto v_ConVar_PrintDescription = p_ConVar_PrintDescription.RCast<void* (*)(ConCommandBase* pVar)>();
+inline void*(*v_ConVar_PrintDescription)(ConCommandBase* pVar);
 
 inline ConVar* g_pConVarVBTable;
 inline IConVar* g_pConVarVFTable;

--- a/r5dev/rtech/rtech_game.h
+++ b/r5dev/rtech/rtech_game.h
@@ -29,13 +29,13 @@ enum class ePakStatus : int
 
 /* ==== RTECH_GAME ====================================================================================================================================================== */
 inline CMemory p_CPakFile_LoadAsync;
-inline auto CPakFile_LoadAsync = p_CPakFile_LoadAsync.RCast<RPakHandle_t(*)(const char* szPakFileName, CAlignedMemAlloc* pMalloc, int nIdx, bool bUnk)>();
+inline RPakHandle_t(*CPakFile_LoadAsync)(const char* szPakFileName, CAlignedMemAlloc* pMalloc, int nIdx, bool bUnk);
 
 inline CMemory p_CPakFile_LoadPak;
 inline auto CPakFile_LoadPak = p_CPakFile_LoadPak.RCast<unsigned int (*)(void* thisptr, void* a2, uint64_t a3)>();
 
 inline CMemory p_CPakFile_UnloadPak;
-inline auto CPakFile_UnloadPak = p_CPakFile_UnloadPak.RCast<void (*)(RPakHandle_t handle)>();
+inline void(*CPakFile_UnloadPak)(RPakHandle_t handle);
 
 inline CMemory p_CPakFile_OpenFileOffset; // Offset to inlined 'CPakFile::LoadPak_OpenFile'.
 

--- a/r5dev/rtech/rtech_utils.h
+++ b/r5dev/rtech/rtech_utils.h
@@ -376,13 +376,13 @@ static_assert(sizeof(RPakPatchCompressedHeader_t) == 16);
 /* ==== RTECH =========================================================================================================================================================== */
 // [ PIXIE ]: I'm very unsure about this, but it really seems like it
 inline CMemory p_RTech_FindFreeSlotInFiles;
-inline auto RTech_FindFreeSlotInFiles = p_RTech_FindFreeSlotInFiles.RCast<int32_t(*)(int32_t*)>();
+inline int32_t(*RTech_FindFreeSlotInFiles)(int32_t*);
 
 inline CMemory p_RTech_OpenFile;
-inline auto RTech_OpenFile = p_RTech_OpenFile.RCast<int32_t(*)(const char*, void*, int64_t*)>();
+inline int32_t(*RTech_OpenFile)(const char*, void*, int64_t*);
 
 inline CMemory p_RTech_RegisterAsset;
-inline auto RTech_RegisterAsset = p_RTech_RegisterAsset.RCast<void(*)(int, int, const char*, void*, void*, void*, void*, int, int, uint32_t, int, int)>();
+inline void(*RTech_RegisterAsset)(int, int, const char*, void*, void*, void*, void*, int, int, uint32_t, int, int);
 
 #ifdef GAMEDLL_S3
 inline CMemory p_Pak_ProcessGuidRelationsForAsset;
@@ -390,7 +390,7 @@ inline auto RTech_Pak_ProcessGuidRelationsForAsset = p_Pak_ProcessGuidRelationsF
 #endif
 
 inline CMemory p_StreamDB_Init;
-inline auto v_StreamDB_Init = p_StreamDB_Init.RCast<void (*)(const char* pszLevelName)>();
+inline void(*v_StreamDB_Init)(const char* pszLevelName);
 
 inline RPakLoadedInfo_t* g_pLoadedPakInfo;
 inline int16_t* g_pRequestedPakCount;

--- a/r5dev/rtech/rui/rui.h
+++ b/r5dev/rtech/rui/rui.h
@@ -2,13 +2,13 @@
 
 /* ==== RUI ====================================================================================================================================================== */
 inline CMemory p_Rui_Draw;
-inline auto v_Rui_Draw = p_Rui_Draw.RCast<bool(*)(__int64* a1, __m128* a2, const __m128i* a3, __int64 a4, __m128* a5)>();
+inline bool(*v_Rui_Draw)(__int64* a1, __m128* a2, const __m128i* a3, __int64 a4, __m128* a5);
 
 inline CMemory p_Rui_LoadAsset;
-inline auto v_Rui_LoadAsset = p_Rui_LoadAsset.RCast<void* (*)(const char* szRuiAssetName)>();
+inline void*(*v_Rui_LoadAsset)(const char* szRuiAssetName);
 
 inline CMemory p_Rui_GetFontFace;
-inline auto v_Rui_GetFontFace = p_Rui_GetFontFace.RCast<int16_t (*)(void)>();
+inline int16_t(*v_Rui_GetFontFace)(void);
 
 ///////////////////////////////////////////////////////////////////////////////
 class V_Rui : public IDetour

--- a/r5dev/rtech/stryder/stryder.h
+++ b/r5dev/rtech/stryder/stryder.h
@@ -2,10 +2,10 @@
 
 /* ==== STRYDER ================================================================================================================================================ */
 inline CMemory p_Stryder_StitchRequest;
-inline auto Stryder_StitchRequest = p_Stryder_StitchRequest.RCast<void*(*)(void* a1)>();
+inline void*(*Stryder_StitchRequest)(void* a1);
 
 inline CMemory p_Stryder_SendOfflineRequest;
-inline auto Stryder_SendOfflineRequest = p_Stryder_SendOfflineRequest.RCast<bool(*)(void)>();
+inline bool(*Stryder_SendOfflineRequest)(void);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VStryder : public IDetour

--- a/r5dev/tier0/commandline.h
+++ b/r5dev/tier0/commandline.h
@@ -31,7 +31,7 @@ inline CCommandLine* CommandLine(void)
 }
 
 inline CMemory p_CCommandLine__CreateCmdLine;
-inline auto v_CCommandLine__CreateCmdLine = p_CCommandLine__CreateCmdLine.RCast<void(*)(CCommandLine* thisptr, const char* pszCommandLine)>();
+inline void(*v_CCommandLine__CreateCmdLine)(CCommandLine* thisptr, const char* pszCommandLine);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VCommandLine : public IDetour

--- a/r5dev/vgui/vgui_baseui_interface.h
+++ b/r5dev/vgui/vgui_baseui_interface.h
@@ -77,13 +77,13 @@ public:
 
 /* ==== CENGINEVGUI ===================================================================================================================================================== */
 inline CMemory p_CEngineVGui_Paint;
-inline auto CEngineVGui_Paint = p_CEngineVGui_Paint.RCast<int (*)(CEngineVGui* thisptr, PaintMode_t mode)>();
+inline int(*CEngineVGui_Paint)(CEngineVGui* thisptr, PaintMode_t mode);
 
 inline CMemory p_CEngineVGui_RenderStart;
-inline auto CEngineVGui_RenderStart = p_CEngineVGui_RenderStart.RCast<void* (*)(CMatSystemSurface* pMatSystemSurface)>();
+inline void*(*CEngineVGui_RenderStart)(CMatSystemSurface* pMatSystemSurface);
 
 inline CMemory p_CEngineVGui_RenderEnd;
-inline auto CEngineVGui_RenderEnd = p_CEngineVGui_RenderEnd.RCast<void* (*)(void)>();
+inline void*(*CEngineVGui_RenderEnd)(void);
 
 inline CEngineVGui* g_pEngineVGui = nullptr;
 

--- a/r5dev/vgui/vgui_fpspanel.h
+++ b/r5dev/vgui/vgui_fpspanel.h
@@ -2,7 +2,7 @@
 
 /* ==== CFPSPANEL ======================================================================================================================================================= */
 inline CMemory p_CFPSPanel_Paint;
-inline auto CFPSPanel_Paint = p_CFPSPanel_Paint.RCast<ConVar* (*)(void* thisptr)>();
+inline ConVar*(*CFPSPanel_Paint)(void* thisptr);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VFPSPanel : public IDetour

--- a/r5dev/vguimatsurface/MatSystemSurface.h
+++ b/r5dev/vguimatsurface/MatSystemSurface.h
@@ -2,7 +2,7 @@
 
 /* ==== CMATSYSTEMSURFACE =============================================================================================================================================== */
 inline CMemory p_CMatSystemSurface_DrawColoredText;
-inline auto CMatSystemSurface_DrawColoredText = p_CMatSystemSurface_DrawColoredText.RCast<void* (*)(void* thisptr, short font, int fontHeight, int offsetX, int offsetY, int red, int green, int blue, int alpha, const char* text, ...)>();
+inline void*(*CMatSystemSurface_DrawColoredText)(void* thisptr, short font, int fontHeight, int offsetX, int offsetY, int red, int green, int blue, int alpha, const char* text, ...);
 
 class CMatSystemSurface
 {

--- a/r5dev/vpc/IAppSystem.h
+++ b/r5dev/vpc/IAppSystem.h
@@ -2,7 +2,7 @@
 
 /* ==== IAPPSYSTEM ============================================================================================================================================== */
 //inline CMemory p_IAppSystem_LoadLibrary; // C initializers/terminators
-//inline auto IAppSystem_LoadLibrary = p_IAppSystem_LoadLibrary.RCast<void* (*)(void)>();
+//inline void*(*IAppSystem_LoadLibrary)(void);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VAppSystem : public IDetour

--- a/r5dev/vpc/keyvalues.h
+++ b/r5dev/vpc/keyvalues.h
@@ -21,25 +21,25 @@ class IBaseFileSystem;
 
 /* ==== KEYVALUES ======================================================================================================================================================= */
 inline CMemory p_KeyValues_FindKey;
-inline auto KeyValues_FindKey = p_KeyValues_FindKey.RCast<void* (*)(KeyValues* thisptr, const char* pkeyName, bool bCreate)>();
+inline void*(*KeyValues_FindKey)(KeyValues* thisptr, const char* pkeyName, bool bCreate);
 
 inline CMemory p_KeyValues_LoadPlaylists;
-inline auto KeyValues_LoadPlaylists = p_KeyValues_LoadPlaylists.RCast<bool (*)(const char* pszPlaylist)>();
+inline bool(*KeyValues_LoadPlaylists)(const char* pszPlaylist);
 
 inline CMemory p_KeyValues_ParsePlaylists;
-inline auto KeyValues_ParsePlaylists = p_KeyValues_ParsePlaylists.RCast<bool (*)(const char* pszPlaylist)>();
+inline bool(*KeyValues_ParsePlaylists)(const char* pszPlaylist);
 
 inline CMemory p_KeyValues_GetCurrentPlaylist;
 inline auto KeyValues_GetCurrentPlaylist = p_KeyValues_GetCurrentPlaylist.RCast<const char* (*)(void)>();
 
 inline CMemory p_KeyValues_ReadKeyValuesFile;
-inline auto KeyValues_ReadKeyValuesFile = p_KeyValues_ReadKeyValuesFile.RCast<KeyValues* (*)(CFileSystem_Stdio* pFileSystem, const char* pFileName)>();
+inline KeyValues*(*KeyValues_ReadKeyValuesFile)(CFileSystem_Stdio* pFileSystem, const char* pFileName);
 
 inline CMemory p_KeyValues_RecursiveSaveToFile;
-inline auto KeyValues_RecursiveSaveToFile = p_KeyValues_RecursiveSaveToFile.RCast<void (*)(KeyValues* thisptr, IBaseFileSystem* pFileSystem, FileHandle_t pHandle, CUtlBuffer* pBuf, int nIndentLevel)>();
+inline void(*KeyValues_RecursiveSaveToFile)(KeyValues* thisptr, IBaseFileSystem* pFileSystem, FileHandle_t pHandle, CUtlBuffer* pBuf, int nIndentLevel);
 
 inline CMemory p_KeyValues_LoadFromFile;
-inline auto KeyValues_LoadFromFile = p_KeyValues_LoadFromFile.RCast<KeyValues* (*)(KeyValues* thisptr, IBaseFileSystem* pFileSystem, const char* pszResourceName, const char* pszPathID, void* pfnEvaluateSymbolProc)>();
+inline KeyValues*(*KeyValues_LoadFromFile)(KeyValues* thisptr, IBaseFileSystem* pFileSystem, const char* pszResourceName, const char* pszPathID, void* pfnEvaluateSymbolProc);
 
 enum KeyValuesTypes_t : char
 {

--- a/r5dev/vphysics/QHull.h
+++ b/r5dev/vphysics/QHull.h
@@ -1,10 +1,10 @@
 #pragma once
 
 inline CMemory p_QHull_PrintFunc;
-inline auto v_QHull_PrintFunc = p_QHull_PrintFunc.RCast<int (*)(const char* fmt, ...)>();
+inline int(*v_QHull_PrintFunc)(const char* fmt, ...);
 
 //inline CMemory p_speex_warning_int;
-//inline auto speex_warning_int = p_speex_warning_int.RCast<int (*)(FILE* stream, const char* format, ...)>();
+//inline int(*speex_warning_int)(FILE* stream, const char* format, ...);
 
 ///////////////////////////////////////////////////////////////////////////////
 int QHull_PrintFunc(const char* fmt, ...);

--- a/r5dev/vscript/languages/squirrel_re/include/sqstdaux.h
+++ b/r5dev/vscript/languages/squirrel_re/include/sqstdaux.h
@@ -7,10 +7,10 @@ extern bool g_bSQAuxBadLogic;
 extern HSQUIRRELVM g_pErrorVM;
 
 inline CMemory p_sqstd_aux_printerror;
-inline auto v_sqstd_aux_printerror = p_sqstd_aux_printerror.RCast<SQInteger(*)(HSQUIRRELVM v)>();
+inline SQInteger(*v_sqstd_aux_printerror)(HSQUIRRELVM v);
 
 inline CMemory p_sqstd_aux_badlogic;
-inline auto v_sqstd_aux_badlogic = p_sqstd_aux_badlogic.RCast<SQInteger(*)(HSQUIRRELVM v, __m128i* a2, __m128i* a3)>();
+inline SQInteger(*v_sqstd_aux_badlogic)(HSQUIRRELVM v, __m128i* a2, __m128i* a3);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VSquirrelAUX : public IDetour

--- a/r5dev/vscript/languages/squirrel_re/include/squirrel.h
+++ b/r5dev/vscript/languages/squirrel_re/include/squirrel.h
@@ -46,37 +46,37 @@ SQRESULT sq_call(HSQUIRRELVM v, SQInteger params, SQBool retval, SQBool raiseerr
 
 /* ==== SQUIRREL ======================================================================================================================================================== */
 inline CMemory p_sq_pushroottable;
-inline auto v_sq_pushroottable = p_sq_pushroottable.RCast<SQRESULT(*)(HSQUIRRELVM v)>();
+inline SQRESULT(*v_sq_pushroottable)(HSQUIRRELVM v);
 
 inline CMemory p_sq_pushbool;
-inline auto v_sq_pushbool = p_sq_pushbool.RCast<void (*)(HSQUIRRELVM v, SQBool b)>();
+inline void(*v_sq_pushbool)(HSQUIRRELVM v, SQBool b);
 
 inline CMemory p_sq_pushstring;
-inline auto v_sq_pushstring = p_sq_pushstring.RCast<void (*)(HSQUIRRELVM v, const SQChar* string, SQInteger len)>();
+inline void(*v_sq_pushstring)(HSQUIRRELVM v, const SQChar* string, SQInteger len);
 
 inline CMemory p_sq_pushinteger;
-inline auto v_sq_pushinteger = p_sq_pushinteger.RCast<void (*)(HSQUIRRELVM v, SQInteger val)>();
+inline void(*v_sq_pushinteger)(HSQUIRRELVM v, SQInteger val);
 
 inline CMemory p_sq_newarray;
-inline auto v_sq_newarray = p_sq_newarray.RCast<void (*)(HSQUIRRELVM v, SQInteger size)>();
+inline void(*v_sq_newarray)(HSQUIRRELVM v, SQInteger size);
 
 inline CMemory p_sq_newtable;
-inline auto v_sq_newtable = p_sq_newtable.RCast<void (*)(HSQUIRRELVM v)>();
+inline void(*v_sq_newtable)(HSQUIRRELVM v);
 
 inline CMemory p_sq_newslot;
-inline auto v_sq_newslot = p_sq_newslot.RCast<SQRESULT(*)(HSQUIRRELVM v, SQInteger idx)>();
+inline SQRESULT(*v_sq_newslot)(HSQUIRRELVM v, SQInteger idx);
 
 inline CMemory p_sq_arrayappend;
-inline auto v_sq_arrayappend = p_sq_arrayappend.RCast<SQRESULT(*)(HSQUIRRELVM v, SQInteger idx)>();
+inline SQRESULT(*v_sq_arrayappend)(HSQUIRRELVM v, SQInteger idx);
 
 inline CMemory p_sq_pushstructure;
-inline auto v_sq_pushstructure = p_sq_pushstructure.RCast<SQRESULT(*)(HSQUIRRELVM v, const SQChar* name, const SQChar* member, const SQChar* codeclass1, const SQChar* codeclass2)>();
+inline SQRESULT(*v_sq_pushstructure)(HSQUIRRELVM v, const SQChar* name, const SQChar* member, const SQChar* codeclass1, const SQChar* codeclass2);
 
 inline CMemory p_sq_compilebuffer;
-inline auto v_sq_compilebuffer = p_sq_compilebuffer.RCast<SQRESULT(*)(HSQUIRRELVM v, SQBufState* bufferstate, const SQChar* buffer, SQInteger level)>();
+inline SQRESULT(*v_sq_compilebuffer)(HSQUIRRELVM v, SQBufState* bufferstate, const SQChar* buffer, SQInteger level);
 
 inline CMemory p_sq_call;
-inline auto v_sq_call = p_sq_call.RCast<SQRESULT(*)(HSQUIRRELVM v, SQInteger params, SQBool retval, SQBool raiseerror)>();
+inline SQRESULT(*v_sq_call)(HSQUIRRELVM v, SQInteger params, SQBool retval, SQBool raiseerror);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VSquirrelAPI : public IDetour

--- a/r5dev/vscript/languages/squirrel_re/include/sqvm.h
+++ b/r5dev/vscript/languages/squirrel_re/include/sqvm.h
@@ -66,28 +66,28 @@ struct SQVM
 
 /* ==== SQUIRREL ======================================================================================================================================================== */
 inline CMemory p_SQVM_PrintFunc;
-inline auto v_SQVM_PrintFunc = p_SQVM_PrintFunc.RCast<SQRESULT(*)(HSQUIRRELVM v, SQChar* fmt, ...)>();
+inline SQRESULT(*v_SQVM_PrintFunc)(HSQUIRRELVM v, SQChar* fmt, ...);
 
 inline CMemory p_SQVM_WarningFunc;
-inline auto v_SQVM_WarningFunc = p_SQVM_WarningFunc.RCast<SQRESULT(*)(HSQUIRRELVM v, SQInteger a2, SQInteger a3, SQInteger* nStringSize, SQChar** ppString)>();
+inline SQRESULT(*v_SQVM_WarningFunc)(HSQUIRRELVM v, SQInteger a2, SQInteger a3, SQInteger* nStringSize, SQChar** ppString);
 
 inline CMemory p_SQVM_GetErrorLine;
-inline auto v_SQVM_GetErrorLine = p_SQVM_GetErrorLine.RCast<size_t(*)(const SQChar* pszFile, SQInteger nLine, SQChar* pszContextBuf, SQInteger nBufLen)>();
+inline size_t(*v_SQVM_GetErrorLine)(const SQChar* pszFile, SQInteger nLine, SQChar* pszContextBuf, SQInteger nBufLen);
 
 inline CMemory p_SQVM_WarningCmd;
-inline auto v_SQVM_WarningCmd = p_SQVM_WarningCmd.RCast<SQRESULT(*)(HSQUIRRELVM v, SQInteger a2)>();
+inline SQRESULT(*v_SQVM_WarningCmd)(HSQUIRRELVM v, SQInteger a2);
 
 inline CMemory p_SQVM_CompileError;
-inline auto v_SQVM_CompileError = p_SQVM_CompileError.RCast<void (*)(HSQUIRRELVM v, const SQChar* pszError, const SQChar* pszFile, SQUnsignedInteger nLine, SQInteger nColumn)>();
+inline void(*v_SQVM_CompileError)(HSQUIRRELVM v, const SQChar* pszError, const SQChar* pszFile, SQUnsignedInteger nLine, SQInteger nColumn);
 
 inline CMemory p_SQVM_LogicError;
-inline auto v_SQVM_LogicError = p_SQVM_LogicError.RCast<void (*)(SQBool bPrompt)>();
+inline void(*v_SQVM_LogicError)(SQBool bPrompt);
 
 inline CMemory p_SQVM_ScriptError;
-inline auto v_SQVM_ScriptError = p_SQVM_ScriptError.RCast<SQInteger (*)(const SQChar* pszFormat, ...)>();
+inline SQInteger(*v_SQVM_ScriptError)(const SQChar* pszFormat, ...);
 
 inline CMemory p_SQVM_RaiseError;
-inline auto v_SQVM_RaiseError = p_SQVM_RaiseError.RCast<SQInteger(*)(HSQUIRRELVM v, const SQChar* pszFormat, ...)>();
+inline SQInteger(*v_SQVM_RaiseError)(HSQUIRRELVM v, const SQChar* pszFormat, ...);
 
 SQRESULT SQVM_PrintFunc(HSQUIRRELVM v, SQChar* fmt, ...);
 SQRESULT SQVM_WarningFunc(HSQUIRRELVM v, SQInteger a2, SQInteger a3, SQInteger* nStringSize, SQChar** ppString);

--- a/r5dev/vscript/languages/squirrel_re/vsquirrel.h
+++ b/r5dev/vscript/languages/squirrel_re/vsquirrel.h
@@ -47,13 +47,13 @@ inline CMemory p_CSquirrelVM_Init;
 inline auto v_CSquirrelVM_Init = p_CSquirrelVM_Init.RCast<bool(__fastcall*)(CSquirrelVM* s, SQCONTEXT context, SQFloat curtime)>();
 
 inline CMemory p_CSquirrelVM_DestroySignalEntryListHead;
-inline auto v_CSquirrelVM_DestroySignalEntryListHead = p_CSquirrelVM_DestroySignalEntryListHead.RCast<SQBool(*)(CSquirrelVM* s, HSQUIRRELVM v, SQFloat f)>();
+inline SQBool(*v_CSquirrelVM_DestroySignalEntryListHead)(CSquirrelVM* s, HSQUIRRELVM v, SQFloat f);
 
 inline CMemory p_CSquirrelVM_RegisterFunction;
-inline auto v_CSquirrelVM_RegisterFunction = p_CSquirrelVM_RegisterFunction.RCast<SQRESULT(*)(CSquirrelVM* s, ScriptFunctionBinding_t* binding, SQInteger a1)>();
+inline SQRESULT(*v_CSquirrelVM_RegisterFunction)(CSquirrelVM* s, ScriptFunctionBinding_t* binding, SQInteger a1);
 
 inline CMemory p_CSquirrelVM_RegisterConstant;
-inline auto v_CSquirrelVM_RegisterConstant = p_CSquirrelVM_RegisterConstant.RCast<SQRESULT(*)(CSquirrelVM* s, const SQChar* name, SQInteger value)>();
+inline SQRESULT(*v_CSquirrelVM_RegisterConstant)(CSquirrelVM* s, const SQChar* name, SQInteger value);
 
 #ifndef DEDICATED
 inline CMemory p_CSquirrelVM_PrecompileClientScripts;

--- a/r5dev/vscript/vscript.h
+++ b/r5dev/vscript/vscript.h
@@ -14,10 +14,10 @@
 class CSquirrelVM;
 
 inline CMemory p_Script_LoadScriptList;
-inline auto v_Script_LoadScriptList = p_Script_LoadScriptList.RCast<RSON::Node_t* (*)(const SQChar* rsonfile)>();
+inline RSON::Node_t*(*v_Script_LoadScriptList)(const SQChar* rsonfile);
 
 inline CMemory p_Script_LoadScriptFile;
-inline auto v_Script_LoadScriptFile = p_Script_LoadScriptFile.RCast<SQBool(*)(HSQUIRRELVM v, const SQChar* path, const SQChar* name, SQInteger flags)>();
+inline SQBool(*v_Script_LoadScriptFile)(HSQUIRRELVM v, const SQChar* path, const SQChar* name, SQInteger flags);
 
 inline CMemory p_Script_ParseScriptList;
 inline auto v_Script_ParseScriptList = p_Script_ParseScriptList.RCast<SQBool(__fastcall*)(SQCONTEXT ctx, const char* scriptListPath, RSON::Node_t* rson, char** scriptArray, int* pScriptCount, char** precompiledScriptArray, int precompiledScriptCount)>();

--- a/r5dev/windows/id3dx.cpp
+++ b/r5dev/windows/id3dx.cpp
@@ -161,8 +161,8 @@ HRESULT __stdcall ResizeBuffers(IDXGISwapChain* pSwapChain, UINT nBufferCount, U
 // Disable stack warning, tells us to move more data to the heap instead. Not really possible with 'initialData' here. Since its parallel processed.
 // Also disable 6378, complains that there is no control path where it would use 'nullptr', if that happens 'Error' will be called though.
 #pragma warning( disable : 6262 6387)
-inline CMemory p_CreateTextureResource;
-inline auto v_CreateTextureResource = p_CreateTextureResource.RCast<void(*)(TextureHeader_t*, INT_PTR)>();
+CMemory p_CreateTextureResource;
+void(*v_CreateTextureResource)(TextureHeader_t*, INT_PTR);
 constexpr uint32_t ALIGNMENT_SIZE = 15; // Creates 2D texture and shader resource from textureHeader and imageData.
 void CreateTextureResource(TextureHeader_t* textureHeader, INT_PTR imageData)
 {


### PR DESCRIPTION
Find regex pattern:
inline auto ([a-zA-Z0-9_]+) = ([a-zA-Z0-9_]+)\.RCast<([a-zA-Z0-9_:<>*]+) *\(\*\)\(([^)]*)\)>\(\); Replace regex pattern:
inline $3(*$1)($4);

This pull request also removes the unnecessary initialization (which was required to type the auto variables), and therefore removed 6kb of unnecessary dynamic initialization code in the compiled SDK module.