### PR TITLE
IDetour: interface refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@ which are located in `<gamedir>\platform\cfg\startup_*.cfg`.
 This is not a cheat or hack; attempting to use the SDK on the live version of the game could result in a permanent account ban.<br />
 The supported game versions are:
 
- * S0 `R5pc_r5launch_J1557_CL387233_2019_01_28_07_43_PM`.
- * S0 `R5pc_r5launch_J1624A_CL394493_2019_02_24_09_29_PM`.
- * S1 `R5pc_r5launch_N52A_CL399039_2019_03_12_03_21_PM`.
- * S2 `R5pc_r5launch_N428_CL436418_2019_08_07_09_35_PM`.
  * S3 `R5pc_r5launch_N1094_CL456479_2019_10_30_05_20_PM`.
 
 ## Pylon [DISCLAIMER]

--- a/src/appframework/IAppSystemGroup.cpp
+++ b/src/appframework/IAppSystemGroup.cpp
@@ -14,7 +14,7 @@
 //-----------------------------------------------------------------------------
 void CAppSystemGroup::StaticDestroy(CAppSystemGroup* pModAppSystemGroup)
 {
-	CAppSystemGroup_Destroy(pModAppSystemGroup);
+	CAppSystemGroup__Destroy(pModAppSystemGroup);
 }
 
 //-----------------------------------------------------------------------------
@@ -68,5 +68,5 @@ void* CAppSystemGroup::FindSystem(const char* pSystemName)
 
 void VAppSystemGroup::Detour(const bool bAttach) const
 {
-	DetourSetup(&CAppSystemGroup_Destroy, &CAppSystemGroup::StaticDestroy, bAttach);
+	DetourSetup(&CAppSystemGroup__Destroy, &CAppSystemGroup::StaticDestroy, bAttach);
 }

--- a/src/cmake/Options.cmake
+++ b/src/cmake/Options.cmake
@@ -26,14 +26,6 @@ macro( apply_project_settings )
     option( OPTION_CERTAIN "This build is certain; debug statements (such as DevMsg(...)) will NOT be compiled" OFF )
     option( OPTION_RETAIL "This build is retail; enable this among with 'OPTION_CERTAIN' to form a release build" OFF )
 
-    set( OPTION_GAMEDLL "GAMEDLL_S3" CACHE STRING "Game DLL version" )
-    set_property( CACHE OPTION_GAMEDLL PROPERTY STRINGS
-        "GAMEDLL_S0"
-        "GAMEDLL_S1"
-        "GAMEDLL_S2"
-        "GAMEDLL_S3"
-    )
-
     # Set common defines
     add_compile_definitions(
         "_CRT_SECURE_NO_WARNINGS"
@@ -48,7 +40,6 @@ macro( apply_project_settings )
 
         # Target is 64bits only.
         "PLATFORM_64BITS"
-        "${OPTION_GAMEDLL}"
     )
 
     if( ${OPTION_CERTAIN} )

--- a/src/codecs/bink/bink_impl.h
+++ b/src/codecs/bink/bink_impl.h
@@ -1,12 +1,7 @@
 #pragma once
 
-inline CMemory p_BinkOpen;
 inline void*(*v_BinkOpen)(HANDLE hBinkFile, UINT32 nFlags);
-
-inline CMemory p_BinkClose;
 inline void(*v_BinkClose)(HANDLE hBinkFile);
-
-inline CMemory p_BinkGetError;
 inline const char*(*v_BinkGetError)(void);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -14,22 +9,18 @@ class BinkCore : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("BinkOpen", p_BinkOpen.GetPtr());
-		LogFunAdr("BinkClose", p_BinkClose.GetPtr());
-		LogFunAdr("BinkGetError", p_BinkGetError.GetPtr());
+		LogFunAdr("BinkOpen", v_BinkOpen);
+		LogFunAdr("BinkClose", v_BinkClose);
+		LogFunAdr("BinkGetError", v_BinkGetError);
 	}
 	virtual void GetFun(void) const
 	{
-		p_BinkOpen = g_RadVideoToolsDll.GetExportedSymbol("BinkOpen");
-		v_BinkOpen = p_BinkOpen.RCast<void*(*)(HANDLE, UINT32)>();
-		p_BinkClose = g_RadVideoToolsDll.GetExportedSymbol("BinkClose");
-		v_BinkClose = p_BinkClose.RCast<void(*)(HANDLE)>();
-		p_BinkGetError = g_RadVideoToolsDll.GetExportedSymbol("BinkGetError");
-		v_BinkGetError = p_BinkGetError.RCast<const char* (*)(void)>();
+		g_RadVideoToolsDll.GetExportedSymbol("BinkOpen").GetPtr(v_BinkOpen);
+		g_RadVideoToolsDll.GetExportedSymbol("BinkClose").GetPtr(v_BinkClose);
+		g_RadVideoToolsDll.GetExportedSymbol("BinkGetError").GetPtr(v_BinkGetError);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;
 };
 ///////////////////////////////////////////////////////////////////////////////
-

--- a/src/codecs/miles/miles_impl.h
+++ b/src/codecs/miles/miles_impl.h
@@ -2,16 +2,9 @@
 #include "miles_types.h"
 
 /* ==== WASAPI THREAD SERVICE =========================================================================================================================================== */
-inline CMemory p_AIL_LogFunc;
 inline void(*v_AIL_LogFunc)(int64_t nLogLevel, const char* pszMessage);
-
-inline CMemory p_Miles_Initialize;
 inline bool(*v_Miles_Initialize)();
-
-inline CMemory p_MilesQueueEventRun;
 inline void(*v_MilesQueueEventRun)(Miles::Queue*, const char*);
-
-inline CMemory p_MilesBankPatch;
 inline void(*v_MilesBankPatch)(Miles::Bank*, char*, char*);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -19,27 +12,18 @@ class MilesCore : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("AIL_LogFunc", p_AIL_LogFunc.GetPtr());
-		LogFunAdr("Miles_Initialize", p_Miles_Initialize.GetPtr());
+		LogFunAdr("AIL_LogFunc", v_AIL_LogFunc);
+		LogFunAdr("Miles_Initialize", v_Miles_Initialize);
+		LogFunAdr("MilesQueueEventRun", v_MilesQueueEventRun);
+		LogFunAdr("MilesBankPatch", v_MilesBankPatch);
 	}
 	virtual void GetFun(void) const
 	{
-		p_AIL_LogFunc = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B DA 48 8D 15 ?? ?? ?? ??");
-		v_AIL_LogFunc = p_AIL_LogFunc.RCast<void(*)(int64_t, const char*)>();
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B DA 48 8D 15 ?? ?? ?? ??").GetPtr(v_AIL_LogFunc);
+		g_GameDll.FindPatternSIMD("40 53 56 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ??").GetPtr(v_Miles_Initialize);
 
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
-		p_Miles_Initialize = g_GameDll.FindPatternSIMD("40 53 56 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ??");
-#else
-		p_Miles_Initialize = g_GameDll.FindPatternSIMD("40 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ??");
-#endif // !(GAMEDLL_S0) || !(GAMEDLL_S1) || !(GAMEDLL_S2)
-		v_Miles_Initialize = p_Miles_Initialize.RCast<bool(*)()>();
-
-		p_MilesQueueEventRun = g_RadAudioSystemDll.GetExportedSymbol("MilesQueueEventRun");
-		v_MilesQueueEventRun = p_MilesQueueEventRun.RCast<void(*)(Miles::Queue*, const char*)>();
-
-		p_MilesBankPatch = g_RadAudioSystemDll.GetExportedSymbol("MilesBankPatch");
-		v_MilesBankPatch = p_MilesBankPatch.RCast<void(*)(Miles::Bank*, char*, char*)>();
-
+		g_RadAudioSystemDll.GetExportedSymbol("MilesQueueEventRun").GetPtr(v_MilesQueueEventRun);
+		g_RadAudioSystemDll.GetExportedSymbol("MilesBankPatch").GetPtr(v_MilesBankPatch);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/codecs/miles/radshal_wasapi.h
+++ b/src/codecs/miles/radshal_wasapi.h
@@ -8,7 +8,7 @@ class VRadShal : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("WASAPI_GetAudioDevice", p_WASAPI_GetAudioDevice.GetPtr());
+		LogFunAdr("WASAPI_GetAudioDevice", (void*)p_WASAPI_GetAudioDevice.GetPtr());
 	}
 	virtual void GetFun(void) const
 	{

--- a/src/common/callback.cpp
+++ b/src/common/callback.cpp
@@ -71,7 +71,7 @@ MP_GameMode_Changed_f
 */
 void MP_GameMode_Changed_f(IConVar* pConVar, const char* pOldString, float flOldValue)
 {
-	SetupGamemode(mp_gamemode->GetString());
+	v_SetupGamemode(mp_gamemode->GetString());
 }
 
 /*
@@ -230,7 +230,7 @@ Host_ReloadPlaylists_f
 */
 void Host_ReloadPlaylists_f(const CCommand& args)
 {
-	_DownloadPlaylists_f();
+	v__DownloadPlaylists_f();
 	KeyValues::InitPlaylists(); // Re-Init playlist.
 }
 
@@ -1203,7 +1203,7 @@ Mat_CrossHair_f
 */
 void Mat_CrossHair_f(const CCommand& args)
 {
-	CMaterialGlue* material = GetMaterialAtCrossHair();
+	CMaterialGlue* material = v_GetMaterialAtCrossHair();
 	if (material)
 	{
 		Msg(eDLL_T::MS, "______________________________________________________________\n");
@@ -1339,7 +1339,7 @@ void Capsule_f(const CCommand& args)
 	g_pDebugOverlay->AddCapsuleOverlay(start, end, radius, { 0,0,0 }, { 0,0,0 }, 141, 233, 135, 0, 100);
 }
 #endif // !DEDICATED
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
+
 /*
 =====================
 BHit_f
@@ -1396,7 +1396,7 @@ void BHit_f(const CCommand& args)
 	}
 #endif // !DEDICATED
 }
-#endif // !GAMEDLL_S0 && !GAMEDLL_S1
+
 /*
 =====================
 CVHelp_f
@@ -1539,11 +1539,11 @@ void Cmd_Exec_f(const CCommand& args)
 		}
 	}
 #endif // !DEDICATED
-	_Cmd_Exec_f(args);
+	v__Cmd_Exec_f(args);
 }
 
 
 void VCallback::Detour(const bool bAttach) const
 {
-	DetourSetup(&_Cmd_Exec_f, &Cmd_Exec_f, bAttach);
+	DetourSetup(&v__Cmd_Exec_f, &Cmd_Exec_f, bAttach);
 }

--- a/src/common/callback.h
+++ b/src/common/callback.h
@@ -1,14 +1,10 @@
 #pragma once
 
-inline CMemory p_SetupGamemode;
-inline bool(*SetupGamemode)(const char* pszPlayList);
+inline bool(*v_SetupGamemode)(const char* pszPlayList);
 
 /* ==== CONCOMMANDCALLBACK ============================================================================================================================================== */
-inline CMemory p_DownloadPlaylists_f;
-inline void(*_DownloadPlaylists_f)(void);
-
-inline CMemory p_Cmd_Exec_f;
-inline void(*_Cmd_Exec_f)(const CCommand& args);
+inline void(*v__DownloadPlaylists_f)(void);
+inline void(*v__Cmd_Exec_f)(const CCommand& args);
 
 ///////////////////////////////////////////////////////////////////////////////
 void MP_GameMode_Changed_f(IConVar* pConVar, const char* pOldString, float flOldValue);
@@ -72,9 +68,7 @@ void Line_f(const CCommand& args);
 void Sphere_f(const CCommand& args);
 void Capsule_f(const CCommand& args);
 #endif // !DEDICATED
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
 void BHit_f(const CCommand& args);
-#endif // !GAMEDLL_S0 && !GAMEDLL_S1
 
 void CVHelp_f(const CCommand& args);
 void CVList_f(const CCommand& args);
@@ -88,19 +82,15 @@ class VCallback : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("SetupGamemode", p_SetupGamemode.GetPtr());
-		LogFunAdr("DownloadPlaylist_f", p_DownloadPlaylists_f.GetPtr());
-		LogFunAdr("Cmd_Exec_f", p_Cmd_Exec_f.GetPtr());
+		LogFunAdr("SetupGamemode", v_SetupGamemode);
+		LogFunAdr("DownloadPlaylist_f", v__DownloadPlaylists_f);
+		LogFunAdr("Cmd_Exec_f", v__Cmd_Exec_f);
 	}
 	virtual void GetFun(void) const
 	{
-		p_SetupGamemode = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B D9 48 C7 C0 ?? ?? ?? ??");
-		p_DownloadPlaylists_f = g_GameDll.FindPatternSIMD("33 C9 C6 05 ?? ?? ?? ?? ?? E9 ?? ?? ?? ??");
-		p_Cmd_Exec_f = g_GameDll.FindPatternSIMD("40 55 53 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B D9");
-
-		SetupGamemode = p_SetupGamemode.RCast<bool(*)(const char*)>();
-		_DownloadPlaylists_f = p_DownloadPlaylists_f.RCast<void(*)(void)>();
-		_Cmd_Exec_f = p_Cmd_Exec_f.RCast<void(*)(const CCommand& args)>();
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B D9 48 C7 C0 ?? ?? ?? ??").GetPtr(v_SetupGamemode);
+		g_GameDll.FindPatternSIMD("33 C9 C6 05 ?? ?? ?? ?? ?? E9 ?? ?? ?? ??").GetPtr(v__DownloadPlaylists_f);
+		g_GameDll.FindPatternSIMD("40 55 53 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B D9").GetPtr(v__Cmd_Exec_f);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/common/completion.h
+++ b/src/common/completion.h
@@ -13,8 +13,7 @@ int RTech_PakLoad_f_CompletionFunc(char const* partial, char commands[COMMAND_CO
 int RTech_PakUnload_f_CompletionFunc(char const* partial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH]);
 int RTech_PakDecompress_f_CompletionFunc(char const* partial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH]);
 
-inline CMemory p_CBaseAutoCompleteFileList_AutoCompletionFunc;
-inline int(*v_CBaseAutoCompleteFileList_AutoCompletionFunc)
+inline int(*CBaseAutoCompleteFileList__AutoCompletionFunc)
 (CBaseAutoCompleteFileList* thisp, const char* partial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH]);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -22,17 +21,11 @@ class VCompletion : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CBaseAutoCompleteFileList::AutoCompletionFunc", p_CBaseAutoCompleteFileList_AutoCompletionFunc.GetPtr());
+		LogFunAdr("CBaseAutoCompleteFileList::AutoCompletionFunc", CBaseAutoCompleteFileList__AutoCompletionFunc);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CBaseAutoCompleteFileList_AutoCompletionFunc = g_GameDll.FindPatternSIMD("40 55 53 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 48 8B 39");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CBaseAutoCompleteFileList_AutoCompletionFunc = g_GameDll.FindPatternSIMD("48 8B C4 4C 89 40 18 55 41 54");
-#endif
-		v_CBaseAutoCompleteFileList_AutoCompletionFunc = p_CBaseAutoCompleteFileList_AutoCompletionFunc.RCast<int(*)(
-			CBaseAutoCompleteFileList*, const char*, char[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH])>();
+		g_GameDll.FindPatternSIMD("48 8B C4 4C 89 40 18 55 41 54").GetPtr(CBaseAutoCompleteFileList__AutoCompletionFunc);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/common/global.cpp
+++ b/src/common/global.cpp
@@ -175,11 +175,9 @@ ConVar* sv_quota_scriptExecsPerSecond       = nullptr;
 ConVar* sv_cheats                          = nullptr;
 ConVar* sv_visualizetraces                 = nullptr;
 ConVar* sv_visualizetraces_duration        = nullptr;
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
 ConVar* bhit_enable                        = nullptr;
 ConVar* bhit_depth_test                    = nullptr;
 ConVar* bhit_abs_origin                    = nullptr;
-#endif // !GAMEDLL_S0 && !GAMEDLL_S1
 //-----------------------------------------------------------------------------
 // CLIENT                                                                     |
 #ifndef DEDICATED
@@ -412,10 +410,10 @@ void ConVar_StaticInit(void)
 	sv_onlineAuthIssuedAtTolerance = ConVar::StaticCreate("sv_onlineAuthIssuedAtTolerance", "30", FCVAR_RELEASE, "The online authentication token 'issued at' claim tolerance in seconds.", true, 0.f, true, float(UINT8_MAX), nullptr, "Must range between [0,255]");
 #endif // !CLIENT_DLL
 	sv_quota_scriptExecsPerSecond = ConVar::StaticCreate("sv_quota_scriptExecsPerSecond", "4", FCVAR_REPLICATED | FCVAR_RELEASE, "How many script executions per second clients are allowed to submit, 0 to disable the limitation thereof.", true, 0.f, false, 0.f, nullptr, nullptr);
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
+
 	bhit_depth_test = ConVar::StaticCreate("bhit_depth_test", "0", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Use depth test for bullet ray trace overlay.", false, 0.f, false, 0.f, nullptr, nullptr);
 	bhit_abs_origin = ConVar::StaticCreate("bhit_abs_origin", "1", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Draw entity's predicted abs origin upon bullet impact for trajectory debugging (requires 'r_visualizetraces' to be set!).", false, 0.f, false, 0.f, nullptr, nullptr);
-#endif // !GAMEDLL_S0 && !GAMEDLL_S1
+
 	//-------------------------------------------------------------------------
 	// CLIENT                                                                 |
 #ifndef DEDICATED
@@ -544,9 +542,7 @@ void ConVar_InitShipped(void)
 {
 #ifndef CLIENT_DLL
 	ai_script_nodes_draw             = g_pCVar->FindVar("ai_script_nodes_draw");
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
 	bhit_enable                      = g_pCVar->FindVar("bhit_enable");
-#endif // !GAMEDLL_S0 && !GAMEDLL_S1
 #endif // !CLIENT_DLL
 	developer                        = g_pCVar->FindVar("developer");
 	fps_max                          = g_pCVar->FindVar("fps_max");
@@ -627,9 +623,7 @@ void ConVar_InitShipped(void)
 	sv_single_core_dedi->RemoveFlags(FCVAR_DEVELOPMENTONLY);
 
 	ai_script_nodes_draw->SetValue(-1);
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
 	bhit_enable->SetValue(0);
-#endif // !(GAMEDLL_S0) || !(GAMEDLL_S1) || !(GAMEDLL_S2)
 #endif // !CLIENT_DLL
 #ifndef DEDICATED
 	cl_updaterate_mp->RemoveFlags(FCVAR_DEVELOPMENTONLY);
@@ -722,9 +716,7 @@ void ConCommand_StaticInit(void)
 {
 	//-------------------------------------------------------------------------
 	// ENGINE DLL                                                             |
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
 	ConCommand::StaticCreate("bhit", "Bullet-hit trajectory debug.", nullptr, FCVAR_DEVELOPMENTONLY | FCVAR_GAMEDLL, BHit_f, nullptr);
-#endif // !GAMEDLL_S0 && !GAMEDLL_S1
 #ifndef DEDICATED
 	ConCommand::StaticCreate("line", "Draw a debug line.", nullptr, FCVAR_DEVELOPMENTONLY | FCVAR_CHEAT, Line_f, nullptr);
 	ConCommand::StaticCreate("sphere", "Draw a debug sphere.", nullptr, FCVAR_DEVELOPMENTONLY | FCVAR_CHEAT, Sphere_f, nullptr);

--- a/src/common/global.h
+++ b/src/common/global.h
@@ -165,11 +165,9 @@ extern ConVar* sv_quota_scriptExecsPerSecond;
 extern ConVar* sv_cheats;
 extern ConVar* sv_visualizetraces;
 extern ConVar* sv_visualizetraces_duration;
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
 extern ConVar* bhit_enable;
 extern ConVar* bhit_depth_test;
 extern ConVar* bhit_abs_origin;
-#endif // !GAMEDLL_S0 && !GAMEDLL_S1
 //-------------------------------------------------------------------------
 // CLIENT                                                                 |
 #ifndef DEDICATED

--- a/src/common/netmessages.h
+++ b/src/common/netmessages.h
@@ -494,15 +494,15 @@ class V_NetMessages : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogConAdr("SVC_Print::`vftable'", reinterpret_cast<uintptr_t>(g_pSVC_Print_VFTable));
-		LogConAdr("SVC_UserMessage::`vftable'", reinterpret_cast<uintptr_t>(g_pSVC_UserMessage_VFTable));
-		LogConAdr("SVC_ServerTick::`vftable'", reinterpret_cast<uintptr_t>(g_pSVC_ServerTick_VFTable));
-		LogConAdr("SVC_VoiceData::`vftable'", reinterpret_cast<uintptr_t>(g_pSVC_VoiceData_VFTable));
-		LogConAdr("SVC_PlaylistOverrides::`vftable'", reinterpret_cast<uintptr_t>(g_pSVC_PlaylistOverrides_VFTable));
-		LogConAdr("CLC_ClientTick::`vftable'", reinterpret_cast<uintptr_t>(g_pCLC_ClientTick_VFTable));
-		LogConAdr("CLC_SetPlaylistVarOverride::`vftable'", reinterpret_cast<uintptr_t>(g_pCLC_SetPlaylistVarOverride_VFTable));
-		LogConAdr("Base_CmdKeyValues::`vftable'", reinterpret_cast<uintptr_t>(g_pBase_CmdKeyValues_VFTable));
-		//LogFunAdr("MM_Heartbeat::ToString", MM_Heartbeat__ToString.GetPtr());
+		LogConAdr("SVC_Print::`vftable'", g_pSVC_Print_VFTable);
+		LogConAdr("SVC_UserMessage::`vftable'", g_pSVC_UserMessage_VFTable);
+		LogConAdr("SVC_ServerTick::`vftable'", g_pSVC_ServerTick_VFTable);
+		LogConAdr("SVC_VoiceData::`vftable'", g_pSVC_VoiceData_VFTable);
+		LogConAdr("SVC_PlaylistOverrides::`vftable'", g_pSVC_PlaylistOverrides_VFTable);
+		LogConAdr("CLC_ClientTick::`vftable'", g_pCLC_ClientTick_VFTable);
+		LogConAdr("CLC_SetPlaylistVarOverride::`vftable'", g_pCLC_SetPlaylistVarOverride_VFTable);
+		LogConAdr("Base_CmdKeyValues::`vftable'", g_pBase_CmdKeyValues_VFTable);
+		//LogFunAdr("MM_Heartbeat::ToString", MM_Heartbeat__ToString);
 	}
 	virtual void GetFun(void) const
 	{

--- a/src/common/opcodes.cpp
+++ b/src/common/opcodes.cpp
@@ -351,7 +351,7 @@ void RuntimePtc_Init() /* .TEXT */
 	CMemory(v_SQVM_CompileError).Offset(0xE0).FindPatternSelf("E8", CMemory::Direction::DOWN, 200).Patch({ 0x90, 0x90, 0x90, 0x90, 0x90 }); // CAL --> NOP | For dedicated we should not perform post-error events such as telemetry / showing 'COM_ExplainDisconnection' UI etc.
 #endif // !DEDICATED
 
-	vector<uint8_t> starPakOpenFile = {
+	const vector<uint8_t> starPakOpenFile = {
 		0x4D, 0x31, 0xC0,                                 // xor, r8, r8
 		0x48, 0x8D, 0x8C, 0x24, 0x90, 0x00, 0x00, 0x00,   // lea  rcx, [rsp+378h+90h] FileName
 

--- a/src/common/opcodes.cpp
+++ b/src/common/opcodes.cpp
@@ -345,10 +345,10 @@ void RuntimePtc_Init() /* .TEXT */
 #ifndef DEDICATED
 	p_WASAPI_GetAudioDevice.Offset(0x410).FindPatternSelf("FF 15 ?? ?? 01 00", CMemory::Direction::DOWN, 100).Patch({ 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0xEB }); // CAL --> NOP | Disable debugger check when miles searches for audio device to allow attaching the debugger to the game upon launch.
 
-	p_SQVM_CompileError.Offset(0x0).FindPatternSelf("41 B0 01", CMemory::Direction::DOWN, 400).Patch({ 0x41, 0xB0, 0x00 });        // MOV --> MOV | Set script error level to 0 (not severe): 'mov r8b, 0'.
-	p_SQVM_CompileError.Offset(0xE0).FindPatternSelf("E8", CMemory::Direction::DOWN, 200).Patch({ 0x90, 0x90, 0x90, 0x90, 0x90 }); // CAL --> NOP | TODO: causes errors on client script error. Research required (same function as soft error but that one doesn't crash).
+	CMemory(v_SQVM_CompileError).Offset(0x0).FindPatternSelf("41 B0 01", CMemory::Direction::DOWN, 400).Patch({ 0x41, 0xB0, 0x00 });        // MOV --> MOV | Set script error level to 0 (not severe): 'mov r8b, 0'.
+	CMemory(v_SQVM_CompileError).Offset(0xE0).FindPatternSelf("E8", CMemory::Direction::DOWN, 200).Patch({ 0x90, 0x90, 0x90, 0x90, 0x90 }); // CAL --> NOP | TODO: causes errors on client script error. Research required (same function as soft error but that one doesn't crash).
 #else
-	p_SQVM_CompileError.Offset(0xE0).FindPatternSelf("E8", CMemory::Direction::DOWN, 200).Patch({ 0x90, 0x90, 0x90, 0x90, 0x90 }); // CAL --> NOP | For dedicated we should not perform post-error events such as telemetry / showing 'COM_ExplainDisconnection' UI etc.
+	CMemory(v_SQVM_CompileError).Offset(0xE0).FindPatternSelf("E8", CMemory::Direction::DOWN, 200).Patch({ 0x90, 0x90, 0x90, 0x90, 0x90 }); // CAL --> NOP | For dedicated we should not perform post-error events such as telemetry / showing 'COM_ExplainDisconnection' UI etc.
 #endif // !DEDICATED
 
 #if defined (GAMEDLL_S2) || defined (GAMEDLL_S3)

--- a/src/common/opcodes.cpp
+++ b/src/common/opcodes.cpp
@@ -351,36 +351,14 @@ void RuntimePtc_Init() /* .TEXT */
 	CMemory(v_SQVM_CompileError).Offset(0xE0).FindPatternSelf("E8", CMemory::Direction::DOWN, 200).Patch({ 0x90, 0x90, 0x90, 0x90, 0x90 }); // CAL --> NOP | For dedicated we should not perform post-error events such as telemetry / showing 'COM_ExplainDisconnection' UI etc.
 #endif // !DEDICATED
 
-#if defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-#ifndef CLIENT_DLL
-	//p_CAI_NetworkManager__ShouldRebuild.Offset(0xA0).FindPatternSelf("FF ?? ?? ?? 00 00", CMemory::Direction::DOWN, 200).Patch({ 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }); // CAL --> NOP | Virtual call to restart when building AIN (which clears the AIN memory). Remove this once writing to file works.
-	//p_Detour_LevelInit.Offset(0x100).FindPatternSelf("74", CMemory::Direction::DOWN, 600).Patch({ 0xEB });                                                              // JE  --> JMP | Do while loop setting fields to -1 in navmesh is writing out of bounds (!TODO).
-#endif // !CLIENT_DLL
-#endif
-
 	vector<uint8_t> starPakOpenFile = {
 		0x4D, 0x31, 0xC0,                                 // xor, r8, r8
 		0x48, 0x8D, 0x8C, 0x24, 0x90, 0x00, 0x00, 0x00,   // lea  rcx, [rsp+378h+90h] FileName
 
 		// call RTech::OpenFile [RIP+RVA]
-    #if defined (GAMEDLL_S0)
-		0xE8, 0x87, 0x96, 0xFF, 0xFF,
-    #elif defined (GAMEDLL_S1)
-		0xE8, 0x27, 0x95, 0xFF, 0xFF,
-    #elif defined (GAMEDLL_S2)
-		0xE8, 0x87, 0x95, 0xFF, 0xFF,
-    #elif defined (GAMEDLL_S3)
 		0xE8, 0x77, 0x8F, 0xFF, 0xFF,
-    #endif
-
 		0x8B, 0xF8,                                       // mov  edi, eax
-
-		// jmp  [RIP+RVA]
-	#if defined (GAMEDLL_S0) || defined(GAMEDLL_S1)
-		0xE9, 0xDC, 0x00, 0x00, 0x00
-    #elif defined (GAMEDLL_S2) || defined(GAMEDLL_S3)
-		0xE9, 0xDA, 0x00, 0x00, 0x00
-	#endif
+		0xE9, 0xDA, 0x00, 0x00, 0x00                      // jmp  [RIP+RVA]
 	};
 
 	p_Pak_OpenFileOffset.Patch(starPakOpenFile);

--- a/src/common/protocol.h
+++ b/src/common/protocol.h
@@ -31,11 +31,7 @@ enum class PERSISTENCE : int
 	PERSISTENCE_NONE      = 0, // no persistence data for this client yet.
 	PERSISTENCE_PENDING   = 1, // pending or processing persistence data.
 	PERSISTENCE_AVAILABLE = 2, // persistence is available for this client.
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1) || defined (GAMEDLL_S2)
-	PERSISTENCE_READY     = 3  // persistence is ready for this client.
-#else
 	PERSISTENCE_READY     = 5  // persistence is ready for this client.
-#endif
 };
 
 #define net_NOP        0 // nop command used for padding.

--- a/src/core/init.cpp
+++ b/src/core/init.cpp
@@ -213,6 +213,7 @@ void Systems_Init()
 	if (hr != NO_ERROR)
 	{
 		// Failed to hook into the process, terminate
+		Assert(0);
 		Error(eDLL_T::COMMON, 0xBAD0C0DE, "Failed to detour process: error code = %08x\n", hr);
 	}
 

--- a/src/datacache/mdlcache.cpp
+++ b/src/datacache/mdlcache.cpp
@@ -274,9 +274,7 @@ studiohwdata_t* CMDLCache::GetHardwareData(CMDLCache* cache, MDLHandle_t handle)
         void* pAnimData = (void*)*((_QWORD*)dataCache + 1);
 
         AcquireSRWLockExclusive(g_pMDLLock);
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
-        v_CStudioHWDataRef__SetFlags(reinterpret_cast<CStudioHWDataRef*>(pAnimData), 1i64); // !!! DECLARED INLINE IN < S3 !!!
-#endif
+        CStudioHWDataRef__SetFlags(reinterpret_cast<CStudioHWDataRef*>(pAnimData), 1i64); // !!! DECLARED INLINE IN < S3 !!!
         ReleaseSRWLockExclusive(g_pMDLLock);
     }
     if ((pStudioData->m_nFlags & STUDIODATA_FLAGS_STUDIOMESH_LOADED))
@@ -311,13 +309,9 @@ bool CMDLCache::IsKnownBadModel(MDLHandle_t handle)
 
 void VMDLCache::Detour(const bool bAttach) const
 {
-    DetourSetup(&v_CMDLCache__FindMDL, &CMDLCache::FindMDL, bAttach);
-#ifdef GAMEDLL_S3 // !!! DECLARED INLINE WITH FINDMDL IN < S3 !!!
-    DetourSetup(&v_CMDLCache__FindCachedMDL, &CMDLCache::FindCachedMDL, bAttach);
-    DetourSetup(&v_CMDLCache__FindUncachedMDL, &CMDLCache::FindUncachedMDL, bAttach);
-#endif // GAMEDLL_S3
-#ifdef GAMEDLL_S3 // !TODO:
-    DetourSetup(&v_CMDLCache__GetHardwareData, &CMDLCache::GetHardwareData, bAttach);
-    DetourSetup(&v_CMDLCache__GetStudioHDR, &CMDLCache::GetStudioHDR, bAttach);
-#endif
+    DetourSetup(&CMDLCache__FindMDL, &CMDLCache::FindMDL, bAttach);
+    DetourSetup(&CMDLCache__FindCachedMDL, &CMDLCache::FindCachedMDL, bAttach);
+    DetourSetup(&CMDLCache__FindUncachedMDL, &CMDLCache::FindUncachedMDL, bAttach);
+    DetourSetup(&CMDLCache__GetHardwareData, &CMDLCache::GetHardwareData, bAttach);
+    DetourSetup(&CMDLCache__GetStudioHDR, &CMDLCache::GetStudioHDR, bAttach);
 }

--- a/src/datacache/mdlcache.h
+++ b/src/datacache/mdlcache.h
@@ -47,10 +47,6 @@ struct studiodata_t
 	unsigned short m_nRefCount;
 	unsigned short m_nFlags;
 	MDLHandle_t m_Handle;
-#ifndef GAMEDLL_S3
-	void* Unk1; // TODO: unverified!
-	void* Unk2; // TODO: unverified!
-#endif // !GAMEDLL_S3
 	void* Unk3; // ptr to flags and model string.
 	CStudioHWDataRef* m_pHardwareRef;
 	void* m_pMaterialTable; // contains a large table of CMaterialGlue objects.
@@ -108,24 +104,15 @@ private:
 	// !TODO: reverse the rest
 };
 
-inline CMemory p_CMDLCache__FindMDL;
-inline studiohdr_t*(*v_CMDLCache__FindMDL)(CMDLCache* pCache, MDLHandle_t handle, void* a3);
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
-inline CMemory p_CMDLCache__FindCachedMDL;
-inline void(*v_CMDLCache__FindCachedMDL)(CMDLCache* pCache, studiodata_t* pStudioData, void* a3);
+inline studiohdr_t*(*CMDLCache__FindMDL)(CMDLCache* pCache, MDLHandle_t handle, void* a3);
+inline void(*CMDLCache__FindCachedMDL)(CMDLCache* pCache, studiodata_t* pStudioData, void* a3);
 
-inline CMemory p_CMDLCache__FindUncachedMDL;
-inline studiohdr_t*(*v_CMDLCache__FindUncachedMDL)(CMDLCache* pCache, MDLHandle_t handle, studiodata_t* pStudioData, void* a4);
-#endif
-inline CMemory p_CMDLCache__GetStudioHDR;
-inline studiohdr_t*(*v_CMDLCache__GetStudioHDR)(CMDLCache* pCache, MDLHandle_t handle);
+inline studiohdr_t*(*CMDLCache__FindUncachedMDL)(CMDLCache* pCache, MDLHandle_t handle, studiodata_t* pStudioData, void* a4);
+inline studiohdr_t*(*CMDLCache__GetStudioHDR)(CMDLCache* pCache, MDLHandle_t handle);
 
-inline CMemory p_CMDLCache__GetHardwareData;
-inline studiohwdata_t*(*v_CMDLCache__GetHardwareData)(CMDLCache* pCache, MDLHandle_t handle);
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
-inline CMemory p_CStudioHWDataRef__SetFlags; // Probably incorrect.
-inline bool(*v_CStudioHWDataRef__SetFlags)(CStudioHWDataRef* ref, int64_t flags);
-#endif
+inline studiohwdata_t*(*CMDLCache__GetHardwareData)(CMDLCache* pCache, MDLHandle_t handle);
+inline bool(*CStudioHWDataRef__SetFlags)(CStudioHWDataRef* ref, int64_t flags); // Probably incorrect name.
+
 inline CMDLCache* g_pMDLCache = nullptr;
 inline PSRWLOCK g_pMDLLock = nullptr; // Possibly a member? research required.
 
@@ -134,54 +121,24 @@ class VMDLCache : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CMDLCache::FindMDL", p_CMDLCache__FindMDL.GetPtr());
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
-		LogFunAdr("CMDLCache::FindCachedMDL", p_CMDLCache__FindCachedMDL.GetPtr());
-		LogFunAdr("CMDLCache::FindUncachedMDL", p_CMDLCache__FindUncachedMDL.GetPtr());
-#endif
-		LogFunAdr("CMDLCache::GetStudioHDR", p_CMDLCache__GetStudioHDR.GetPtr());
-		LogFunAdr("CMDLCache::GetHardwareData", p_CMDLCache__GetHardwareData.GetPtr());
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
-		LogFunAdr("CStudioHWDataRef::SetFlags", p_CStudioHWDataRef__SetFlags.GetPtr());
-#endif
-		LogVarAdr("g_MDLCache", reinterpret_cast<uintptr_t>(g_pMDLCache));
-		LogVarAdr("g_MDLLock", reinterpret_cast<uintptr_t>(g_pMDLLock));
+		LogFunAdr("CMDLCache::FindMDL", CMDLCache__FindMDL);
+		LogFunAdr("CMDLCache::FindCachedMDL", CMDLCache__FindCachedMDL);
+		LogFunAdr("CMDLCache::FindUncachedMDL", CMDLCache__FindUncachedMDL);
+		LogFunAdr("CMDLCache::GetStudioHDR", CMDLCache__GetStudioHDR);
+		LogFunAdr("CMDLCache::GetHardwareData", CMDLCache__GetHardwareData);
+		LogFunAdr("CStudioHWDataRef::SetFlags", CStudioHWDataRef__SetFlags);
+
+		LogVarAdr("g_MDLCache", g_pMDLCache);
+		LogVarAdr("g_MDLLock", g_pMDLLock);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1) || defined (GAMEDLL_S2)
-		p_CMDLCache__FindMDL = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 83 EC 20 4C 8B F1 0F B7 DA");
-		v_CMDLCache__FindMDL = p_CMDLCache__FindMDL.RCast<studiohdr_t* (*)(CMDLCache*, void*, void*)>(); /*48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 41 56 48 83 EC 20 4C 8B F1 0F B7 DA*/
-
-		p_CMDLCache__GetStudioHDR = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F1 0F B7 FA 48 8D 0D ?? ?? ?? ??");
-		v_CMDLCache__GetStudioHDR = p_CMDLCache__GetStudioHDR.RCast<studiohdr_t* (*)(CMDLCache*, MDLHandle_t)>(); /*48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 20 48 8B F1 0F B7 FA 48 8D 0D ? ? ? ?*/
-
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CMDLCache__GetHardwareData = g_GameDll.FindPatternSIMD("40 56 48 83 EC 20 48 89 5C 24 ?? 48 8D 0D ?? ?? ?? ??");
-		v_CMDLCache__GetHardwareData = p_CMDLCache__GetHardwareData.RCast<studiohwdata_t* (*)(CMDLCache*, MDLHandle_t)>(); /*40 56 48 83 EC 20 48 89 5C 24 ? 48 8D 0D ? ? ? ?*/
-#else
-		p_CMDLCache__GetHardwareData = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 48 8D 0D ?? ?? ?? ?? 0F B7 DA FF 15 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 8D 14 5B 48 8D 0D ?? ?? ?? ?? 48 8B 7C D0 ?? FF 15 ?? ?? ?? ?? 48 8B 1F");
-		v_CMDLCache__GetHardwareData = p_CMDLCache__GetHardwareData.RCast<studiohwdata_t* (*)(CMDLCache*, MDLHandle_t)>(); /*48 89 5C 24 ? 57 48 83 EC 20 48 8D 0D ? ? ? ? 0F B7 DA FF 15 ? ? ? ? 48 8B 05 ? ? ? ? 48 8D 14 5B 48 8D 0D ? ? ? ? 48 8B 7C D0 ? FF 15 ? ? ? ? 48 8B 1F*/
-#endif
-#else
-		p_CMDLCache__FindMDL = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F1 0F B7 EA");
-		v_CMDLCache__FindMDL = p_CMDLCache__FindMDL.RCast<studiohdr_t* (*)(CMDLCache*, MDLHandle_t, void*)>(); /*48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC 20 48 8B F1 0F B7 EA*/
-
-		p_CMDLCache__FindCachedMDL = g_GameDll.FindPatternSIMD("4D 85 C0 74 7A 48 89 6C 24 ??");
-		v_CMDLCache__FindCachedMDL = p_CMDLCache__FindCachedMDL.RCast<void(*)(CMDLCache*, studiodata_t*, void*)>(); /*4D 85 C0 74 7A 48 89 6C 24 ?*/
-
-		p_CMDLCache__FindUncachedMDL = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 83 EC 20 48 8B E9 0F B7 FA");
-		v_CMDLCache__FindUncachedMDL = p_CMDLCache__FindUncachedMDL.RCast<studiohdr_t* (*)(CMDLCache*, MDLHandle_t, studiodata_t*, void*)>(); /*48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 41 56 48 83 EC 20 48 8B E9 0F B7 FA*/
-
-		p_CMDLCache__GetStudioHDR = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8D 0D ?? ?? ?? ?? 0F B7 DA FF 15 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 8D 14 5B 48 8D 0D ?? ?? ?? ?? 48 8B 5C D0 ?? FF 15 ?? ?? ?? ?? 48 8B 03 48 8B 48 08");
-		v_CMDLCache__GetStudioHDR = p_CMDLCache__GetStudioHDR.RCast<studiohdr_t* (*)(CMDLCache*, MDLHandle_t)>(); /*40 53 48 83 EC 20 48 8D 0D ? ? ? ? 0F B7 DA FF 15 ? ? ? ? 48 8B 05 ? ? ? ? 48 8D 14 5B 48 8D 0D ? ? ? ? 48 8B 5C D0 ? FF 15 ? ? ? ? 48 8B 03 48 8B 48 08*/
-
-		p_CMDLCache__GetHardwareData = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 48 8D 0D ?? ?? ?? ?? 0F B7 DA FF 15 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 8D 14 5B 48 8D 0D ?? ?? ?? ?? 48 8B 7C D0 ?? FF 15 ?? ?? ?? ?? 48 8B 1F");
-		v_CMDLCache__GetHardwareData = p_CMDLCache__GetHardwareData.RCast<studiohwdata_t* (*)(CMDLCache*, MDLHandle_t)>(); /*48 89 5C 24 ? 57 48 83 EC 20 48 8D 0D ? ? ? ? 0F B7 DA FF 15 ? ? ? ? 48 8B 05 ? ? ? ? 48 8D 14 5B 48 8D 0D ? ? ? ? 48 8B 7C D0 ? FF 15 ? ? ? ? 48 8B 1F*/
-
-		p_CStudioHWDataRef__SetFlags = g_GameDll.FindPatternSIMD("48 83 EC 08 4C 8D 14 12");
-		v_CStudioHWDataRef__SetFlags = p_CStudioHWDataRef__SetFlags.RCast<bool (*)(CStudioHWDataRef*, int64_t)>(); /*48 83 EC 08 4C 8D 14 12*/
-#endif
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F1 0F B7 EA").GetPtr(CMDLCache__FindMDL);
+		g_GameDll.FindPatternSIMD("4D 85 C0 74 7A 48 89 6C 24 ??").GetPtr(CMDLCache__FindCachedMDL);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 83 EC 20 48 8B E9 0F B7 FA").GetPtr(CMDLCache__FindUncachedMDL);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8D 0D ?? ?? ?? ?? 0F B7 DA FF 15 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 8D 14 5B 48 8D 0D ?? ?? ?? ?? 48 8B 5C D0 ?? FF 15 ?? ?? ?? ?? 48 8B 03 48 8B 48 08").GetPtr(CMDLCache__GetStudioHDR);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 48 8D 0D ?? ?? ?? ?? 0F B7 DA FF 15 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 8D 14 5B 48 8D 0D ?? ?? ?? ?? 48 8B 7C D0 ?? FF 15 ?? ?? ?? ?? 48 8B 1F").GetPtr(CMDLCache__GetHardwareData);
+		g_GameDll.FindPatternSIMD("48 83 EC 08 4C 8D 14 12").GetPtr(CStudioHWDataRef__SetFlags);
 	}
 	virtual void GetVar(void) const
 	{
@@ -189,7 +146,7 @@ class VMDLCache : public IDetour
 		g_pMDLCache = g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 05 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? 48 85 C0 48 0F 45 C8 FF 05 ?? ?? ?? ?? 48 83 3D ?? ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??")
 			.FindPatternSelf("48 8D 05").ResolveRelativeAddressSelf(0x3, 0x7).RCast<CMDLCache*>();
 
-		g_pMDLLock = p_CMDLCache__GetHardwareData.Offset(0x35).FindPatternSelf("48 8D 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<PSRWLOCK>();
+		g_pMDLLock = CMemory(CMDLCache__GetHardwareData).Offset(0x35).FindPatternSelf("48 8D 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<PSRWLOCK>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/ebisusdk/EbisuSDK.h
+++ b/src/ebisusdk/EbisuSDK.h
@@ -1,12 +1,7 @@
 #pragma once
 
-inline CMemory p_EbisuSDK_Tier0_Init;
 inline void(*EbisuSDK_Tier0_Init)(void);
-
-inline CMemory p_EbisuSDK_CVar_Init;
 inline void(*EbisuSDK_CVar_Init)(void);
-
-inline CMemory p_EbisuSDK_SetState;
 inline void(*EbisuSDK_SetState)(void);
 
 inline uint64_t* g_NucleusID = nullptr;
@@ -26,39 +21,30 @@ class VEbisuSDK : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("EbisuSDK_Tier0_Init", p_EbisuSDK_Tier0_Init.GetPtr());
-		LogFunAdr("EbisuSDK_CVar_Init", p_EbisuSDK_CVar_Init.GetPtr());
-		LogFunAdr("EbisuSDK_SetState", p_EbisuSDK_SetState.GetPtr());
-		LogVarAdr("g_NucleusID", reinterpret_cast<uintptr_t>(g_NucleusID));
-		LogVarAdr("g_NucleusToken", reinterpret_cast<uintptr_t>(g_NucleusToken));
-		LogVarAdr("g_OriginAuthCode", reinterpret_cast<uintptr_t>(g_OriginAuthCode));
-		LogVarAdr("g_OriginErrorLevel", reinterpret_cast<uintptr_t>(g_OriginErrorLevel));
-		LogVarAdr("g_EbisuProfileInit", reinterpret_cast<uintptr_t>(g_EbisuProfileInit));
-		LogVarAdr("g_EbisuSDKInit", reinterpret_cast<uintptr_t>(g_EbisuSDKInit));
+		LogFunAdr("EbisuSDK_Tier0_Init", EbisuSDK_Tier0_Init);
+		LogFunAdr("EbisuSDK_CVar_Init", EbisuSDK_CVar_Init);
+		LogFunAdr("EbisuSDK_SetState", EbisuSDK_SetState);
+		LogVarAdr("g_NucleusID", g_NucleusID);
+		LogVarAdr("g_NucleusToken", g_NucleusToken);
+		LogVarAdr("g_OriginAuthCode", g_OriginAuthCode);
+		LogVarAdr("g_OriginErrorLevel", g_OriginErrorLevel);
+		LogVarAdr("g_EbisuProfileInit", g_EbisuProfileInit);
+		LogVarAdr("g_EbisuSDKInit", g_EbisuSDKInit);
 	}
 	virtual void GetFun(void) const
 	{
-		p_EbisuSDK_Tier0_Init = g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 0F 85 ?? 02 ?? ?? 48 89 5C 24 20");
-		EbisuSDK_Tier0_Init = p_EbisuSDK_Tier0_Init.RCast<void(*)(void)>(); /*48 83 EC 28 80 3D ?? ?? ?? ?? 00 0F 85 ?? 02 00 00 48 89 5C 24 20*/
-
-		p_EbisuSDK_CVar_Init = g_GameDll.FindPatternSIMD("40 57 48 83 EC 40 83 3D");
-		EbisuSDK_CVar_Init = p_EbisuSDK_CVar_Init.RCast<void(*)(void)>(); /*40 57 48 83 EC 40 83 3D*/
-
-		p_EbisuSDK_SetState = g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 74 5B");
-		EbisuSDK_SetState = p_EbisuSDK_SetState.RCast<void(*)(void)>(); /*48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 74 5B*/
+		g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 0F 85 ?? 02 ?? ?? 48 89 5C 24 20").GetPtr(EbisuSDK_Tier0_Init);
+		g_GameDll.FindPatternSIMD("40 57 48 83 EC 40 83 3D").GetPtr(EbisuSDK_CVar_Init);
+		g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 74 5B").GetPtr(EbisuSDK_SetState);
 	}
 	virtual void GetVar(void) const
 	{
-		g_NucleusID = p_EbisuSDK_CVar_Init.Offset(0x20).FindPatternSelf("4C 89 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x3, 0x7).RCast<uint64_t*>();
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		g_NucleusToken = p_EbisuSDK_SetState.Offset(0x1EF).FindPatternSelf("38 1D", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x6).RCast<char*>(); // !TODO: TEST!
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		g_NucleusToken = p_EbisuSDK_SetState.Offset(0x1EF).FindPatternSelf("80 3D", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x7).RCast<char*>();
-#endif
-		g_OriginAuthCode = p_EbisuSDK_SetState.Offset(0x1BF).FindPatternSelf("0F B6", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x3, 0x7).RCast<char*>();
-		g_OriginErrorLevel = p_EbisuSDK_SetState.Offset(0x20).FindPatternSelf("89 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x6).RCast<int*>();
-		g_EbisuProfileInit = p_EbisuSDK_CVar_Init.Offset(0x12A).FindPatternSelf("C6 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
-		g_EbisuSDKInit = p_EbisuSDK_Tier0_Init.Offset(0x0).FindPatternSelf("80 3D", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
+		g_NucleusID = CMemory(EbisuSDK_CVar_Init).Offset(0x20).FindPatternSelf("4C 89 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x3, 0x7).RCast<uint64_t*>();
+		g_NucleusToken = CMemory(EbisuSDK_SetState).Offset(0x1EF).FindPatternSelf("80 3D", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x7).RCast<char*>();
+		g_OriginAuthCode = CMemory(EbisuSDK_SetState).Offset(0x1BF).FindPatternSelf("0F B6", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x3, 0x7).RCast<char*>();
+		g_OriginErrorLevel = CMemory(EbisuSDK_SetState).Offset(0x20).FindPatternSelf("89 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x6).RCast<int*>();
+		g_EbisuProfileInit = CMemory(EbisuSDK_CVar_Init).Offset(0x12A).FindPatternSelf("C6 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
+		g_EbisuSDKInit = CMemory(EbisuSDK_Tier0_Init).Offset(0x0).FindPatternSelf("80 3D", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const { }

--- a/src/engine/client/cdll_engine_int.cpp
+++ b/src/engine/client/cdll_engine_int.cpp
@@ -80,7 +80,7 @@ void FrameStageNotify_Post(const ClientFrameStage_t frameStage)
 void CHLClient::FrameStageNotify(CHLClient* pHLClient, ClientFrameStage_t frameStage)
 {
 	FrameStageNotify_Pre(frameStage);
-	CHLClient_FrameStageNotify(pHLClient, frameStage);
+	CHLClient__FrameStageNotify(pHLClient, frameStage);
 	FrameStageNotify_Post(frameStage);
 }
 
@@ -91,7 +91,7 @@ void CHLClient::FrameStageNotify(CHLClient* pHLClient, ClientFrameStage_t frameS
 //-----------------------------------------------------------------------------
 ClientClass* CHLClient::GetAllClasses()
 {
-	return CHLClient_GetAllClasses();
+	return CHLClient__GetAllClasses();
 }
 #endif // !DEDICATED
 
@@ -99,6 +99,6 @@ ClientClass* CHLClient::GetAllClasses()
 void VDll_Engine_Int::Detour(const bool bAttach) const
 {
 #ifndef DEDICATED
-	DetourSetup(&CHLClient_FrameStageNotify, &CHLClient::FrameStageNotify, bAttach);
+	DetourSetup(&CHLClient__FrameStageNotify, &CHLClient::FrameStageNotify, bAttach);
 #endif // !DEDICATED
 }

--- a/src/engine/client/cdll_engine_int.h
+++ b/src/engine/client/cdll_engine_int.h
@@ -51,20 +51,11 @@ public:
 
 /* ==== CHLCLIENT ======================================================================================================================================================= */
 #ifndef DEDICATED
-inline CMemory p_CHLClient_PostInit;
-inline void*(*CHLClient_PostInit)(void);
-
-inline CMemory p_CHLClient_LevelShutdown;
-inline void*(*CHLClient_LevelShutdown)(CHLClient* thisptr);
-
-inline CMemory p_CHLClient_HudProcessInput;
-inline void(*CHLClient_HudProcessInput)(CHLClient* thisptr, bool bActive);
-
-inline CMemory p_CHLClient_FrameStageNotify;
-inline void(*CHLClient_FrameStageNotify)(CHLClient* thisptr, ClientFrameStage_t frameStage);
-
-inline CMemory p_CHLClient_GetAllClasses;
-inline ClientClass*(*CHLClient_GetAllClasses)();
+inline void*(*CHLClient__PostInit)(void);
+inline void*(*CHLClient__LevelShutdown)(CHLClient* thisptr);
+inline void(*CHLClient__HudProcessInput)(CHLClient* thisptr, bool bActive);
+inline void(*CHLClient__FrameStageNotify)(CHLClient* thisptr, ClientFrameStage_t frameStage);
+inline ClientClass*(*CHLClient__GetAllClasses)();
 #endif // !DEDICATED
 
 inline CHLClient* g_pHLClient = nullptr;
@@ -76,39 +67,25 @@ class VDll_Engine_Int : public IDetour
 	virtual void GetAdr(void) const
 	{
 #ifndef DEDICATED
-		LogFunAdr("CHLClient::PostInit", p_CHLClient_PostInit.GetPtr());
-		LogFunAdr("CHLClient::LevelShutdown", p_CHLClient_LevelShutdown.GetPtr());
-		LogFunAdr("CHLClient::HudProcessInput", p_CHLClient_HudProcessInput.GetPtr());
-		LogFunAdr("CHLClient::FrameStageNotify", p_CHLClient_FrameStageNotify.GetPtr());
-		LogFunAdr("CHLClient::GetAllClasses", p_CHLClient_GetAllClasses.GetPtr());
+		LogFunAdr("CHLClient::PostInit", CHLClient__PostInit);
+		LogFunAdr("CHLClient::LevelShutdown", CHLClient__LevelShutdown);
+		LogFunAdr("CHLClient::HudProcessInput", CHLClient__HudProcessInput);
+		LogFunAdr("CHLClient::FrameStageNotify", CHLClient__FrameStageNotify);
+		LogFunAdr("CHLClient::GetAllClasses", CHLClient__GetAllClasses);
 #endif // !DEDICATED
-		LogVarAdr("g_HLClient", reinterpret_cast<uintptr_t>(g_pHLClient));
-		LogVarAdr("g_pHLClient", reinterpret_cast<uintptr_t>(g_ppHLClient));
+		LogVarAdr("g_HLClient", g_pHLClient);
+		LogVarAdr("g_pHLClient", g_ppHLClient);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CHLClient_LevelShutdown    = g_GameDll.FindPatternSIMD("40 53 56 41 54 41 56 48 83 EC 28 48 8B F1");
 #ifndef DEDICATED
-		p_CHLClient_PostInit         = g_GameDll.FindPatternSIMD("48 83 3D ?? ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??");
-		p_CHLClient_FrameStageNotify = g_GameDll.FindPatternSIMD("48 83 EC 38 89 15 ?? ?? ?? ??");
-		p_CHLClient_GetAllClasses    = g_GameDll.FindPatternSIMD("48 8B 05 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 48 89 74 24 ??");
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F9 48 8D 0D ?? ?? ?? ??").GetPtr(CHLClient__LevelShutdown);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 48 83 3D ?? ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??").GetPtr(CHLClient__PostInit);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 89 15 ?? ?? ?? ??").GetPtr(CHLClient__FrameStageNotify);
+		g_GameDll.FindPatternSIMD("48 8B 05 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 48 8B 05 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ??").GetPtr(CHLClient__GetAllClasses);
 #endif // !DEDICATED
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 #ifndef DEDICATED
-		p_CHLClient_LevelShutdown    = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F9 48 8D 0D ?? ?? ?? ??");
-		p_CHLClient_PostInit         = g_GameDll.FindPatternSIMD("48 83 EC 28 48 83 3D ?? ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??");
-		p_CHLClient_FrameStageNotify = g_GameDll.FindPatternSIMD("48 83 EC 28 89 15 ?? ?? ?? ??");
-		p_CHLClient_GetAllClasses    = g_GameDll.FindPatternSIMD("48 8B 05 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 48 8B 05 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ??");
-#endif // !DEDICATED
-#endif
-#ifndef DEDICATED
-		p_CHLClient_HudProcessInput  = g_GameDll.FindPatternSIMD("48 83 EC 28 0F B6 0D ?? ?? ?? ?? 88 15 ?? ?? ?? ??");
-		CHLClient_LevelShutdown    = p_CHLClient_LevelShutdown.RCast<void*(*)(CHLClient*)>();                       /*48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F9 48 8D 0D ?? ?? ?? ??*/
-		CHLClient_PostInit         = p_CHLClient_PostInit.RCast<void*(*)(void)>();                                  /*48 83 EC 28 48 83 3D ?? ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??*/
-		CHLClient_FrameStageNotify = p_CHLClient_FrameStageNotify.RCast<void(*)(CHLClient*, ClientFrameStage_t)>(); /*48 83 EC 28 89 15 ?? ?? ?? ??*/
-		CHLClient_HudProcessInput  = p_CHLClient_HudProcessInput.RCast<void(*)(CHLClient*, bool)>();                /*48 83 EC 28 0F B6 0D ?? ?? ?? ?? 88 15 ?? ?? ?? ??*/
-		CHLClient_GetAllClasses    = p_CHLClient_GetAllClasses.RCast<ClientClass*(*)()>();                          /*48 8B 05 ? ? ? ? C3 CC CC CC CC CC CC CC CC 48 8B 05 ? ? ? ? 48 8D 0D ? ? ? ?*/
+		g_GameDll.FindPatternSIMD("48 83 EC 28 0F B6 0D ?? ?? ?? ?? 88 15 ?? ?? ?? ??").GetPtr(CHLClient__HudProcessInput);
 #endif // !DEDICATED
 	}
 	virtual void GetVar(void) const

--- a/src/engine/client/cl_ents_parse.h
+++ b/src/engine/client/cl_ents_parse.h
@@ -1,7 +1,6 @@
 #ifndef CL_ENTS_PARSE_H
 #define CL_ENTS_PARSE_H
 
-inline CMemory p_CL_CopyExistingEntity;
 inline bool(*v_CL_CopyExistingEntity)(__int64 a1, unsigned int* a2, char* a3);
 
 bool CL_CopyExistingEntity(__int64 a1, unsigned int* a2, char* a3);
@@ -10,12 +9,11 @@ class V_CL_Ents_Parse : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CL_CopyExistingEntity", p_CL_CopyExistingEntity.GetPtr());
+		LogFunAdr("CL_CopyExistingEntity", v_CL_CopyExistingEntity);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CL_CopyExistingEntity = g_GameDll.FindPatternSIMD("40 53 48 83 EC 70 4C 63 51 28");
-		v_CL_CopyExistingEntity = p_CL_CopyExistingEntity.RCast<bool (*)(__int64, unsigned int*, char*)>(); /*40 53 48 83 EC 70 4C 63 51 28*/
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 70 4C 63 51 28").GetPtr(v_CL_CopyExistingEntity);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -113,10 +113,10 @@ void CL_MoveEx()
 			cl->m_nOutgoingCommandNr = nextCommandNr;
 		}
 
-		CL_RunPrediction();
+		v_CL_RunPrediction();
 
 		if (sendPacket)
-			CL_SendMove();
+			v_CL_SendMove();
 		else
 			chan->SetChoked(); // Choke the packet...
 
@@ -143,5 +143,5 @@ void CL_MoveEx()
 
 void VCL_Main::Detour(const bool bAttach) const
 {
-	DetourSetup(&CL_Move, &CL_MoveEx, bAttach);
+	DetourSetup(&v_CL_Move, &CL_MoveEx, bAttach);
 }

--- a/src/engine/client/cl_main.h
+++ b/src/engine/client/cl_main.h
@@ -1,19 +1,10 @@
 #pragma once
 
-inline CMemory p_CL_Move;
-inline void(*CL_Move)(void);
-
-inline CMemory p_CL_SendMove;
-inline void(*CL_SendMove)(void);
-
-inline CMemory p_CL_EndMovie;
-inline int(*CL_EndMovie)(void);
-
-inline CMemory p_CL_ClearState;
-inline int(*CL_ClearState)(void);
-
-inline CMemory p_CL_RunPrediction;
-inline void(*CL_RunPrediction)(void);
+inline void(*v_CL_Move)(void);
+inline void(*v_CL_SendMove)(void);
+inline int(*v_CL_EndMovie)(void);
+inline int(*v_CL_ClearState)(void);
+inline void(*v_CL_RunPrediction)(void);
 
 inline bool g_bClientDLL = false;
 
@@ -28,32 +19,19 @@ class VCL_Main : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CL_Move", p_CL_Move.GetPtr());
-		LogFunAdr("CL_SendMove", p_CL_SendMove.GetPtr());
-		LogFunAdr("CL_EndMovie", p_CL_EndMovie.GetPtr());
-		LogFunAdr("CL_ClearState", p_CL_ClearState.GetPtr());
-		LogFunAdr("CL_RunPrediction", p_CL_RunPrediction.GetPtr());
+		LogFunAdr("CL_Move", v_CL_Move);
+		LogFunAdr("CL_SendMove", v_CL_SendMove);
+		LogFunAdr("CL_EndMovie", v_CL_EndMovie);
+		LogFunAdr("CL_ClearState", v_CL_ClearState);
+		LogFunAdr("CL_RunPrediction", v_CL_RunPrediction);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CL_Move = g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 83 3D ?? ?? ?? ?? ?? 0F B6 DA");
-		p_CL_SendMove = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B 05 ?? ?? ?? ??");
-		p_CL_EndMovie = g_GameDll.FindPatternSIMD("48 8B C4 48 83 EC 68 80 3D ?? ?? ?? ?? ??");
-		p_CL_ClearState = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B 1D ?? ?? ?? ??");
-		p_CL_RunPrediction = g_GameDll.FindPatternSIMD("4C 8B DC 48 83 EC 58 83 3D ?? ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CL_Move = g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? 83 3D ?? ?? ?? ?? ?? 44 0F 29 5C 24 ??");
-		p_CL_SendMove = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B 05 ?? ?? ?? ??");
-		p_CL_EndMovie = g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 74 7B");
-		p_CL_ClearState = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B 01");
-		p_CL_RunPrediction = g_GameDll.FindPatternSIMD("48 83 EC 48 83 3D ?? ?? ?? ?? ?? 0F 85 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ??");
-#endif
-		CL_Move = p_CL_Move.RCast<void(*)(void)>();
-		CL_SendMove = p_CL_SendMove.RCast<void(*)(void)>();
-		CL_EndMovie = p_CL_EndMovie.RCast<int(*)(void)>();
-		CL_ClearState = p_CL_ClearState.RCast<int(*)(void)>();
-		CL_RunPrediction = p_CL_RunPrediction.RCast<void(*)(void)>();
+		g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? 83 3D ?? ?? ?? ?? ?? 44 0F 29 5C 24 ??").GetPtr(v_CL_Move);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B 05 ?? ?? ?? ??").GetPtr(v_CL_SendMove);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 74 7B").GetPtr(v_CL_EndMovie);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B 01").GetPtr(v_CL_ClearState);
+		g_GameDll.FindPatternSIMD("48 83 EC 48 83 3D ?? ?? ?? ?? ?? 0F 85 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ??").GetPtr(v_CL_RunPrediction);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/client/cl_splitscreen.h
+++ b/src/engine/client/cl_splitscreen.h
@@ -128,21 +128,14 @@ class VSplitScreen : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogVarAdr("g_SplitScreenMgr", reinterpret_cast<uintptr_t>(g_pSplitScreenMgr));
+		LogVarAdr("g_SplitScreenMgr", g_pSplitScreenMgr);
 	}
 	virtual void GetFun(void) const { }
 	virtual void GetVar(void) const
 	{
-		const char* pszPattern;
-		const char* pszInstruction;
+		const char* const pszPattern = "40 53 48 83 EC 20 48 8D 1D ?? ?? ?? ?? 83 FA FF 75 12 48 8B 05 ?? ?? ?? ?? 48 8B CB FF 50 28 48 63 C8 EB 03 48 63 CA 48 69 C1 ?? ?? ?? ?? 66 C7 84 18 ?? ?? ?? ?? ?? ??";;
+		const char* const pszInstruction = "48 8D";
 
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		pszPattern = "83 FA FF 75 22 48 8D 05 ?? ?? ?? ??";
-		pszInstruction = "4C 8D";
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		pszPattern = "40 53 48 83 EC 20 48 8D 1D ?? ?? ?? ?? 83 FA FF 75 12 48 8B 05 ?? ?? ?? ?? 48 8B CB FF 50 28 48 63 C8 EB 03 48 63 CA 48 69 C1 ?? ?? ?? ?? 66 C7 84 18 ?? ?? ?? ?? ?? ??";
-		pszInstruction = "48 8D";
-#endif
 		g_pSplitScreenMgr = g_GameDll.FindPatternSIMD(pszPattern).FindPatternSelf(pszInstruction).ResolveRelativeAddressSelf(0x3, 0x7).RCast<CSplitScreen*>();
 	}
 	virtual void GetCon(void) const { }

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -29,7 +29,7 @@ void CClient::Clear(void)
 #ifndef CLIENT_DLL
 	GetClientExtended()->Reset(); // Reset extended data.
 #endif // !CLIENT_DLL
-	v_CClient_Clear(this);
+	CClient__Clear(this);
 }
 
 //---------------------------------------------------------------------------------
@@ -201,7 +201,7 @@ bool CClient::Connect(const char* szName, CNetChan* pNetChan, bool bFakePlayer,
 	GetClientExtended()->Reset(); // Reset extended data.
 #endif
 
-	if (!v_CClient_Connect(this, szName, pNetChan, bFakePlayer, conVars, szMessage, nMessageSize))
+	if (!CClient__Connect(this, szName, pNetChan, bFakePlayer, conVars, szMessage, nMessageSize))
 		return false;
 
 #ifndef CLIENT_DLL
@@ -271,7 +271,7 @@ void CClient::Disconnect(const Reputation_t nRepLvl, const char* szReason, ...)
 			szBuf[sizeof(szBuf) - 1] = '\0';
 			va_end(vArgs);
 		}/////////////////////////////
-		v_CClient_Disconnect(this, nRepLvl, szBuf);
+		CClient__Disconnect(this, nRepLvl, szBuf);
 	}
 }
 
@@ -283,7 +283,7 @@ void CClient::VActivatePlayer(CClient* pClient)
 {
 	// Set the client instance to 'ready' before calling ActivatePlayer.
 	pClient->SetPersistenceState(PERSISTENCE::PERSISTENCE_READY);
-	v_CClient_ActivatePlayer(pClient);
+	CClient__ActivatePlayer(pClient);
 
 #ifndef CLIENT_DLL
 	const CNetChan* pNetChan = pClient->GetNetChan();
@@ -312,7 +312,7 @@ bool CClient::SendNetMsgEx(CNetMessage* pMsg, bool bLocal, bool bForceReliable, 
 		pMsg->m_nGroup = NetMessageGroup::NoReplay;
 	}
 
-	return v_CClient_SendNetMsgEx(this, pMsg, bLocal, bForceReliable, bVoice);
+	return CClient__SendNetMsgEx(this, pMsg, bLocal, bForceReliable, bVoice);
 }
 
 //---------------------------------------------------------------------------------
@@ -324,7 +324,7 @@ bool CClient::SendNetMsgEx(CNetMessage* pMsg, bool bLocal, bool bForceReliable, 
 //---------------------------------------------------------------------------------
 void* CClient::VSendSnapshot(CClient* pClient, CClientFrame* pFrame, int nTick, int nTickAck)
 {
-	return v_CClient_SendSnapshot(pClient, pFrame, nTick, nTickAck);
+	return CClient__SendSnapshot(pClient, pFrame, nTick, nTickAck);
 }
 
 //---------------------------------------------------------------------------------
@@ -347,16 +347,12 @@ bool CClient::VSendNetMsgEx(CClient* pClient, CNetMessage* pMsg, bool bLocal, bo
 //---------------------------------------------------------------------------------
 CClient* AdjustShiftedThisPointer(CClient* shiftedPointer)
 {
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-	return shiftedPointer;
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 	/* Original function called method "CClient::ExecuteStringCommand" with an optimization
 	 * that shifted the 'this' pointer with 8 bytes.
 	 * Since this has been inlined with "CClient::ProcessStringCmd" as of S2, the shifting
 	 * happens directly to anything calling this function. */
 	char* pShifted = reinterpret_cast<char*>(shiftedPointer) - 8;
 	return reinterpret_cast<CClient*>(pShifted);
-#endif // !GAMEDLL_S0 || !GAMEDLL_S1
 }
 
 //---------------------------------------------------------------------------------
@@ -425,7 +421,7 @@ bool CClient::VProcessStringCmd(CClient* pClient, NET_StringCmd* pMsg)
 	}
 #endif // !CLIENT_DLL
 
-	return v_CClient_ProcessStringCmd(pClient, pMsg);
+	return CClient__ProcessStringCmd(pClient, pMsg);
 }
 
 //---------------------------------------------------------------------------------
@@ -491,13 +487,13 @@ bool CClient::VProcessSetConVar(CClient* pClient, NET_SetConVar* pMsg)
 void VClient::Detour(const bool bAttach) const
 {
 #ifndef CLIENT_DLL
-	DetourSetup(&v_CClient_Clear, &CClient::VClear, bAttach);
-	DetourSetup(&v_CClient_Connect, &CClient::VConnect, bAttach);
-	DetourSetup(&v_CClient_ActivatePlayer, &CClient::VActivatePlayer, bAttach);
-	DetourSetup(&v_CClient_SendNetMsgEx, &CClient::VSendNetMsgEx, bAttach);
-	//DetourSetup(&p_CClient_SendSnapshot, &CClient::VSendSnapshot, bAttach);
+	DetourSetup(&CClient__Clear, &CClient::VClear, bAttach);
+	DetourSetup(&CClient__Connect, &CClient::VConnect, bAttach);
+	DetourSetup(&CClient__ActivatePlayer, &CClient::VActivatePlayer, bAttach);
+	DetourSetup(&CClient__SendNetMsgEx, &CClient::VSendNetMsgEx, bAttach);
+	//DetourSetup(&CClient__SendSnapshot, &CClient::VSendSnapshot, bAttach);
 
-	DetourSetup(&v_CClient_ProcessStringCmd, &CClient::VProcessStringCmd, bAttach);
-	DetourSetup(&v_CClient_ProcessSetConVar, &CClient::VProcessSetConVar, bAttach);
+	DetourSetup(&CClient__ProcessStringCmd, &CClient::VProcessStringCmd, bAttach);
+	DetourSetup(&CClient__ProcessSetConVar, &CClient::VProcessSetConVar, bAttach);
 #endif // !CLIENT_DLL
 }

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -188,10 +188,8 @@ private:
 	int m_nSignonTick;
 	int m_nBaselineUpdateTick_MAYBE;
 	char pad_03C0[448];
-#if defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 	int unk3;
 	int m_nForceWaitForTick;
-#endif
 	bool m_bFakePlayer;
 	bool m_bReceivedPacket;
 	bool m_bLowViolence;
@@ -202,16 +200,10 @@ private:
 	ServerDataBlock m_DataBlock;
 	char pad_4A3D8[60];
 	int m_LastMovementTick;
-#if defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 	char pad_4A418[86];
-#endif
 	char pad_4A46E[80];
 };
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-static_assert(sizeof(CClient) == 0x4A440);
-#else
 static_assert(sizeof(CClient) == 0x4A4C0);
-#endif
 
 //-----------------------------------------------------------------------------
 // Extended CClient class
@@ -277,82 +269,43 @@ private:
 };
 
 /* ==== CBASECLIENT ===================================================================================================================================================== */
-inline CMemory p_CClient_Connect;
-inline bool(*v_CClient_Connect)(CClient* pClient, const char* szName, CNetChan* pNetChan, bool bFakePlayer, CUtlVector<NET_SetConVar::cvar_t>* conVars, char* szMessage, int nMessageSize);
-
-inline CMemory p_CClient_Disconnect;
-inline bool(*v_CClient_Disconnect)(CClient* pClient, const Reputation_t nRepLvl, const char* szReason, ...);
-
-inline CMemory p_CClient_Clear;
-inline void(*v_CClient_Clear)(CClient* pClient);
-
-inline CMemory p_CClient_ActivatePlayer;
-inline void(*v_CClient_ActivatePlayer)(CClient* pClient);
-
-inline CMemory p_CClient_SetSignonState;
-inline bool(*v_CClient_SetSignonState)(CClient* pClient, SIGNONSTATE signon);
-
-inline CMemory p_CClient_SendNetMsgEx;
-inline bool(*v_CClient_SendNetMsgEx)(CClient* pClient, CNetMessage* pMsg, bool bLocal, bool bForceReliable, bool bVoice);
-
-inline CMemory p_CClient_SendSnapshot;
-inline void*(*v_CClient_SendSnapshot)(CClient* pClient, CClientFrame* pFrame, int nTick, int nTickAck);
-
-inline CMemory p_CClient_ProcessStringCmd;
-inline bool(*v_CClient_ProcessStringCmd)(CClient* pClient, NET_StringCmd* pMsg);
-
-inline CMemory p_CClient_ProcessSetConVar;
-inline bool(*v_CClient_ProcessSetConVar)(CClient* pClient, NET_SetConVar* pMsg);
+inline bool(*CClient__Connect)(CClient* pClient, const char* szName, CNetChan* pNetChan, bool bFakePlayer, CUtlVector<NET_SetConVar::cvar_t>* conVars, char* szMessage, int nMessageSize);
+inline bool(*CClient__Disconnect)(CClient* pClient, const Reputation_t nRepLvl, const char* szReason, ...);
+inline void(*CClient__Clear)(CClient* pClient);
+inline void(*CClient__ActivatePlayer)(CClient* pClient);
+inline bool(*CClient__SetSignonState)(CClient* pClient, SIGNONSTATE signon);
+inline bool(*CClient__SendNetMsgEx)(CClient* pClient, CNetMessage* pMsg, bool bLocal, bool bForceReliable, bool bVoice);
+inline void*(*CClient__SendSnapshot)(CClient* pClient, CClientFrame* pFrame, int nTick, int nTickAck);
+inline bool(*CClient__ProcessStringCmd)(CClient* pClient, NET_StringCmd* pMsg);
+inline bool(*CClient__ProcessSetConVar)(CClient* pClient, NET_SetConVar* pMsg);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VClient : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CClient::Connect", p_CClient_Connect.GetPtr());
-		LogFunAdr("CClient::Disconnect", p_CClient_Disconnect.GetPtr());
-		LogFunAdr("CClient::Clear", p_CClient_Clear.GetPtr());
-		LogFunAdr("CClient::ActivatePlayer", p_CClient_ActivatePlayer.GetPtr());
-		LogFunAdr("CClient::SetSignonState", p_CClient_SetSignonState.GetPtr());
-		LogFunAdr("CClient::SendNetMsgEx", p_CClient_SendNetMsgEx.GetPtr());
-		LogFunAdr("CClient::SendSnapshot", p_CClient_SendSnapshot.GetPtr());
-		LogFunAdr("CClient::ProcessStringCmd", p_CClient_ProcessStringCmd.GetPtr());
-		LogFunAdr("CClient::ProcessSetConVar", p_CClient_ProcessSetConVar.GetPtr());
+		LogFunAdr("CClient::Connect", CClient__Connect);
+		LogFunAdr("CClient::Disconnect", CClient__Disconnect);
+		LogFunAdr("CClient::Clear", CClient__Clear);
+		LogFunAdr("CClient::ActivatePlayer", CClient__ActivatePlayer);
+		LogFunAdr("CClient::SetSignonState", CClient__SetSignonState);
+		LogFunAdr("CClient::SendNetMsgEx", CClient__SendNetMsgEx);
+		LogFunAdr("CClient::SendSnapshot", CClient__SendSnapshot);
+		LogFunAdr("CClient::ProcessStringCmd", CClient__ProcessStringCmd);
+		LogFunAdr("CClient::ProcessSetConVar", CClient__ProcessSetConVar);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CClient_Connect    = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 20 41 0F B6 E9");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1) || defined (GAMEDLL_S2)
-		p_CClient_Disconnect = g_GameDll.FindPatternSIMD("48 8B C4 4C 89 40 18 4C 89 48 20 53 56 57 48 81 EC ?? ?? ?? ?? 83 B9 ?? ?? ?? ?? ?? 49 8B F8 0F B6 F2");
-#else // !GAMEDLL_S0 || !GAMEDLL_S1 || !GAMEDLL_S2
-		p_CClient_Disconnect = g_GameDll.FindPatternSIMD("48 8B C4 4C 89 40 18 4C 89 48 20 53 56 57 48 81 EC ?? ?? ?? ?? 83 B9 ?? ?? ?? ?? ?? 49 8B F8 8B F2");
-#endif
-		p_CClient_Clear      = g_GameDll.FindPatternSIMD("40 53 41 56 41 57 48 83 EC 20 48 8B D9 48 89 74");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CClient_ActivatePlayer = g_GameDll.FindPatternSIMD("40 53 57 41 57 48 83 EC 30 8B 81 ?? ?? ?? ??");
-		p_CClient_SendNetMsg = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 56 41 57 48 83 EC 30 48 8B 05 ?? ?? ?? ?? 45 0F B6 F1");
-		p_CClient_SendSnapshot = g_GameDll.FindPatternSIMD("44 89 44 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 55");
-		p_CClient_ProcessStringCmd = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 48 81 EC ?? ?? ?? ?? 49 8B D8");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CClient_ActivatePlayer = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 8B 81 B0 03 ?? ?? 48 8B D9 C6");
-		p_CClient_SendNetMsgEx = g_GameDll.FindPatternSIMD("40 53 55 56 57 41 56 48 83 EC 40 48 8B 05 ?? ?? ?? ??");
-		p_CClient_SendSnapshot = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 56 41 55 41 56 41 57 48 8D 6C 24 ??");
-		p_CClient_ProcessStringCmd = g_GameDll.FindPatternSIMD("48 89 6C 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B 7A 20");
-#endif // !GAMEDLL_S0 || !GAMEDLL_S1
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 20 41 0F B6 E9").GetPtr(CClient__Connect);
+		g_GameDll.FindPatternSIMD("48 8B C4 4C 89 40 18 4C 89 48 20 53 56 57 48 81 EC ?? ?? ?? ?? 83 B9 ?? ?? ?? ?? ?? 49 8B F8 8B F2").GetPtr(CClient__Disconnect);
+		g_GameDll.FindPatternSIMD("40 53 41 56 41 57 48 83 EC 20 48 8B D9 48 89 74").GetPtr(CClient__Clear);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 8B 81 B0 03 ?? ?? 48 8B D9 C6").GetPtr(CClient__ActivatePlayer);
+		g_GameDll.FindPatternSIMD("40 53 55 56 57 41 56 48 83 EC 40 48 8B 05 ?? ?? ?? ??").GetPtr(CClient__SendNetMsgEx);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 56 41 55 41 56 41 57 48 8D 6C 24 ??").GetPtr(CClient__SendSnapshot);
+		g_GameDll.FindPatternSIMD("48 89 6C 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B 7A 20").GetPtr(CClient__ProcessStringCmd);
 
-		p_CClient_ProcessSetConVar = g_GameDll.FindPatternSIMD("48 83 EC 28 48 83 C2 20");
-		p_CClient_SetSignonState = g_GameDll.FindPatternSIMD("48 8B C4 48 89 58 10 48 89 70 18 57 48 81 EC ?? ?? ?? ?? 0F 29 70 E8 8B F2");
-
-		v_CClient_Connect    = p_CClient_Connect.RCast<bool (*)(CClient*, const char*, CNetChan*, bool, CUtlVector<NET_SetConVar::cvar_t>*, char*, int)>();
-		v_CClient_Disconnect = p_CClient_Disconnect.RCast<bool (*)(CClient*, const Reputation_t, const char*, ...)>();
-		v_CClient_Clear      = p_CClient_Clear.RCast<void (*)(CClient*)>();
-		v_CClient_ActivatePlayer = p_CClient_ActivatePlayer.RCast<void (*)(CClient* pClient)>();
-		v_CClient_SetSignonState = p_CClient_SetSignonState.RCast<bool (*)(CClient*, SIGNONSTATE)>();
-		v_CClient_SendNetMsgEx = p_CClient_SendNetMsgEx.RCast<bool (*)(CClient*, CNetMessage*, bool, bool, bool)>();
-		v_CClient_SendSnapshot = p_CClient_SendSnapshot.RCast<void* (*)(CClient*, CClientFrame*, int, int)>();
-
-		v_CClient_ProcessStringCmd = p_CClient_ProcessStringCmd.RCast<bool (*)(CClient*, NET_StringCmd*)>();
-		v_CClient_ProcessSetConVar = p_CClient_ProcessSetConVar.RCast<bool (*)(CClient*, NET_SetConVar*)>();
+		g_GameDll.FindPatternSIMD("48 83 EC 28 48 83 C2 20").GetPtr(CClient__ProcessSetConVar);
+		g_GameDll.FindPatternSIMD("48 8B C4 48 89 58 10 48 89 70 18 57 48 81 EC ?? ?? ?? ?? 0F 29 70 E8 8B F2").GetPtr(CClient__SetSignonState);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/client/clientstate.cpp
+++ b/src/engine/client/clientstate.cpp
@@ -138,7 +138,7 @@ void CClientState::VConnectionClosing(CClientState* thisptr, const char* szReaso
         {
             // Reload the local playlist to override the cached
             // one from the server we got disconnected from.
-            _DownloadPlaylists_f();
+            v__DownloadPlaylists_f();
             KeyValues::InitPlaylists();
         }, 0);
 }

--- a/src/engine/client/clientstate.h
+++ b/src/engine/client/clientstate.h
@@ -125,9 +125,6 @@ public:
 	int m_nServerClassBits;
 	__int64 m_StringTableContainer;
 	char m_PersistenceData[98304];
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-	char pads0[8];
-#endif
 	_BYTE m_bPersistenceBaselineRecvd;
 	int m_nPersistenceBaselineEntries;
 	int field_18350;
@@ -206,11 +203,7 @@ public:
 	char byte34A38;
 	char field_34A39[7];
 };
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-static_assert(sizeof(CClientState) == 0x34A28);
-#else
 static_assert(sizeof(CClientState) == 0x34A20);
-#endif
 
 #ifndef DEDICATED
 extern CClientState* g_pClientState;
@@ -218,22 +211,11 @@ extern CClientState** g_pClientState_Shifted; // Shifted by 0x10 forward!
 #endif // DEDICATED
 
 /* ==== CCLIENTSTATE ==================================================================================================================================================== */
-inline CMemory p_CClientState__RunFrame;
 inline void(*CClientState__RunFrame)(CClientState* thisptr);
-
-inline CMemory p_CClientState__Connect;
 inline void(*CClientState__Connect)(CClientState* thisptr, connectparams_t* connectParams);
-
-inline CMemory p_CClientState__Disconnect;
 inline void(*CClientState__Disconnect)(CClientState* thisptr, bool bSendTrackingContext);
-
-inline CMemory p_CClientState__ConnectionClosing;
 inline void(*CClientState__ConnectionClosing)(CClientState* thisptr, const char* szReason);
-
-inline CMemory p_CClientState__ProcessStringCmd;
 inline bool(*CClientState__ProcessStringCmd)(CClientState* thisptr, NET_StringCmd* msg);
-
-inline CMemory p_CClientState__ProcessServerTick;
 inline bool(*CClientState__ProcessServerTick)(CClientState* thisptr, SVC_ServerTick* msg);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -241,39 +223,23 @@ class VClientState : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CClientState::RunFrame", p_CClientState__RunFrame.GetPtr());
-		LogFunAdr("CClientState::Connect", p_CClientState__Connect.GetPtr());
-		LogFunAdr("CClientState::Disconnect", p_CClientState__Disconnect.GetPtr());
-		LogFunAdr("CClientState::ConnectionClosing", p_CClientState__ConnectionClosing.GetPtr());
-		LogFunAdr("CClientState::ProcessStringCmd", p_CClientState__ProcessStringCmd.GetPtr());
-		LogFunAdr("CClientState::ProcessServerTick", p_CClientState__ProcessServerTick.GetPtr());
-		LogVarAdr("g_ClientState", reinterpret_cast<uintptr_t>(g_pClientState));
-		LogVarAdr("g_ClientState_Shifted", reinterpret_cast<uintptr_t>(g_pClientState_Shifted));
+		LogFunAdr("CClientState::RunFrame", CClientState__RunFrame);
+		LogFunAdr("CClientState::Connect", CClientState__Connect);
+		LogFunAdr("CClientState::Disconnect", CClientState__Disconnect);
+		LogFunAdr("CClientState::ConnectionClosing", CClientState__ConnectionClosing);
+		LogFunAdr("CClientState::ProcessStringCmd", CClientState__ProcessStringCmd);
+		LogFunAdr("CClientState::ProcessServerTick", CClientState__ProcessServerTick);
+		LogVarAdr("g_ClientState", g_pClientState);
+		LogVarAdr("g_ClientState_Shifted", g_pClientState_Shifted);
 	}
 	virtual void GetFun(void) const
 	{
-
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CClientState__RunFrame = g_GameDll.FindPatternSIMD("48 89 4C 24 ?? 57 48 81 EC ?? ?? ?? ?? 83 B9 ?? ?? ?? ?? ??");
-		p_CClientState__Disconnect = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 57 41 56 48 83 EC 30 0F B6 EA");
-		p_CClientState__ConnectionClosing = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 83 B9 ?? ?? ?? ?? ?? 48 8B DA 7E 6E");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CClientState__RunFrame = g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 83 B9 ?? ?? ?? ?? ?? 48 8B D9 7D 0B");
-		p_CClientState__Disconnect = g_GameDll.FindPatternSIMD("40 56 57 41 54 41 55 41 57 48 83 EC 30 44 0F B6 FA");
-		p_CClientState__ConnectionClosing = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 83 B9 ?? ?? ?? ?? ?? 48 8B DA 0F 8E ?? ?? ?? ??");
-#endif
-		p_CClientState__ProcessStringCmd = g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 80 B9 ?? ?? ?? ?? ?? 48 8B DA");
-		p_CClientState__ProcessServerTick = g_GameDll.FindPatternSIMD("40 57 48 83 EC 20 83 B9 ?? ?? ?? ?? ?? 48 8B F9 7C 66");
-
-		p_CClientState__Connect = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 81 EC ?? ?? ?? ?? 48 8B 32");
-
-
-		CClientState__RunFrame = p_CClientState__RunFrame.RCast<void(*)(CClientState*)>();
-		CClientState__Connect = p_CClientState__Connect.RCast<void(*)(CClientState*, connectparams_t*)>();
-		CClientState__Disconnect = p_CClientState__Disconnect.RCast<void(*)(CClientState*, bool)>();
-		CClientState__ConnectionClosing = p_CClientState__ConnectionClosing.RCast<void(*)(CClientState*, const char*)>();
-		CClientState__ProcessStringCmd = p_CClientState__ProcessStringCmd.RCast<bool(*)(CClientState*, NET_StringCmd*)>();
-		CClientState__ProcessServerTick = p_CClientState__ProcessServerTick.RCast<bool(*)(CClientState*, SVC_ServerTick*)>();
+		g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 83 B9 ?? ?? ?? ?? ?? 48 8B D9 7D 0B").GetPtr(CClientState__RunFrame);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 81 EC ?? ?? ?? ?? 48 8B 32").GetPtr(CClientState__Connect);
+		g_GameDll.FindPatternSIMD("40 56 57 41 54 41 55 41 57 48 83 EC 30 44 0F B6 FA").GetPtr(CClientState__Disconnect);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 83 B9 ?? ?? ?? ?? ?? 48 8B DA 0F 8E ?? ?? ?? ??").GetPtr(CClientState__ConnectionClosing);
+		g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 80 B9 ?? ?? ?? ?? ?? 48 8B DA").GetPtr(CClientState__ProcessStringCmd);
+		g_GameDll.FindPatternSIMD("40 57 48 83 EC 20 83 B9 ?? ?? ?? ?? ?? 48 8B F9 7C 66").GetPtr(CClientState__ProcessServerTick);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/engine/client/datablock_receiver.cpp
+++ b/src/engine/client/datablock_receiver.cpp
@@ -11,7 +11,7 @@
 //-----------------------------------------------------------------------------
 ClientDataBlockReceiver::~ClientDataBlockReceiver()
 {
-	v_ClientDataBlockReceiver__Destructor(this);
+	ClientDataBlockReceiver__Destructor(this);
 }
 
 //-----------------------------------------------------------------------------
@@ -20,5 +20,5 @@ ClientDataBlockReceiver::~ClientDataBlockReceiver()
 //-----------------------------------------------------------------------------
 void ClientDataBlockReceiver::AcknowledgeTransmission()
 {
-	v_ClientDataBlockReceiver__AcknowledgeTransmission(this);
+	ClientDataBlockReceiver__AcknowledgeTransmission(this);
 }

--- a/src/engine/client/datablock_receiver.h
+++ b/src/engine/client/datablock_receiver.h
@@ -27,29 +27,24 @@ protected:
 	void* m_pBigBuffer;
 };
 
-inline CMemory p_ClientDataBlockReceiver__Destructor;
-inline void*(*v_ClientDataBlockReceiver__Destructor)(ClientDataBlockReceiver* thisptr);
-
-inline CMemory p_ClientDataBlockReceiver__AcknowledgeTransmission;
-inline void*(*v_ClientDataBlockReceiver__AcknowledgeTransmission)(ClientDataBlockReceiver* thisptr);
+inline void*(*ClientDataBlockReceiver__Destructor)(ClientDataBlockReceiver* thisptr);
+inline void*(*ClientDataBlockReceiver__AcknowledgeTransmission)(ClientDataBlockReceiver* thisptr);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VClientDataBlockReceiver : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("ClientDataBlockReceiver::~ClientDataBlockReceiver", p_ClientDataBlockReceiver__Destructor.GetPtr());
-		LogFunAdr("ClientDataBlockReceiver::AcknowledgeTransmission", p_ClientDataBlockReceiver__AcknowledgeTransmission.GetPtr());
+		LogFunAdr("ClientDataBlockReceiver::~ClientDataBlockReceiver", ClientDataBlockReceiver__Destructor);
+		LogFunAdr("ClientDataBlockReceiver::AcknowledgeTransmission", ClientDataBlockReceiver__AcknowledgeTransmission);
 	}
 	virtual void GetFun(void) const
 	{
-		p_ClientDataBlockReceiver__Destructor = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 8B DA 48 8B F9 E8 ?? ?? ?? ?? F6 C3 01 74"
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 8B DA 48 8B F9 E8 ?? ?? ?? ?? F6 C3 01 74"
 			" 0D BA ?? ?? ?? ?? 48 8B CF E8 ?? ?? ?? ?? 48 8B C7 48 8B 5C 24 ?? 48 83 C4 20 5F C3 CC CC CC CC CC CC CC CC CC CC CC CC 48 89 5C 24"
-			" ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8D 05 ?? ?? ?? ?? C6 41 12 00");
-		v_ClientDataBlockReceiver__Destructor = p_ClientDataBlockReceiver__Destructor.RCast<void* (*)(ClientDataBlockReceiver*)>();
+			" ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8D 05 ?? ?? ?? ?? C6 41 12 00").GetPtr(ClientDataBlockReceiver__Destructor);
 
-		p_ClientDataBlockReceiver__AcknowledgeTransmission = g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 4C 8B 51 08");
-		v_ClientDataBlockReceiver__AcknowledgeTransmission = p_ClientDataBlockReceiver__AcknowledgeTransmission.RCast<void* (*)(ClientDataBlockReceiver*)>();
+		g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 4C 8B 51 08").GetPtr(ClientDataBlockReceiver__AcknowledgeTransmission);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/client/vengineclient_impl.cpp
+++ b/src/engine/client/vengineclient_impl.cpp
@@ -56,11 +56,7 @@ bool CEngineClient::GetRestrictClientCommands() const
 //---------------------------------------------------------------------------------
 int CEngineClient::GetLocalPlayer()
 {
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-	const static int index = 35;
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 	const static int index = 36;
-#endif
 	return CallVFunc<int>(index, this);
 }
 

--- a/src/engine/client/vengineclient_impl.h
+++ b/src/engine/client/vengineclient_impl.h
@@ -15,7 +15,6 @@ public:
 
 /* ==== CVENGINECLIENT ================================================================================================================================================== */
 ///////////////////////////////////////////////////////////////////////////////
-inline CMemory p_CEngineClient__ClientCmd;
 inline void(*CEngineClient__ClientCmd)(CEngineClient* thisptr, const char* const szCmdString);
 
 inline CMemory g_pEngineClientVFTable = nullptr;
@@ -26,13 +25,12 @@ class HVEngineClient : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogConAdr("CEngineClient::`vftable'", g_pEngineClientVFTable.GetPtr());
-		LogFunAdr("CEngineClient::ClientCmd", p_CEngineClient__ClientCmd.GetPtr());
+		LogConAdr("CEngineClient::`vftable'", (void*)g_pEngineClientVFTable.GetPtr());
+		LogFunAdr("CEngineClient::ClientCmd", CEngineClient__ClientCmd);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CEngineClient__ClientCmd = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 80 3D ?? ?? ?? ?? ?? 48 8B DA 74 0C");
-		CEngineClient__ClientCmd = p_CEngineClient__ClientCmd.RCast<void(*)(CEngineClient*, const char* const)>();
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 80 3D ?? ?? ?? ?? ?? 48 8B DA 74 0C").GetPtr(CEngineClient__ClientCmd);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const 

--- a/src/engine/cmd.h
+++ b/src/engine/cmd.h
@@ -27,19 +27,10 @@ extern bool Cbuf_HasRoomForExecutionMarkers(const int cExecutionMarkers);
 extern bool Cbuf_AddTextWithMarkers(const char* text, const ECmdExecutionMarker markerLeft, const ECmdExecutionMarker markerRight);
 
 /* ==== COMMAND_BUFFER ================================================================================================================================================== */
-inline CMemory p_Cbuf_AddText;
 inline void(*Cbuf_AddText)(ECommandTarget_t eTarget, const char* pText, cmd_source_t cmdSource);
-
-inline CMemory p_Cbuf_AddExecutionMarker;
 inline void(*Cbuf_AddExecutionMarker)(ECommandTarget_t target, ECmdExecutionMarker marker);
-
-inline CMemory p_Cbuf_Execute;
 inline void(*Cbuf_Execute)(void);
-
-inline CMemory p_Cmd_Dispatch;
 inline void(*v_Cmd_Dispatch)(ECommandTarget_t eTarget, const ConCommandBase* pCmdBase, const CCommand* pCommand, bool bCallBackupCallback);
-
-inline CMemory p_Cmd_ForwardToServer;
 inline bool(*v_Cmd_ForwardToServer)(const CCommand* pCommand);
 
 extern CCommandBuffer** s_pCommandBuffer;
@@ -53,35 +44,29 @@ class VCmd : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Cbuf_AddText", p_Cbuf_AddText.GetPtr());
-		LogFunAdr("Cbuf_AddExecutionMarker", p_Cbuf_AddExecutionMarker.GetPtr());
-		LogFunAdr("Cbuf_Execute", p_Cbuf_Execute.GetPtr());
-		LogFunAdr("Cmd_Dispatch", p_Cmd_Dispatch.GetPtr());
-		LogFunAdr("Cmd_ForwardToServer", p_Cmd_ForwardToServer.GetPtr());
-		LogVarAdr("s_CommandBuffer", reinterpret_cast<uintptr_t>(s_pCommandBuffer));
-		LogVarAdr("s_CommandBufferMutex", reinterpret_cast<uintptr_t>(s_pCommandBufferMutex));
-		LogVarAdr("g_ExecutionMarkers", reinterpret_cast<uintptr_t>(g_pExecutionMarkers));
+		LogFunAdr("Cbuf_AddText", Cbuf_AddText);
+		LogFunAdr("Cbuf_AddExecutionMarker", Cbuf_AddExecutionMarker);
+		LogFunAdr("Cbuf_Execute", Cbuf_Execute);
+		LogFunAdr("Cmd_Dispatch", v_Cmd_Dispatch);
+		LogFunAdr("Cmd_ForwardToServer", v_Cmd_ForwardToServer);
+		LogVarAdr("s_CommandBuffer", s_pCommandBuffer);
+		LogVarAdr("s_CommandBufferMutex", s_pCommandBufferMutex);
+		LogVarAdr("g_ExecutionMarkers", g_pExecutionMarkers);
 	}
 	virtual void GetFun(void) const
 	{
-		p_Cbuf_AddText            = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 63 D9 41 8B F8 48 8D 0D ?? ?? ?? ?? 48 8B F2 FF 15 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 41 B9 ?? ?? ?? ??");
-		p_Cbuf_AddExecutionMarker = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 44 8B 05 ?? ?? ?? ??");
-		p_Cbuf_Execute            = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 FF 15 ?? ?? ?? ??");
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 63 D9 41 8B F8 48 8D 0D ?? ?? ?? ?? 48 8B F2 FF 15 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 41 B9 ?? ?? ?? ??").GetPtr(Cbuf_AddText);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 44 8B 05 ?? ?? ?? ??").GetPtr(Cbuf_AddExecutionMarker);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 FF 15 ?? ?? ?? ??").GetPtr(Cbuf_Execute);
 
-		p_Cmd_Dispatch            = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 8B ?? 0C 49 FF C7").FollowNearCallSelf();
-		p_Cmd_ForwardToServer     = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 44 8B 59 04");
-
-		Cbuf_AddText            = p_Cbuf_AddText.RCast<void (*)(ECommandTarget_t, const char*, cmd_source_t)>(); /*48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 63 D9 41 8B F8 48 8D 0D ?? ?? ?? ?? 48 8B F2 FF 15 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 41 B9 ?? ?? ?? ??*/
-		Cbuf_AddExecutionMarker = p_Cbuf_AddExecutionMarker.RCast<void(*)(ECommandTarget_t, ECmdExecutionMarker)>();
-		Cbuf_Execute            = p_Cbuf_Execute.RCast<void (*)(void)>();                                        /*48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 FF 15 ?? ?? ?? ??*/
-		v_Cmd_Dispatch          = p_Cmd_Dispatch.RCast<void (*)(ECommandTarget_t, const ConCommandBase*, const CCommand*, bool)>();
-		v_Cmd_ForwardToServer   = p_Cmd_ForwardToServer.RCast<bool (*)(const CCommand*)>();             /*48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 44 8B 59 04*/
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 8B ?? 0C 49 FF C7").FollowNearCallSelf().GetPtr(v_Cmd_Dispatch);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 44 8B 59 04").GetPtr(v_Cmd_ForwardToServer);
 	}
 	virtual void GetVar(void) const
 	{
-		s_pCommandBuffer      = p_Cbuf_AddText.FindPattern("48 8D 05").ResolveRelativeAddressSelf(3, 7).RCast<CCommandBuffer**>();
-		s_pCommandBufferMutex = p_Cbuf_AddText.FindPattern("48 8D 0D").ResolveRelativeAddressSelf(3, 7).RCast<LPCRITICAL_SECTION>();
-		g_pExecutionMarkers   = p_Cbuf_AddExecutionMarker.FindPattern("48 8B 0D").ResolveRelativeAddressSelf(3, 7).RCast<CUtlVector<int>*>();
+		s_pCommandBuffer      = CMemory(Cbuf_AddText).FindPattern("48 8D 05").ResolveRelativeAddressSelf(3, 7).RCast<CCommandBuffer**>();
+		s_pCommandBufferMutex = CMemory(Cbuf_AddText).FindPattern("48 8D 0D").ResolveRelativeAddressSelf(3, 7).RCast<LPCRITICAL_SECTION>();
+		g_pExecutionMarkers   = CMemory(Cbuf_AddExecutionMarker).FindPattern("48 8B 0D").ResolveRelativeAddressSelf(3, 7).RCast<CUtlVector<int>*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/cmodel_bsp.cpp
+++ b/src/engine/cmodel_bsp.cpp
@@ -377,11 +377,7 @@ void Mod_ProcessPakQueue()
         v21 = *(_DWORD*)v15;
         if (*(_DWORD*)v15 != INVALID_PAK_HANDLE)
         {
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1) || defined (GAMEDLL_S2)
-            v22 = 232i64 * (v21 & 0x1FF);
-#else
             v22 = 184i64 * (v21 & 0x1FF);
-#endif
             if (*(_DWORD*)((char*)&*g_pLoadedPakInfo + v22) != _DWORD(v21) || ((*(_DWORD*)((char*)&*g_pLoadedPakInfo + v22 + 4) - 9) & 0xFFFFFFFB) != 0)
             {
                 *byte_16709DDDF = 0;                return;

--- a/src/engine/cmodel_bsp.h
+++ b/src/engine/cmodel_bsp.h
@@ -6,10 +6,7 @@
 //-----------------------------------------------------------------------------
 class KeyValues;
 
-inline CMemory p_Mod_LoadPakForMap;
 inline void(*v_Mod_LoadPakForMap)(const char* szLevelName);
-
-inline CMemory p_Mod_ProcessPakQueue;
 inline void(*v_Mod_ProcessPakQueue)(void);
 
 inline float* dword_14B383420;
@@ -41,52 +38,41 @@ class VModel_BSP : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Mod_LoadPakForMap", p_Mod_LoadPakForMap.GetPtr());
-		LogFunAdr("Mod_ProcessPakQueue", p_Mod_ProcessPakQueue.GetPtr());
-		LogFunAdr("sub_14045BAC0", reinterpret_cast<uintptr_t>(sub_14045BAC0));
-		LogFunAdr("sub_14045A1D0", reinterpret_cast<uintptr_t>(sub_14045A1D0));
-		LogFunAdr("sub_140441220", reinterpret_cast<uintptr_t>(sub_140441220));
-		LogVarAdr("dword_14B383420", reinterpret_cast<uintptr_t>(dword_14B383420));
-		LogVarAdr("dword_1634F445C", reinterpret_cast<uintptr_t>(dword_1634F445C));
-		LogVarAdr("qword_167ED7BB8", reinterpret_cast<uintptr_t>(qword_167ED7BB8));
-		LogVarAdr("byte_16709DDDF", reinterpret_cast<uintptr_t>(byte_16709DDDF));
-		LogVarAdr("off_141874660", reinterpret_cast<uintptr_t>(off_141874660));
-		LogVarAdr("unk_141874555", reinterpret_cast<uintptr_t>(unk_141874555));
-		LogVarAdr("unk_1418749B0", reinterpret_cast<uintptr_t>(unk_1418749B0));
-		LogVarAdr("unk_141874550", reinterpret_cast<uintptr_t>(unk_141874550));
-		LogVarAdr("qword_167ED7BC0", reinterpret_cast<uintptr_t>(qword_167ED7BC0));
+		LogFunAdr("Mod_LoadPakForMap", v_Mod_LoadPakForMap);
+		LogFunAdr("Mod_ProcessPakQueue", v_Mod_ProcessPakQueue);
+		LogFunAdr("sub_14045BAC0", sub_14045BAC0);
+		LogFunAdr("sub_14045A1D0", sub_14045A1D0);
+		LogFunAdr("sub_140441220", sub_140441220);
+		LogVarAdr("dword_14B383420", dword_14B383420);
+		LogVarAdr("dword_1634F445C", dword_1634F445C);
+		LogVarAdr("qword_167ED7BB8", qword_167ED7BB8);
+		LogVarAdr("byte_16709DDDF", byte_16709DDDF);
+		LogVarAdr("off_141874660", off_141874660);
+		LogVarAdr("unk_141874555", unk_141874555);
+		LogVarAdr("unk_1418749B0", unk_1418749B0);
+		LogVarAdr("unk_141874550", unk_141874550);
+		LogVarAdr("qword_167ED7BC0", qword_167ED7BC0);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_Mod_LoadPakForMap = g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? 4C 8B C1 48 8D 15 ?? ?? ?? ?? 48 8D 4C 24 ?? E8 ?? ?? ?? ?? 4C 8D 0D ?? ?? ?? ??");
-		v_Mod_LoadPakForMap = p_Mod_LoadPakForMap.RCast<void(*)(const char*)>(); /*48 81 EC ? ? ? ? 4C 8B C1 48 8D 15 ? ? ? ? 48 8D 4C 24 ? E8 ? ? ? ? 4C 8D 0D ? ? ? ?*/
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_Mod_LoadPakForMap = g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? 0F B6 05 ?? ?? ?? ?? 4C 8D 05 ?? ?? ?? ?? 84 C0");
-		v_Mod_LoadPakForMap = p_Mod_LoadPakForMap.RCast<void(*)(const char*)>(); /*48 81 EC ? ? ? ? 0F B6 05 ? ? ? ? 4C 8D 05 ? ? ? ? 84 C0*/
-#endif
-		p_Mod_ProcessPakQueue = g_GameDll.FindPatternSIMD("40 53 48 83 EC ?? F3 0F 10 05 ?? ?? ?? ?? 32 DB");
-		v_Mod_ProcessPakQueue = p_Mod_ProcessPakQueue.RCast<void(*)(void)>(); /*40 53 48 83 EC ?? F3 0F 10 05 ? ? ? ? 32 DB*/
+		g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? 0F B6 05 ?? ?? ?? ?? 4C 8D 05 ?? ?? ?? ?? 84 C0").GetPtr(v_Mod_LoadPakForMap);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC ?? F3 0F 10 05 ?? ?? ?? ?? 32 DB").GetPtr(v_Mod_ProcessPakQueue);
 
-		sub_14045BAC0 = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 4C 89 4C 24 ?? 4C 89 44 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 60").RCast<__int64(*)(__int64(__fastcall* a1)(__int64, _DWORD*, __int64, _QWORD*), JobFifoLock_s* pFifoLock, __int64 a3, __int64 a4)>();
-		sub_14045A1D0 = g_GameDll.FindPatternSIMD("4C 89 4C 24 ?? 4C 89 44 24 ?? 48 89 54 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ??").RCast<__int64(*)(unsigned __int8(__fastcall* a1)(_QWORD), JobFifoLock_s* pFifoLock, __int64 a3, __int64 a4, volatile signed __int64* a5, char a6)>();
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		sub_140441220 = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 48 83 EC 20 33 ED 48 39 2D ?? ?? ?? ??").RCast<void(*)(__int64 a1, __int64 a2)>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		sub_140441220 = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 33 ED 48 8D 35 ?? ?? ?? ?? 48 39 2D ?? ?? ?? ??").RCast<void(*)(__int64 a1, __int64 a2)>();
-#endif
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 4C 89 4C 24 ?? 4C 89 44 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 60").GetPtr(sub_14045BAC0);
+		g_GameDll.FindPatternSIMD("4C 89 4C 24 ?? 4C 89 44 24 ?? 48 89 54 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ??").GetPtr(sub_14045A1D0);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 33 ED 48 8D 35 ?? ?? ?? ?? 48 39 2D ?? ?? ?? ??").GetPtr(sub_140441220);
 	}
 	virtual void GetVar(void) const
 	{
-		dword_14B383420 = p_Mod_ProcessPakQueue.FindPattern("F3 0F 10").ResolveRelativeAddressSelf(0x4, 0x8).RCast<float*>();
-		dword_1634F445C = p_Mod_ProcessPakQueue.FindPattern("8B 05").ResolveRelativeAddressSelf(0x2, 0x6).RCast<int32_t*>();
-		qword_167ED7BB8 = p_Mod_ProcessPakQueue.Offset(0x10).FindPatternSelf("48 83").ResolveRelativeAddressSelf(0x3, 0x8).RCast<void**>();
-		byte_16709DDDF = p_Mod_ProcessPakQueue.Offset(0x20).FindPatternSelf("88 1D").ResolveRelativeAddressSelf(0x2, 0x6).RCast<bool*>();
-		off_141874660 = p_Mod_ProcessPakQueue.Offset(0x40).FindPatternSelf("4C 8D 15").ResolveRelativeAddressSelf(0x3, 0x7).RCast<char**>();
-		unk_141874555 = p_Mod_ProcessPakQueue.Offset(0x40).FindPatternSelf("4C 8D 1D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<void**>();
-		unk_1418749B0 = p_Mod_ProcessPakQueue.Offset(0xA0).FindPatternSelf("48 8D 1D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<void**>();
-		unk_141874550 = p_Mod_ProcessPakQueue.Offset(0x150).FindPatternSelf("48 8D 2D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<void**>();
-		qword_167ED7BC0 = p_Mod_ProcessPakQueue.Offset(0x200).FindPatternSelf("48 83 3D").ResolveRelativeAddressSelf(0x3, 0x8).RCast<int64_t*>();
+		dword_14B383420 = CMemory(v_Mod_ProcessPakQueue).FindPattern("F3 0F 10").ResolveRelativeAddressSelf(0x4, 0x8).RCast<float*>();
+		dword_1634F445C = CMemory(v_Mod_ProcessPakQueue).FindPattern("8B 05").ResolveRelativeAddressSelf(0x2, 0x6).RCast<int32_t*>();
+		qword_167ED7BB8 = CMemory(v_Mod_ProcessPakQueue).Offset(0x10).FindPatternSelf("48 83").ResolveRelativeAddressSelf(0x3, 0x8).RCast<void**>();
+		byte_16709DDDF = CMemory(v_Mod_ProcessPakQueue).Offset(0x20).FindPatternSelf("88 1D").ResolveRelativeAddressSelf(0x2, 0x6).RCast<bool*>();
+		off_141874660 = CMemory(v_Mod_ProcessPakQueue).Offset(0x40).FindPatternSelf("4C 8D 15").ResolveRelativeAddressSelf(0x3, 0x7).RCast<char**>();
+		unk_141874555 = CMemory(v_Mod_ProcessPakQueue).Offset(0x40).FindPatternSelf("4C 8D 1D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<void**>();
+		unk_1418749B0 = CMemory(v_Mod_ProcessPakQueue).Offset(0xA0).FindPatternSelf("48 8D 1D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<void**>();
+		unk_141874550 = CMemory(v_Mod_ProcessPakQueue).Offset(0x150).FindPatternSelf("48 8D 2D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<void**>();
+		qword_167ED7BC0 = CMemory(v_Mod_ProcessPakQueue).Offset(0x200).FindPatternSelf("48 83 3D").ResolveRelativeAddressSelf(0x3, 0x8).RCast<int64_t*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/common.h
+++ b/src/engine/common.h
@@ -1,13 +1,8 @@
 #pragma once
 
 /* ==== COMMON ========================================================================================================================================================== */
-inline CMemory p_COM_InitFilesystem;
 inline void*(*v_COM_InitFilesystem)(const char* pFullModPath);
-
-inline CMemory p_COM_GetPrintMessageBuffer;
 inline char* const(*v_COM_GetPrintMessageBuffer)(void);
-
-inline CMemory p_COM_ExplainDisconnection;
 inline void(*v_COM_ExplainDisconnection)(bool bPrint, const char* fmt, ...);
 
 const char* COM_FormatSeconds(int seconds);
@@ -17,19 +12,15 @@ class VCommon : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("COM_InitFilesystem", p_COM_InitFilesystem.GetPtr());
-		LogFunAdr("COM_GetPrintMessageBuffer", p_COM_GetPrintMessageBuffer.GetPtr());
-		LogFunAdr("COM_ExplainDisconnection", p_COM_ExplainDisconnection.GetPtr());
+		LogFunAdr("COM_InitFilesystem", v_COM_InitFilesystem);
+		LogFunAdr("COM_GetPrintMessageBuffer", v_COM_GetPrintMessageBuffer);
+		LogFunAdr("COM_ExplainDisconnection", v_COM_ExplainDisconnection);
 	}
 	virtual void GetFun(void) const
 	{
-		p_COM_InitFilesystem = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 48 C7 44 24 ?? ?? ?? ?? ??");
-		p_COM_GetPrintMessageBuffer = g_GameDll.FindPatternSIMD("48 8D 05 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 4C 89 44 24 ??");
-		p_COM_ExplainDisconnection = g_GameDll.FindPatternSIMD("48 8B C4 48 89 50 10 4C 89 40 18 4C 89 48 20 48 81 EC ?? ?? ?? ??");
-
-		v_COM_InitFilesystem = p_COM_InitFilesystem.RCast<void* (*)(const char*)>();
-		v_COM_GetPrintMessageBuffer = p_COM_GetPrintMessageBuffer.RCast<char* const(*)(void)>();
-		v_COM_ExplainDisconnection = p_COM_ExplainDisconnection.RCast<void(*)(bool, const char*, ...)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 48 C7 44 24 ?? ?? ?? ?? ??").GetPtr(v_COM_InitFilesystem);
+		g_GameDll.FindPatternSIMD("48 8D 05 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 4C 89 44 24 ??").GetPtr(v_COM_GetPrintMessageBuffer);
+		g_GameDll.FindPatternSIMD("48 8B C4 48 89 50 10 4C 89 40 18 4C 89 48 20 48 81 EC ?? ?? ?? ??").GetPtr(v_COM_ExplainDisconnection);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/debugoverlay.h
+++ b/src/engine/debugoverlay.h
@@ -5,19 +5,10 @@
 #include "mathlib/ssemath.h"
 
 // Something has to be hardcoded..
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1) || defined (GAMEDLL_S2)
-
-constexpr auto MATERIALSYSTEM_VCALL_OFF_0 = 0x3F8;
-constexpr auto CMATQUEUEDRENDERCONTEXT_VCALL_OFS_0 = 0x278;
-constexpr auto CMATQUEUEDRENDERCONTEXT_VCALL_OFS_1 = 0x280;
-
-#elif defined (GAMEDLL_S3)
-
 constexpr auto MATERIALSYSTEM_VCALL_OFF_0 = 0x3F0;
 constexpr auto CMATQUEUEDRENDERCONTEXT_VCALL_OFS_0 = 0x288;
 constexpr auto CMATQUEUEDRENDERCONTEXT_VCALL_OFS_1 = 0x290;
 
-#endif
 constexpr auto CMATQUEUEDRENDERCONTEXT_VCALL_OFS_2 = 0x8;
 constexpr auto NDEBUG_PERSIST_TILL_NEXT_SERVER = (0.01023f);
 
@@ -159,19 +150,10 @@ struct OverlayCapsule_t : public OverlayBase_t
 void DestroyOverlay(OverlayBase_t* pOverlay);
 void DrawOverlay(OverlayBase_t* pOverlay);
 
-inline CMemory p_DrawAllOverlays;
 inline void(*v_DrawAllOverlays)(bool bDraw);
-
-inline CMemory p_DestroyOverlay;
 inline void(*v_DestroyOverlay)(OverlayBase_t* pOverlay);
-
-inline CMemory p_RenderLine;
 inline void*(*v_RenderLine)(const Vector3D& vOrigin, const Vector3D& vDest, Color color, bool bZBuffer);
-
-inline CMemory p_RenderBox;
 inline void*(*v_RenderBox)(const matrix3x4_t& vTransforms, const Vector3D& vMins, const Vector3D& vMaxs, Color color, bool bZBuffer);
-
-inline CMemory p_RenderWireframeSphere;
 inline void*(*v_RenderWireframeSphere)(const Vector3D& vCenter, float flRadius, int nTheta, int nPhi, Color color, bool bZBuffer);
 
 inline OverlayBase_t** s_pOverlays = nullptr;
@@ -185,47 +167,31 @@ class VDebugOverlay : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("DrawAllOverlays", p_DrawAllOverlays.GetPtr());
-		LogFunAdr("DestroyOverlay", p_DestroyOverlay.GetPtr());
-		LogFunAdr("RenderLine", p_RenderLine.GetPtr());
-		LogFunAdr("RenderBox", p_RenderBox.GetPtr());
-		LogFunAdr("RenderWireframeSphere", p_RenderWireframeSphere.GetPtr());
-		LogVarAdr("s_Overlays", reinterpret_cast<uintptr_t>(s_pOverlays));
-		LogVarAdr("s_OverlayMutex", reinterpret_cast<uintptr_t>(s_OverlayMutex));
-		LogVarAdr("g_nOverlayTickCount", reinterpret_cast<uintptr_t>(g_nOverlayTickCount));
-		LogVarAdr("g_nRenderTickCount", reinterpret_cast<uintptr_t>(g_nRenderTickCount));
+		LogFunAdr("DrawAllOverlays", v_DrawAllOverlays);
+		LogFunAdr("DestroyOverlay", v_DestroyOverlay);
+		LogFunAdr("RenderLine", v_RenderLine);
+		LogFunAdr("RenderBox", v_RenderBox);
+		LogFunAdr("RenderWireframeSphere", v_RenderWireframeSphere);
+		LogVarAdr("s_Overlays", s_pOverlays);
+		LogVarAdr("s_OverlayMutex", s_OverlayMutex);
+		LogVarAdr("g_nOverlayTickCount", g_nOverlayTickCount);
+		LogVarAdr("g_nRenderTickCount", g_nRenderTickCount);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_DrawAllOverlays = g_GameDll.FindPatternSIMD("40 55 48 83 EC 50 48 8B 05 ?? ?? ?? ??");
-		p_RenderBox = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 44 89 4C 24 ?? 55 41 56");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_DrawAllOverlays = g_GameDll.FindPatternSIMD("40 55 48 83 EC 30 48 8B 05 ?? ?? ?? ?? 0F B6 E9");
-		p_RenderBox = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 44 89 4C 24 ??");
-#endif
-		p_DestroyOverlay = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B D9 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 63 03");
-		p_RenderWireframeSphere = g_GameDll.FindPatternSIMD("40 56 41 54 41 55 48 81 EC ?? ?? ?? ??");
-		p_RenderLine     = g_GameDll.FindPatternSIMD("48 89 74 24 ?? 44 89 44 24 ?? 57 41 56");
-
-		v_DrawAllOverlays = p_DrawAllOverlays.RCast<void (*)(bool)>();                                                                /*40 55 48 83 EC 30 48 8B 05 ?? ?? ?? ?? 0F B6 E9*/
-		v_DestroyOverlay = p_DestroyOverlay.RCast<void (*)(OverlayBase_t*)>();                                                        /*40 53 48 83 EC 20 48 8B D9 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 63 03 */
-		v_RenderBox = p_RenderBox.RCast<void* (*)(const matrix3x4_t&, const Vector3D&, const Vector3D&, Color, bool)>();              /*48 89 5C 24 ?? 48 89 6C 24 ?? 44 89 4C 24 ??*/
-		v_RenderWireframeSphere = p_RenderWireframeSphere.RCast<void* (*)(const Vector3D&, float, int, int, Color, bool)>();          /*40 56 41 54 41 55 48 81 EC ?? ?? ?? ??*/
-		v_RenderLine = p_RenderLine.RCast<void* (*)(const Vector3D&, const Vector3D&, Color, bool)>();                                /*48 89 74 24 ?? 44 89 44 24 ?? 57 41 56*/
+		g_GameDll.FindPatternSIMD("40 55 48 83 EC 30 48 8B 05 ?? ?? ?? ?? 0F B6 E9").GetPtr(v_DrawAllOverlays);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 44 89 4C 24 ??").GetPtr(v_RenderBox);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B D9 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 63 03").GetPtr(v_DestroyOverlay);
+		g_GameDll.FindPatternSIMD("40 56 41 54 41 55 48 81 EC ?? ?? ?? ??").GetPtr(v_RenderWireframeSphere);
+		g_GameDll.FindPatternSIMD("48 89 74 24 ?? 44 89 44 24 ?? 57 41 56").GetPtr(v_RenderLine);
 	}
 	virtual void GetVar(void) const
 	{
-		s_pOverlays = p_DrawAllOverlays.Offset(0x10).FindPatternSelf("48 8B 3D", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x3, 0x7).RCast<OverlayBase_t**>();
-		s_OverlayMutex = p_DrawAllOverlays.Offset(0x10).FindPatternSelf("48 8D 0D", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x3, 0x7).RCast<LPCRITICAL_SECTION>();
+		s_pOverlays = CMemory(v_DrawAllOverlays).Offset(0x10).FindPatternSelf("48 8B 3D", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x3, 0x7).RCast<OverlayBase_t**>();
+		s_OverlayMutex = CMemory(v_DrawAllOverlays).Offset(0x10).FindPatternSelf("48 8D 0D", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x3, 0x7).RCast<LPCRITICAL_SECTION>();
 
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		g_nRenderTickCount = p_DrawAllOverlays.Offset(0x80).FindPatternSelf("3B 0D", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x6).RCast<int*>();
-		g_nOverlayTickCount = p_DrawAllOverlays.Offset(0x70).FindPatternSelf("3B 0D", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x6).RCast<int*>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		g_nRenderTickCount = p_DrawAllOverlays.Offset(0x50).FindPatternSelf("3B 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x6).RCast<int*>();
-		g_nOverlayTickCount = p_DrawAllOverlays.Offset(0x70).FindPatternSelf("3B 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x6).RCast<int*>();
-#endif
+		g_nRenderTickCount = CMemory(v_DrawAllOverlays).Offset(0x50).FindPatternSelf("3B 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x6).RCast<int*>();
+		g_nOverlayTickCount = CMemory(v_DrawAllOverlays).Offset(0x70).FindPatternSelf("3B 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x6).RCast<int*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/enginetrace.h
+++ b/src/engine/enginetrace.h
@@ -28,10 +28,10 @@ class VEngineTrace : public IDetour
 	virtual void GetAdr(void) const
 	{
 #ifndef CLIENT_DLL
-		LogVarAdr("g_pEngineTraceServer", reinterpret_cast<uintptr_t>(g_pEngineTraceServer));
+		LogVarAdr("g_pEngineTraceServer", g_pEngineTraceServer);
 #endif // CLIENT_DLL
 #ifndef DEDICATED
-		LogVarAdr("g_pEngineTraceClient", reinterpret_cast<uintptr_t>(g_pEngineTraceClient));
+		LogVarAdr("g_pEngineTraceClient", g_pEngineTraceClient);
 #endif // DEDICATED
 	}
 	virtual void GetFun(void) const { }

--- a/src/engine/gl_drawlights.h
+++ b/src/engine/gl_drawlights.h
@@ -1,20 +1,17 @@
 #pragma once
 
-inline CMemory p_DrawLightSprites;
 inline void(*v_DrawLightSprites)(void*);
-
 
 ///////////////////////////////////////////////////////////////////////////////
 class VGL_DrawLights : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("DrawLightSprites", p_DrawLightSprites.GetPtr());
+		LogFunAdr("DrawLightSprites", v_DrawLightSprites);
 	}
 	virtual void GetFun(void) const
 	{
-		p_DrawLightSprites = g_GameDll.FindPatternSIMD("48 8B C4 55 57 48 8D 68 A1 48 81 EC ?? ?? ?? ?? 48 8B 15 ?? ?? ?? ??");
-		v_DrawLightSprites = p_DrawLightSprites.RCast<void(*)(void*)>();
+		g_GameDll.FindPatternSIMD("48 8B C4 55 57 48 8D 68 A1 48 81 EC ?? ?? ?? ?? 48 8B 15 ?? ?? ?? ??").GetPtr(v_DrawLightSprites);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/gl_matsysiface.h
+++ b/src/engine/gl_matsysiface.h
@@ -1,7 +1,6 @@
 #pragma once
 
 /* ==== MATSYSIFACE ===================================================================================================================================================== */
-inline CMemory p_InitMaterialSystem;
 inline void*(*v_InitMaterialSystem)(void);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9,16 +8,11 @@ class VGL_MatSysIFace : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("InitMaterialSystem", p_InitMaterialSystem.GetPtr());
+		LogFunAdr("InitMaterialSystem", v_InitMaterialSystem);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_InitMaterialSystem = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B 0D ?? ?? ?? ?? 48 8D 1D ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ??");
-#else
-		p_InitMaterialSystem = g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 0D ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ?? 48 8B 01 FF 90 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ?? 48 8B 01 FF 90 ?? ?? ?? ??");
-#endif // !(GAMEDLL_S0) || !(GAMEDLL_S1)
-		v_InitMaterialSystem = p_InitMaterialSystem.RCast<void* (*)(void)>();
+		g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 0D ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ?? 48 8B 01 FF 90 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ?? 48 8B 01 FF 90 ?? ?? ?? ??").GetPtr(v_InitMaterialSystem);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/gl_rsurf.h
+++ b/src/engine/gl_rsurf.h
@@ -1,16 +1,9 @@
 #pragma once
 #include "public/ivrenderview.h"
 
-inline CMemory P_DrawDepthOfField;
 inline void*(*V_DrawDepthOfField)(const float scalar);
-
-inline CMemory P_DrawWorldMeshes;
 inline void*(*V_DrawWorldMeshes)(void* baseEntity, void* renderContext, DrawWorldLists_t worldLists);
-
-inline CMemory P_DrawWorldMeshesDepthOnly;
 inline void*(*V_DrawWorldMeshesDepthOnly)(void* renderContext, DrawWorldLists_t worldLists);
-
-inline CMemory P_DrawWorldMeshesDepthAtTheEnd;
 inline void*(*V_DrawWorldMeshesDepthAtTheEnd)(void* ptr1, void* ptr2, void* ptr3, DrawWorldLists_t worldLists);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -18,26 +11,17 @@ class VGL_RSurf : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("R_DrawDepthOfField", P_DrawDepthOfField.GetPtr());
-		LogFunAdr("R_DrawWorldMeshes", P_DrawWorldMeshes.GetPtr());
-		LogFunAdr("R_DrawWorldMeshesDepthOnly", P_DrawWorldMeshesDepthOnly.GetPtr());
-		LogFunAdr("R_DrawWorldMeshesDepthAtTheEnd", P_DrawWorldMeshesDepthAtTheEnd.GetPtr());
+		LogFunAdr("R_DrawDepthOfField", V_DrawDepthOfField);
+		LogFunAdr("R_DrawWorldMeshes", V_DrawWorldMeshes);
+		LogFunAdr("R_DrawWorldMeshesDepthOnly", V_DrawWorldMeshesDepthOnly);
+		LogFunAdr("R_DrawWorldMeshesDepthAtTheEnd", V_DrawWorldMeshesDepthAtTheEnd);
 	}
 	virtual void GetFun(void) const
 	{
-		P_DrawDepthOfField = g_GameDll.FindPatternSIMD("48 83 EC 48 0F 28 E8");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		P_DrawWorldMeshes              = g_GameDll.FindPatternSIMD("48 8B C4 48 89 48 08 53 48 83 EC 70");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		P_DrawWorldMeshes              = g_GameDll.FindPatternSIMD("48 8B C4 48 89 48 08 53 57 41 55");
-#endif
-		P_DrawWorldMeshesDepthOnly     = g_GameDll.FindPatternSIMD("40 56 57 B8 ?? ?? ?? ??");
-		P_DrawWorldMeshesDepthAtTheEnd = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 0D ?? ?? ?? ?? 41 8B F9");
-
-		V_DrawDepthOfField             = P_DrawDepthOfField.RCast<void* (*)(const float)>();
-		V_DrawWorldMeshes              = P_DrawWorldMeshes.RCast<void* (*)(void*, void*, DrawWorldLists_t)>();                     /*48 8B C4 48 89 48 08 53 57 41 55*/
-		V_DrawWorldMeshesDepthOnly     = P_DrawWorldMeshesDepthOnly.RCast<void* (*)(void*, DrawWorldLists_t)>();                   /*40 56 57 B8 ?? ?? ?? ??*/
-		V_DrawWorldMeshesDepthAtTheEnd = P_DrawWorldMeshesDepthAtTheEnd.RCast<void* (*)(void*, void*, void*, DrawWorldLists_t)>(); /*48 89 5C 24 ?? 48 89 74 24 ? 57 48 83 EC 20 48 8B 0D ?? ?? ?? ?? 41 8B F9*/
+		g_GameDll.FindPatternSIMD("48 83 EC 48 0F 28 E8").GetPtr(V_DrawDepthOfField);
+		g_GameDll.FindPatternSIMD("48 8B C4 48 89 48 08 53 57 41 55").GetPtr(V_DrawWorldMeshes);
+		g_GameDll.FindPatternSIMD("40 56 57 B8 ?? ?? ?? ??").GetPtr(V_DrawWorldMeshesDepthOnly);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 0D ?? ?? ?? ?? 41 8B F9").GetPtr(V_DrawWorldMeshesDepthAtTheEnd);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/gl_screen.h
+++ b/src/engine/gl_screen.h
@@ -1,7 +1,7 @@
 #pragma once
 
 ///////////////////////////////////////////////////////////////////////////////
-inline CMemory SCR_BeginLoadingPlaque;
+inline __int64(*v_SCR_BeginLoadingPlaque)(void* a1);
 
 ///////////////////////////////////////////////////////////////////////////////
 inline bool* scr_drawloading = nullptr;
@@ -14,29 +14,18 @@ class VGL_Screen : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("SCR_BeginLoadingPlaque", SCR_BeginLoadingPlaque.GetPtr());
-		LogVarAdr("scr_drawloading", reinterpret_cast<uintptr_t>(scr_drawloading));
-		LogVarAdr("scr_engineevent_loadingstarted", reinterpret_cast<uintptr_t>(scr_engineevent_loadingstarted));
+		LogFunAdr("SCR_BeginLoadingPlaque", v_SCR_BeginLoadingPlaque);
+		LogVarAdr("scr_drawloading", scr_drawloading);
+		LogVarAdr("scr_engineevent_loadingstarted", scr_engineevent_loadingstarted);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		SCR_BeginLoadingPlaque = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 0F 29 74 24 ?? 48 8B F9");
-		// 0x14022A4A0 // 48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 30 0F 29 74 24 ? 48 8B F9 //
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		SCR_BeginLoadingPlaque = g_GameDll.FindPatternSIMD("48 83 EC 38 0F 29 74 24 ?? 48 89 5C 24 ??");
-		// 0x14022A4A0 // 48 83 EC 38 0F 29 74 24 ? 48 89 5C 24 ? //
-#endif
+		g_GameDll.FindPatternSIMD("48 83 EC 38 0F 29 74 24 ?? 48 89 5C 24 ??").GetPtr(v_SCR_BeginLoadingPlaque);
 	}
 	virtual void GetVar(void) const
 	{
 		scr_drawloading = g_GameDll.FindPatternSIMD("0F B6 05 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 48 83 EC 28").ResolveRelativeAddressSelf(0x3, 0x7).RCast<bool*>();
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		scr_engineevent_loadingstarted = SCR_BeginLoadingPlaque.Offset(0x130).FindPatternSelf("C6 05 ?? ?? ?? ?? 01", CMemory::Direction::DOWN).ResolveRelativeAddress(0x2, 0x7).RCast<bool*>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		scr_engineevent_loadingstarted = SCR_BeginLoadingPlaque.Offset(0x60).FindPatternSelf("C6 05 ?? ?? ?? ?? 01", CMemory::Direction::DOWN).ResolveRelativeAddress(0x2, 0x7).RCast<bool*>();
-#endif
-
+		scr_engineevent_loadingstarted = CMemory(v_SCR_BeginLoadingPlaque).Offset(0x60).FindPatternSelf("C6 05 ?? ?? ?? ?? 01", CMemory::Direction::DOWN).ResolveRelativeAddress(0x2, 0x7).RCast<bool*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const { }

--- a/src/engine/host.h
+++ b/src/engine/host.h
@@ -1,22 +1,11 @@
 #pragma once
 #include "engine/gl_model_private.h"
 
-inline CMemory p_Host_RunFrame;
 inline void(*v_Host_RunFrame)(void* unused, float time);
-
-inline CMemory p_Host_RunFrame_Render;
 inline void(*v_Host_RunFrame_Render)(void);
-
-inline CMemory p_Host_CountRealTimePackets;
 inline void(*v_Host_CountRealTimePackets)(void);
-
-inline CMemory p_Host_ShouldRun;
 inline bool(*v_Host_ShouldRun)();
-
-inline CMemory p_Host_Error;
 inline void(*v_Host_Error)(const char* error, ...);
-
-//inline CMemory p_VCR_EnterPausedState; // DEDICATED PATCH!
 //inline void(*v_VCR_EnterPausedState)(void);
 
 inline bool* g_bAbortServerSet = nullptr;
@@ -56,60 +45,47 @@ class VHost : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("_Host_RunFrame", p_Host_RunFrame.GetPtr());
-		LogFunAdr("_Host_RunFrame_Render", p_Host_RunFrame_Render.GetPtr());
-		LogFunAdr("Host_CountRealTimePackets", p_Host_CountRealTimePackets.GetPtr());
-		LogFunAdr("Host_ShouldRun", p_Host_ShouldRun.GetPtr());
-		LogFunAdr("Host_Error", p_Host_Error.GetPtr());
-		//LogFunAdr("VCR_EnterPausedState", p_VCR_EnterPausedState.GetPtr());
-		LogVarAdr("g_CommonHostState", reinterpret_cast<uintptr_t>(g_pCommonHostState));
-		LogVarAdr("g_bAbortServerSet", reinterpret_cast<uintptr_t>(g_bAbortServerSet));
-		LogVarAdr("host_abortserver", reinterpret_cast<uintptr_t>(host_abortserver));
-		LogVarAdr("host_initialized", reinterpret_cast<uintptr_t>(host_initialized));
-		LogVarAdr("host_frametime_unbounded", reinterpret_cast<uintptr_t>(host_frametime_unbounded));
-		LogVarAdr("host_frametime_stddeviation", reinterpret_cast<uintptr_t>(host_frametime_stddeviation));
+		LogFunAdr("_Host_RunFrame", v_Host_RunFrame);
+		LogFunAdr("_Host_RunFrame_Render", v_Host_RunFrame_Render);
+		LogFunAdr("Host_CountRealTimePackets", v_Host_CountRealTimePackets);
+		LogFunAdr("Host_ShouldRun", v_Host_ShouldRun);
+		LogFunAdr("Host_Error", v_Host_Error);
+		//LogFunAdr("VCR_EnterPausedState", v_VCR_EnterPausedState);
+		LogVarAdr("g_CommonHostState", g_pCommonHostState);
+		LogVarAdr("g_bAbortServerSet", g_bAbortServerSet);
+		LogVarAdr("host_abortserver", host_abortserver);
+		LogVarAdr("host_initialized", host_initialized);
+		LogVarAdr("host_frametime_unbounded", host_frametime_unbounded);
+		LogVarAdr("host_frametime_stddeviation", host_frametime_stddeviation);
 	}
 	virtual void GetFun(void) const
 	{
-		p_Host_RunFrame = g_GameDll.FindPatternSIMD("48 8B C4 48 89 58 18 48 89 70 20 F3 0F 11 48 ??");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_Host_RunFrame_Render = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 48 8B 1D ?? ?? ?? ?? 33 FF");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_Host_RunFrame_Render = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B 0D ?? ?? ?? ?? 48 85 C9 75 34");
-#endif
-		p_Host_CountRealTimePackets = g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 65 48 8B 04 25 ?? ?? ?? ?? 33 DB");
-		p_Host_ShouldRun = g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 05 ?? ?? ?? ?? 83 78 6C 00 75 07 B0 01");
-		p_Host_Error = g_GameDll.FindPatternSIMD("48 89 4C 24 ?? 48 89 54 24 ?? 4C 89 44 24 ?? 4C 89 4C 24 ?? 53 57 48 81 EC ?? ?? ?? ??");
-		//p_VCR_EnterPausedState = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 65 48 8B 04 25 ?? ?? ?? ?? BB ?? ?? ?? ?? C6 05 ?? ?? ?? ?? ??");
-
-		v_Host_RunFrame = p_Host_RunFrame.RCast<void(*)(void*, float)>();
-		v_Host_RunFrame_Render = p_Host_RunFrame_Render.RCast<void(*)(void)>();
-		v_Host_CountRealTimePackets = p_Host_CountRealTimePackets.RCast<void(*)(void)>();
-		v_Host_ShouldRun = p_Host_ShouldRun.RCast<bool(*)()>();
-		v_Host_Error = p_Host_Error.RCast<void(*)(const char*, ...)>();
-		//v_VCR_EnterPausedState = p_VCR_EnterPausedState.RCast<void(*)(void)>();
+		g_GameDll.FindPatternSIMD("48 8B C4 48 89 58 18 48 89 70 20 F3 0F 11 48 ??").GetPtr(v_Host_RunFrame);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B 0D ?? ?? ?? ?? 48 85 C9 75 34").GetPtr(v_Host_RunFrame_Render);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 65 48 8B 04 25 ?? ?? ?? ?? 33 DB").GetPtr(v_Host_CountRealTimePackets);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 05 ?? ?? ?? ?? 83 78 6C 00 75 07 B0 01").GetPtr(v_Host_ShouldRun);
+		g_GameDll.FindPatternSIMD("48 89 4C 24 ?? 48 89 54 24 ?? 4C 89 44 24 ?? 4C 89 4C 24 ?? 53 57 48 81 EC ?? ?? ?? ??").GetPtr(v_Host_Error);
+		//g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 65 48 8B 04 25 ?? ?? ?? ?? BB ?? ?? ?? ?? C6 05 ?? ?? ?? ?? ??").GetPtr(v_VCR_EnterPausedState);
 	}
 	virtual void GetVar(void) const
 	{
 		g_pCommonHostState = g_GameDll.FindPatternSIMD("48 83 EC 28 84 C9 75 0B")
 			.FindPatternSelf("48 8B 15").ResolveRelativeAddressSelf(0x3, 0x7).RCast<CCommonHostState*>();
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		g_bAbortServerSet = p_Host_Error.FindPattern("40 38 3D", CMemory::Direction::DOWN, 512, 2).ResolveRelativeAddress(3, 7).RCast<bool*>();
-		host_abortserver = p_Host_Error.FindPattern("48 8D 0D", CMemory::Direction::DOWN, 512, 3).ResolveRelativeAddress(3, 7).RCast<jmp_buf*>();
 
-		static const int n_host_frametime_unbounded_search_offset = 0x380;
-		static const int n_host_frametime_stddeviation_search_offset = 0x1200;
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		g_bAbortServerSet = p_Host_Error.FindPattern("40 38 3D", CMemory::Direction::DOWN, 512, 4).ResolveRelativeAddress(3, 7).RCast<bool*>();
-		host_abortserver = p_Host_Error.FindPattern("48 8D 0D", CMemory::Direction::DOWN, 512, 5).ResolveRelativeAddress(3, 7).RCast<jmp_buf*>();
+		const CMemory hostErrorBase(v_Host_Error);
 
-		static const int n_host_initialized_search_offset = 0x500; // TODO: S1!!!
+		g_bAbortServerSet = hostErrorBase.FindPattern("40 38 3D", CMemory::Direction::DOWN, 512, 4).ResolveRelativeAddress(3, 7).RCast<bool*>();
+		host_abortserver = hostErrorBase.FindPattern("48 8D 0D", CMemory::Direction::DOWN, 512, 5).ResolveRelativeAddress(3, 7).RCast<jmp_buf*>();
+
+		static const int n_host_initialized_search_offset = 0x500;
 		static const int n_host_frametime_unbounded_search_offset = 0x330;
 		static const int n_host_frametime_stddeviation_search_offset = 0xFAA;
-#endif
-		host_initialized = p_Host_RunFrame.Offset(n_host_initialized_search_offset).FindPatternSelf("44 38").ResolveRelativeAddressSelf(0x3, 0x7).RCast<bool*>();
-		host_frametime_unbounded = p_Host_RunFrame.Offset(n_host_frametime_unbounded_search_offset).FindPatternSelf("F3 0F 11").ResolveRelativeAddressSelf(0x4, 0x8).RCast<float*>();
-		host_frametime_stddeviation = p_Host_RunFrame.Offset(n_host_frametime_stddeviation_search_offset).FindPatternSelf("F3 0F 11").ResolveRelativeAddressSelf(0x4, 0x8).RCast<float*>();
+
+		const CMemory hostRunFrameBase(v_Host_RunFrame);
+
+		host_initialized = hostRunFrameBase.Offset(n_host_initialized_search_offset).FindPatternSelf("44 38").ResolveRelativeAddressSelf(0x3, 0x7).RCast<bool*>();
+		host_frametime_unbounded = hostRunFrameBase.Offset(n_host_frametime_unbounded_search_offset).FindPatternSelf("F3 0F 11").ResolveRelativeAddressSelf(0x4, 0x8).RCast<float*>();
+		host_frametime_stddeviation = hostRunFrameBase.Offset(n_host_frametime_stddeviation_search_offset).FindPatternSelf("F3 0F 11").ResolveRelativeAddressSelf(0x4, 0x8).RCast<float*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/host_cmd.cpp
+++ b/src/engine/host_cmd.cpp
@@ -62,7 +62,6 @@ void Host_Status_PrintClient(CClient* client, bool bShowAddress, void (*print) (
 	//print("\n");
 }
 
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
 /*
 ==================
 DFS_InitializeFeatureFlagDefinitions
@@ -78,16 +77,13 @@ bool DFS_InitializeFeatureFlagDefinitions(const char* pszFeatureFlags)
 
 	return v_DFS_InitializeFeatureFlagDefinitions(pszFeatureFlags);
 }
-#endif // !(GAMEDLL_S0) || !(GAMEDLL_S1) || !(GAMEDLL_S2)
 
 ///////////////////////////////////////////////////////////////////////////////
 void VHostCmd::Detour(const bool bAttach) const
 {
 	DetourSetup(&v_Host_Shutdown, &Host_Shutdown, bAttach);
 	DetourSetup(&v_Host_Status_PrintClient, &Host_Status_PrintClient, bAttach);
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
 	DetourSetup(&v_DFS_InitializeFeatureFlagDefinitions, &DFS_InitializeFeatureFlagDefinitions, bAttach);
-#endif // !(GAMEDLL_S0) || !(GAMEDLL_S1) || !(GAMEDLL_S2)
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/engine/host_cmd.h
+++ b/src/engine/host_cmd.h
@@ -18,37 +18,17 @@ struct EngineParms_t
 extern EngineParms_t* g_pEngineParms;
 
 /* ==== HOST ============================================================================================================================================================ */
-inline CMemory p_Host_Init;
 inline void(*v_Host_Init)();
-
-inline CMemory p_Host_Init_DuringVideo;
 inline void(*v_Host_Init_DuringVideo)(bool* bDedicated);
-
-inline CMemory p_Host_Init_PostVideo;
 inline void(*v_Host_Init_PostVideo)(bool* bDedicated);
-
-inline CMemory p_Host_Shutdown;
 inline void(*v_Host_Shutdown)();
-
-inline CMemory p_Host_NewGame;
 inline bool(*v_Host_NewGame)(char* pszMapName, char* pszMapGroup, bool bLoadGame, char bBackground, LARGE_INTEGER PerformanceCount);
-
-inline CMemory p_Host_Disconnect;
 inline void(*v_Host_Disconnect)(bool bShowMainMenu);
-
-inline CMemory p_Host_ChangeLevel;
 inline bool(*v_Host_ChangeLevel)(bool bLoadFromSavedGame, const char* pszMapName, const char* pszMapGroup);
-
-inline CMemory p_Host_Status_PrintClient;
 inline void (*v_Host_Status_PrintClient)(CClient* client, bool bShowAddress, void (*print) (const char* fmt, ...));
 
-inline CMemory p_SetLaunchOptions;
 inline int(*v_SetLaunchOptions)(const CCommand& args);
-
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
-inline CMemory p_DFS_InitializeFeatureFlagDefinitions;
 inline bool(*v_DFS_InitializeFeatureFlagDefinitions)(const char* pszFeatureFlags);
-#endif // !(GAMEDLL_S0) || !(GAMEDLL_S1) || !(GAMEDLL_S2)
 
 extern EngineParms_t* g_pEngineParms;
 
@@ -57,60 +37,37 @@ class VHostCmd : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Host_Init", p_Host_Init.GetPtr());
-		LogFunAdr("Host_Init_DuringVideo", p_Host_Init_DuringVideo.GetPtr());
-		LogFunAdr("Host_Init_PostVideo", p_Host_Init_PostVideo.GetPtr());
-		LogFunAdr("Host_Shutdown", p_Host_Shutdown.GetPtr());
-		LogFunAdr("Host_Disconnect", p_Host_Disconnect.GetPtr());
-		LogFunAdr("Host_NewGame", p_Host_NewGame.GetPtr());
-		LogFunAdr("Host_ChangeLevel", p_Host_ChangeLevel.GetPtr());
-		LogFunAdr("Host_Status_PrintClient", p_Host_Status_PrintClient.GetPtr());
-		LogFunAdr("SetLaunchOptions", p_SetLaunchOptions.GetPtr());
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
-		LogFunAdr("DFS_InitializeFeatureFlagDefinitions", p_DFS_InitializeFeatureFlagDefinitions.GetPtr());
-#endif // !(GAMEDLL_S0) || !(GAMEDLL_S1) || !(GAMEDLL_S2)
-		LogVarAdr("g_pEngineParms", reinterpret_cast<uintptr_t>(g_pEngineParms));
+		LogFunAdr("Host_Init", v_Host_Init);
+		LogFunAdr("Host_Init_DuringVideo", v_Host_Init_DuringVideo);
+		LogFunAdr("Host_Init_PostVideo", v_Host_Init_PostVideo);
+		LogFunAdr("Host_Shutdown", v_Host_Shutdown);
+		LogFunAdr("Host_Disconnect", v_Host_Disconnect);
+		LogFunAdr("Host_NewGame", v_Host_NewGame);
+		LogFunAdr("Host_ChangeLevel", v_Host_ChangeLevel);
+		LogFunAdr("Host_Status_PrintClient", v_Host_Status_PrintClient);
+		LogFunAdr("SetLaunchOptions", v_SetLaunchOptions);
+
+		LogFunAdr("DFS_InitializeFeatureFlagDefinitions", v_DFS_InitializeFeatureFlagDefinitions);
+		LogVarAdr("g_pEngineParms", g_pEngineParms);
 	}
 	virtual void GetFun(void) const
 	{
-		p_Host_Init = g_GameDll.FindPatternSIMD("88 4C 24 08 53 55 56 57 48 83 EC 68");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_Host_Init_DuringVideo = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? 48 8B D9 FF 15 ?? ?? ?? ??");
-		p_Host_NewGame = g_GameDll.FindPatternSIMD("48 8B C4 56 41 54 41 57 48 81 EC ?? ?? ?? ?? F2 0F 10 05 ?? ?? ?? ??");
-		p_Host_Disconnect = g_GameDll.FindPatternSIMD("48 83 EC 38 48 89 7C 24 ?? 0F B6 F9");
-		p_Host_ChangeLevel = g_GameDll.FindPatternSIMD("40 53 56 41 56 48 81 EC ?? ?? ?? ?? 49 8B D8");
-		p_SetLaunchOptions = g_GameDll.FindPatternSIMD("48 89 6C 24 ?? 57 48 83 EC 20 48 8B E9 48 8B 0D ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_Host_Init_DuringVideo = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B D9");
-		p_Host_NewGame = g_GameDll.FindPatternSIMD("48 8B C4 ?? 41 54 41 55 48 81 EC 70 04 ?? ?? F2 0F 10 05 ?? ?? ?? 0B");
-		p_Host_Disconnect = g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 0F B6 D9");
-		p_Host_ChangeLevel = g_GameDll.FindPatternSIMD("40 56 57 41 56 48 81 EC ?? ?? ?? ??");
-		p_SetLaunchOptions = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 57 48 83 EC 20 48 8B 1D ?? ?? ?? ?? 48 8B E9 48 85 DB");
-#endif
-		p_Host_Init_PostVideo = g_GameDll.FindPatternSIMD("48 8B C4 41 56 48 81 EC ?? ?? ?? ?? 45 33 F6");
-		p_Host_Shutdown = g_GameDll.FindPatternSIMD("48 8B C4 48 83 EC ?? 80 3D ?? ?? ?? ?? ?? 0F 85 ?? ?? ?? ?? 8B 15 ?? ?? ?? ??");
-		p_Host_Status_PrintClient = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 60 48 8B A9 ?? ?? ?? ??");
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
-		p_DFS_InitializeFeatureFlagDefinitions = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 40 38 3D ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ?? 48 8B CE").FollowNearCallSelf();
-		v_DFS_InitializeFeatureFlagDefinitions = p_DFS_InitializeFeatureFlagDefinitions.RCast<bool (*)(const char*)>(); /*48 8B C4 55 53 48 8D 68 E8*/
-#endif // !(GAMEDLL_S0) || !(GAMEDLL_S1) || !(GAMEDLL_S2)
-		v_Host_Init = p_Host_Init.RCast<void (*)()>();
-		v_Host_Init_DuringVideo = p_Host_Init_DuringVideo.RCast<void (*)(bool*)>();                                        /*48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B D9*/
-		v_Host_Init_PostVideo = p_Host_Init_PostVideo.RCast<void (*)(bool*)>();
-		v_Host_Shutdown = p_Host_Shutdown.RCast<void (*)()>();
-		v_Host_NewGame = p_Host_NewGame.RCast<bool (*)(char*, char*, bool, char, LARGE_INTEGER)>(); /*48 8B C4 ?? 41 54 41 55 48 81 EC 70 04 00 00 F2 0F 10 05 ?? ?? ?? 0B*/
-		v_Host_Disconnect = p_Host_Disconnect.RCast<void (*)(bool)>();
-		v_Host_ChangeLevel = p_Host_ChangeLevel.RCast<bool (*)(bool, const char*, const char*)>();  /*40 56 57 41 56 48 81 EC ?? ?? ?? ??*/
-		v_Host_Status_PrintClient = p_Host_Status_PrintClient.RCast<void (*)(CClient*, bool, void (*) (const char*, ...))>();
-		v_SetLaunchOptions = p_SetLaunchOptions.RCast<int (*)(const CCommand&)>();                /*48 89 5C 24 ?? 48 89 6C 24 ?? 57 48 83 EC 20 48 8B 1D ?? ?? ?? ?? 48 8B E9 48 85 DB*/
+		g_GameDll.FindPatternSIMD("88 4C 24 08 53 55 56 57 48 83 EC 68").GetPtr(v_Host_Init);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B D9").GetPtr(v_Host_Init_DuringVideo);
+		g_GameDll.FindPatternSIMD("48 8B C4 ?? 41 54 41 55 48 81 EC 70 04 ?? ?? F2 0F 10 05 ?? ?? ?? 0B").GetPtr(v_Host_NewGame);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 0F B6 D9").GetPtr(v_Host_Disconnect);
+		g_GameDll.FindPatternSIMD("40 56 57 41 56 48 81 EC ?? ?? ?? ??").GetPtr(v_Host_ChangeLevel);
+		g_GameDll.FindPatternSIMD("48 8B C4 41 56 48 81 EC ?? ?? ?? ?? 45 33 F6").GetPtr(v_Host_Init_PostVideo);
+		g_GameDll.FindPatternSIMD("48 8B C4 48 83 EC ?? 80 3D ?? ?? ?? ?? ?? 0F 85 ?? ?? ?? ?? 8B 15 ?? ?? ?? ??").GetPtr(v_Host_Shutdown);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 60 48 8B A9 ?? ?? ?? ??").GetPtr(v_Host_Status_PrintClient);
+
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 57 48 83 EC 20 48 8B 1D ?? ?? ?? ?? 48 8B E9 48 85 DB").GetPtr(v_SetLaunchOptions);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 40 38 3D ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ?? 48 8B CE").FollowNearCallSelf().GetPtr(v_DFS_InitializeFeatureFlagDefinitions);
 	}
 	virtual void GetVar(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		g_pEngineParms = p_CModAppSystemGroup_Main.FindPattern("48 8B", CMemory::Direction::DOWN, 100).ResolveRelativeAddress(0x3, 0x7).RCast<EngineParms_t*>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		g_pEngineParms = p_CModAppSystemGroup_Main.FindPattern("4C 8B", CMemory::Direction::DOWN, 100).ResolveRelativeAddress(0x3, 0x7).RCast<EngineParms_t*>();
-#endif
+		g_pEngineParms = CMemory(CModAppSystemGroup__Main).FindPattern("48 8B", CMemory::Direction::DOWN, 100).ResolveRelativeAddress(0x3, 0x7).RCast<EngineParms_t*>();
+		g_pEngineParms = CMemory(CModAppSystemGroup__Main).FindPattern("4C 8B", CMemory::Direction::DOWN, 100).ResolveRelativeAddress(0x3, 0x7).RCast<EngineParms_t*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/host_state.cpp
+++ b/src/engine/host_state.cpp
@@ -172,22 +172,22 @@ void CHostState::FrameUpdate(CHostState* pHostState, double flCurrentTime, float
 					bResetIdleName = true;
 				}
 
-				CHostState_State_Run(&g_pHostState->m_iCurrentState, flCurrentTime, flFrameTime);
+				CHostState__State_Run(&g_pHostState->m_iCurrentState, flCurrentTime, flFrameTime);
 				break;
 			}
 			case HostStates_t::HS_GAME_SHUTDOWN:
 			{
 				Msg(eDLL_T::ENGINE, "%s: Shutdown host game\n", __FUNCTION__);
-				CHostState_State_GameShutDown(g_pHostState);
+				CHostState__State_GameShutDown(g_pHostState);
 				break;
 			}
 			case HostStates_t::HS_RESTART:
 			{
 				Msg(eDLL_T::ENGINE, "%s: Restarting state machine\n", __FUNCTION__);
 #ifndef DEDICATED
-				CL_EndMovie();
+				v_CL_EndMovie();
 #endif // !DEDICATED
-				Stryder_SendOfflineRequest(); // We have hostnames nulled anyway.
+				v_Stryder_SendOfflineRequest(); // We have hostnames nulled anyway.
 				g_pEngine->SetNextState(IEngine::DLL_RESTART);
 				break;
 			}
@@ -195,9 +195,9 @@ void CHostState::FrameUpdate(CHostState* pHostState, double flCurrentTime, float
 			{
 				Msg(eDLL_T::ENGINE, "%s: Shutdown state machine\n", __FUNCTION__);
 #ifndef DEDICATED
-				CL_EndMovie();
+				v_CL_EndMovie();
 #endif // !DEDICATED
-				Stryder_SendOfflineRequest(); // We have hostnames nulled anyway.
+				v_Stryder_SendOfflineRequest(); // We have hostnames nulled anyway.
 				g_pEngine->SetNextState(IEngine::DLL_CLOSE);
 				break;
 			}
@@ -223,7 +223,7 @@ void CHostState::Init(void)
 	{
 		if (m_iNextState == HostStates_t::HS_GAME_SHUTDOWN)
 		{
-			CHostState_State_GameShutDown(this);
+			CHostState__State_GameShutDown(this);
 		}
 		else
 		{
@@ -316,7 +316,7 @@ void CHostState::Think(void) const
 	{
 		SetConsoleTitleA(Format("%s - %d/%d Players (%s on %s) - %d%% Server CPU (%.3f msec on frame %d)",
 			hostname->GetString(), g_pServer->GetNumClients(),
-			g_ServerGlobalVariables->m_nMaxClients, KeyValues_GetCurrentPlaylist(), m_levelName,
+			g_ServerGlobalVariables->m_nMaxClients, KeyValues__GetCurrentPlaylist(), m_levelName,
 			static_cast<int>(g_pServer->GetCPUUsage() * 100.0f), (g_pEngine->GetFrameTime() * 1000.0f),
 			g_pServer->GetTick()).c_str());
 
@@ -337,7 +337,7 @@ void CHostState::Think(void) const
 			hostdesc->GetString(),
 			sv_pylonVisibility->GetInt() == EServerVisibility_t::HIDDEN,
 			g_pHostState->m_levelName,
-			KeyValues_GetCurrentPlaylist(),
+			KeyValues__GetCurrentPlaylist(),
 			hostip->GetString(),
 			hostport->GetInt(),
 			g_pNetKey->GetBase64NetKey(),
@@ -520,7 +520,7 @@ void CHostState::ResetLevelName(void)
 
 void VHostState::Detour(const bool bAttach) const
 {
-	DetourSetup(&CHostState_FrameUpdate, &CHostState::FrameUpdate, bAttach);
+	DetourSetup(&CHostState__FrameUpdate, &CHostState::FrameUpdate, bAttach);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/engine/host_state.h
+++ b/src/engine/host_state.h
@@ -51,16 +51,9 @@ public:
 };
 
 /* ==== CHOSTSTATE ====================================================================================================================================================== */
-inline CMemory p_CHostState_FrameUpdate;
-inline void(*CHostState_FrameUpdate)(CHostState* pHostState, double flCurrentTime, float flFrameTime);
-
-inline CMemory p_CHostState_State_Run;
-inline void(*CHostState_State_Run)(HostStates_t* pState, double flCurrentTime, float flFrameTime);
-
-inline CMemory p_CHostState_State_GameShutDown;
-inline void(*CHostState_State_GameShutDown)(CHostState* thisptr);
-
-inline CMemory p_HostState_ChangeLevelMP;
+inline void(*CHostState__FrameUpdate)(CHostState* pHostState, double flCurrentTime, float flFrameTime);
+inline void(*CHostState__State_Run)(HostStates_t* pState, double flCurrentTime, float flFrameTime);
+inline void(*CHostState__State_GameShutDown)(CHostState* thisptr);
 inline void(*v_HostState_ChangeLevelMP)(char const* pNewLevel, char const* pLandmarkName);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -71,33 +64,22 @@ class VHostState : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CHostState::FrameUpdate", p_CHostState_FrameUpdate.GetPtr());
-		LogFunAdr("CHostState::State_Run", p_CHostState_State_Run.GetPtr());
-		LogFunAdr("CHostState::State_GameShutDown", p_CHostState_State_GameShutDown.GetPtr());
-		LogFunAdr("HostState_ChangeLevelMP", p_HostState_ChangeLevelMP.GetPtr());
-		LogVarAdr("g_pHostState", reinterpret_cast<uintptr_t>(g_pHostState));
+		LogFunAdr("CHostState::FrameUpdate", CHostState__FrameUpdate);
+		LogFunAdr("CHostState::State_Run", CHostState__State_Run);
+		LogFunAdr("CHostState::State_GameShutDown", CHostState__State_GameShutDown);
+		LogFunAdr("HostState_ChangeLevelMP", v_HostState_ChangeLevelMP);
+		LogVarAdr("g_pHostState", g_pHostState);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CHostState_FrameUpdate  = g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 20 F3 0F 11 54 24 18");
-		p_CHostState_State_Run    = g_GameDll.FindPatternSIMD("48 8B C4 48 89 58 10 48 89 70 18 48 89 78 20 55 41 54 41 55 41 56 41 57 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 0F 29 70 C8 45 33 E4");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CHostState_State_GameShutDown = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 56 48 83 EC 20 8B 05 ?? ?? ?? ?? 48 8B F1");
-#elif defined (GAMEDLL_S2)
-		p_CHostState_State_GameShutDown = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 8B 05 ?? ?? ?? ?? 33 FF 48 8B F1");
-#elif defined (GAMEDLL_S3)
-		p_CHostState_State_GameShutDown = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 48 8B D9 E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ??");
-#endif
-		p_HostState_ChangeLevelMP = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F9 48 8B F2 8B 0D ?? ?? ?? ??");
-
-		CHostState_FrameUpdate        = p_CHostState_FrameUpdate.RCast<void(*)(CHostState*, double, float)>(); /*48 89 5C 24 08 48 89 6C 24 20 F3 0F 11 54 24 18*/
-		CHostState_State_Run          = p_CHostState_State_Run.RCast<void(*)(HostStates_t*, double, float)>(); /*48 8B C4 48 89 58 10 48 89 70 18 48 89 78 20 55 41 54 41 55 41 56 41 57 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 0F 29 70 C8 45 33 E4*/
-		CHostState_State_GameShutDown = p_CHostState_State_GameShutDown.RCast<void(*)(CHostState* thisptr)>(); /*48 89 5C 24 ?? 57 48 83 EC 20 48 8B D9 E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ??*/
-		v_HostState_ChangeLevelMP     = p_HostState_ChangeLevelMP.RCast<void(*)(char const*, char const*)>();  /*48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 20 48 8B F9 48 8B F2 8B 0D ? ? ? ?*/
+		g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 20 F3 0F 11 54 24 18").GetPtr(CHostState__FrameUpdate);
+		g_GameDll.FindPatternSIMD("48 8B C4 48 89 58 10 48 89 70 18 48 89 78 20 55 41 54 41 55 41 56 41 57 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 0F 29 70 C8 45 33 E4").GetPtr(CHostState__State_Run);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 48 8B D9 E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ??").GetPtr(CHostState__State_GameShutDown);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F9 48 8B F2 8B 0D ?? ?? ?? ??").GetPtr(v_HostState_ChangeLevelMP);
 	}
 	virtual void GetVar(void) const
 	{
-		g_pHostState = p_CHostState_FrameUpdate.FindPattern("48 8D ?? ?? ?? ?? 01", CMemory::Direction::DOWN, 100).ResolveRelativeAddressSelf(0x3, 0x7).RCast<CHostState*>();
+		g_pHostState = CMemory(CHostState__FrameUpdate).FindPattern("48 8D ?? ?? ?? ?? 01", CMemory::Direction::DOWN, 100).ResolveRelativeAddressSelf(0x3, 0x7).RCast<CHostState*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/keys.h
+++ b/src/engine/keys.h
@@ -52,16 +52,16 @@ class VKeys : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Input_Event", reinterpret_cast<uintptr_t>(v_Input_Event));
-		LogFunAdr("Key_Event", reinterpret_cast<uintptr_t>(v_Key_Event));
-		LogVarAdr("g_pKeyInfo", reinterpret_cast<uintptr_t>(g_pKeyInfo));
-		LogVarAdr("g_pKeyEventTicks", reinterpret_cast<uintptr_t>(g_pKeyEventTicks));
-		LogVarAdr("g_nKeyEventCount", reinterpret_cast<uintptr_t>(g_nKeyEventCount));
+		LogFunAdr("Input_Event", v_Input_Event);
+		LogFunAdr("Key_Event", v_Key_Event);
+		LogVarAdr("g_pKeyInfo", g_pKeyInfo);
+		LogVarAdr("g_pKeyEventTicks", g_pKeyEventTicks);
+		LogVarAdr("g_nKeyEventCount", g_nKeyEventCount);
 	}
 	virtual void GetFun(void) const
 	{
-		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 56", v_Input_Event);
-		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 4C 63 41 08", v_Key_Event);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 56").GetPtr(v_Input_Event);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 4C 63 41 08").GetPtr(v_Key_Event);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/engine/matsys_interface.h
+++ b/src/engine/matsys_interface.h
@@ -2,17 +2,16 @@
 #define MATSYS_INTERFACE_H
 
 #include "public/imaterialsystem.h"
+#include "public/inputsystem/ButtonCode.h"
 
 //-------------------------------------------------------------------------
 // RUNTIME: GAME_CFG
 //-------------------------------------------------------------------------
-inline CMemory p_UpdateCurrentVideoConfig;
-inline CMemory p_UpdateMaterialSystemConfig;
-inline CMemory p_HandleConfigFile;
-inline CMemory p_ResetPreviousGameState;
-inline CMemory p_LoadPlayerConfig;
-
-inline bool(*v_UpdateCurrentVideoConfig)(MaterialSystem_Config_t* pConfig);
+inline void(*v_UpdateMaterialSystemConfig)(void);
+inline bool(*v_UpdateCurrentVideoConfig)(MaterialSystem_Config_t* const pConfig);
+inline bool(*v_HandleConfigFile)(const int configType); //(saved games cfg) 0 = local, 1 = profile.
+inline void(*v_ResetPreviousGameState)(void);
+inline void(*v_LoadPlayerConfig)(ButtonCode_t buttonCode, void* unused);
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -20,25 +19,19 @@ class VMatSys_Interface : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("UpdateMaterialSystemConfig", p_UpdateMaterialSystemConfig.GetPtr());
-		LogFunAdr("UpdateCurrentVideoConfig", p_UpdateCurrentVideoConfig.GetPtr());
-		LogFunAdr("HandleConfigFile", p_HandleConfigFile.GetPtr());
-		LogFunAdr("ResetPreviousGameState", p_ResetPreviousGameState.GetPtr());
-		LogFunAdr("LoadPlayerConfig", p_LoadPlayerConfig.GetPtr());
+		LogFunAdr("UpdateMaterialSystemConfig", v_UpdateMaterialSystemConfig);
+		LogFunAdr("UpdateCurrentVideoConfig", v_UpdateCurrentVideoConfig);
+		LogFunAdr("HandleConfigFile", v_HandleConfigFile);
+		LogFunAdr("ResetPreviousGameState", v_ResetPreviousGameState);
+		LogFunAdr("LoadPlayerConfig", v_LoadPlayerConfig);
 	}
 	virtual void GetFun(void) const
 	{
-		p_UpdateMaterialSystemConfig = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 80 3D ?? ?? ?? ?? ?? 0F 84 ?? ?? ?? ??");
-		p_UpdateCurrentVideoConfig = g_GameDll.FindPatternSIMD("40 55 ?? 41 56 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 4C 8B F1");
-		p_HandleConfigFile = g_GameDll.FindPatternSIMD("40 56 48 81 EC ?? ?? ?? ?? 8B F1");
-		p_ResetPreviousGameState = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 44 89 3D ?? ?? ?? ?? ?? 8B ?? 24 ??").ResolveRelativeAddressSelf(0x1, 0x5);
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1) || defined (GAMEDLL_S2)
-		p_LoadPlayerConfig = g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? 48 83 3D ?? ?? ?? ?? ?? 75 0C");
-#elif defined (GAMEDLL_S3)
-		p_LoadPlayerConfig = g_GameDll.FindPatternSIMD("E9 ?? ?? ?? ?? CC CC CC CC CC CC CC CC CC CC CC 40 53 48 83 EC 30 4D 8B D1").FollowNearCallSelf();
-#endif
-
-		v_UpdateCurrentVideoConfig = p_UpdateCurrentVideoConfig.RCast<bool (*)(MaterialSystem_Config_t*)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 80 3D ?? ?? ?? ?? ?? 0F 84 ?? ?? ?? ??").GetPtr(v_UpdateMaterialSystemConfig);
+		g_GameDll.FindPatternSIMD("40 55 ?? 41 56 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 4C 8B F1").GetPtr(v_UpdateCurrentVideoConfig);
+		g_GameDll.FindPatternSIMD("40 56 48 81 EC ?? ?? ?? ?? 8B F1").GetPtr(v_HandleConfigFile);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 44 89 3D ?? ?? ?? ?? ?? 8B ?? 24 ??").ResolveRelativeAddressSelf(0x1, 0x5).GetPtr(v_ResetPreviousGameState);
+		g_GameDll.FindPatternSIMD("E9 ?? ?? ?? ?? CC CC CC CC CC CC CC CC CC CC CC 40 53 48 83 EC 30 4D 8B D1").FollowNearCallSelf().GetPtr(v_LoadPlayerConfig);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/modelinfo.h
+++ b/src/engine/modelinfo.h
@@ -41,10 +41,10 @@ class VModelInfo : public IDetour
 	virtual void GetAdr(void) const
 	{
 #ifndef CLIENT_DLL
-		LogFunAdr("g_pModelInfoServer", reinterpret_cast<uintptr_t>(g_pModelInfoServer));
+		LogFunAdr("g_pModelInfoServer", g_pModelInfoServer);
 #endif // CLIENT_DLL
 #ifndef DEDICATED
-		LogFunAdr("g_pModelInfoClient", reinterpret_cast<uintptr_t>(g_pModelInfoClient));
+		LogFunAdr("g_pModelInfoClient", g_pModelInfoClient);
 #endif // DEDICATED
 	}
 	virtual void GetFun(void) const { }

--- a/src/engine/modelloader.h
+++ b/src/engine/modelloader.h
@@ -71,38 +71,19 @@ public:
 	char m_szLumpFilename[260];
 };
 
-inline CMemory p_CModelLoader__FindModel;
 inline void*(*CModelLoader__FindModel)(CModelLoader* loader, const char* pszModelName);
-
-inline CMemory p_CModelLoader__LoadModel;
 inline void(*CModelLoader__LoadModel)(CModelLoader* loader, model_t* model);
-
-inline CMemory p_CModelLoader__UnloadModel;
 inline uint64_t(*CModelLoader__UnloadModel)(CModelLoader* loader, model_t* model);
-
-inline CMemory p_CModelLoader__Studio_LoadModel;
 inline void*(*CModelLoader__Studio_LoadModel)(CModelLoader* loader);
-
-inline CMemory p_CModelLoader__Map_LoadModelGuts;
 inline uint64_t(*CModelLoader__Map_LoadModelGuts)(CModelLoader* loader, model_t* model);
-
-inline CMemory p_CModelLoader__Map_IsValid;
 inline bool(*CModelLoader__Map_IsValid)(CModelLoader* loader, const char* pszMapName);
-
-inline CMemory p_CMapLoadHelper__CMapLoadHelper;
 inline void(*CMapLoadHelper__CMapLoadHelper)(CMapLoadHelper * helper, int lumpToLoad);
 
-inline CMemory p_AddGameLump;
 inline void(*v_AddGameLump)(void);
-
-inline CMemory p_Map_LoadModel;
 inline void(*v_Map_LoadModel)(void);
 
-//inline CMemory p_GetSpriteInfo; // DEDICATED PATCH!
-//inline void*(*GetSpriteInfo)(const char* pName, bool bIsAVI, bool bIsBIK, int& nWidth, int& nHeight, int& nFrameCount, void* a7);
-
-//inline CMemory p_BuildSpriteLoadName; // DEDICATED PATCH!
-//inline void*(*BuildSpriteLoadName)(const char* pName, char* pOut, int outLen, bool& bIsAVI, bool& bIsBIK);
+inline void*(*v_GetSpriteInfo)(const char* pName, bool bIsAVI, bool bIsBIK, int& nWidth, int& nHeight, int& nFrameCount, void* a7);
+inline void*(*v_BuildSpriteLoadName)(const char* pName, char* pOut, int outLen, bool& bIsAVI, bool& bIsBIK);
 
 inline CModelLoader* g_pModelLoader;
 inline FileHandle_t* s_MapFileHandle;
@@ -114,69 +95,48 @@ class VModelLoader : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CModelLoader::FindModel", p_CModelLoader__FindModel.GetPtr());
-		LogFunAdr("CModelLoader::LoadModel", p_CModelLoader__LoadModel.GetPtr());
-		LogFunAdr("CModelLoader::UnloadModel", p_CModelLoader__UnloadModel.GetPtr());
-		LogFunAdr("CModelLoader::Map_LoadModelGuts", p_CModelLoader__Map_LoadModelGuts.GetPtr());
-		LogFunAdr("CModelLoader::Map_IsValid", p_CModelLoader__Map_IsValid.GetPtr());
-		LogFunAdr("CModelLoader::Studio_LoadModel", p_CModelLoader__Studio_LoadModel.GetPtr());
-		LogFunAdr("CMapLoadHelper::CMapLoadHelper", p_CMapLoadHelper__CMapLoadHelper.GetPtr());
-		LogFunAdr("AddGameLump", p_AddGameLump.GetPtr());
-		LogFunAdr("Map_LoadModel", p_Map_LoadModel.GetPtr());
-		//LogFunAdr("GetSpriteInfo", p_GetSpriteInfo.GetPtr());
-		//LogFunAdr("BuildSpriteLoadName", p_BuildSpriteLoadName.GetPtr());
-		LogVarAdr("g_pModelLoader", reinterpret_cast<uintptr_t>(g_pModelLoader));
-		LogVarAdr("s_MapFileHandle", reinterpret_cast<uintptr_t>(s_MapFileHandle));
-		LogVarAdr("s_MapHeader", reinterpret_cast<uintptr_t>(s_MapHeader));
-		LogVarAdr("s_szMapPathName", reinterpret_cast<uintptr_t>(s_szMapPathName));
+		LogFunAdr("CModelLoader::FindModel", CModelLoader__FindModel);
+		LogFunAdr("CModelLoader::LoadModel", CModelLoader__LoadModel);
+		LogFunAdr("CModelLoader::UnloadModel", CModelLoader__UnloadModel);
+		LogFunAdr("CModelLoader::Map_LoadModelGuts", CModelLoader__Map_LoadModelGuts);
+		LogFunAdr("CModelLoader::Map_IsValid", CModelLoader__Map_IsValid);
+		LogFunAdr("CModelLoader::Studio_LoadModel", CModelLoader__Studio_LoadModel);
+
+		LogFunAdr("CMapLoadHelper::CMapLoadHelper", CMapLoadHelper__CMapLoadHelper);
+
+		LogFunAdr("AddGameLump", v_AddGameLump);
+		LogFunAdr("Map_LoadModel", v_Map_LoadModel);
+		LogFunAdr("GetSpriteInfo", v_GetSpriteInfo);
+		LogFunAdr("BuildSpriteLoadName", v_BuildSpriteLoadName);
+
+		LogVarAdr("g_pModelLoader", g_pModelLoader);
+		LogVarAdr("s_MapFileHandle", s_MapFileHandle);
+		LogVarAdr("s_MapHeader", s_MapHeader);
+		LogVarAdr("s_szMapPathName", s_szMapPathName);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CModelLoader__FindModel         = g_GameDll.FindPatternSIMD("40 55 41 55 41 56 48 8D AC 24 ?? ?? ?? ??");
-		p_CModelLoader__LoadModel         = g_GameDll.FindPatternSIMD("40 53 57 41 56 48 81 EC ?? ?? ?? ?? 48 8B FA");
-		p_CModelLoader__UnloadModel       = g_GameDll.FindPatternSIMD("48 8B C4 48 89 58 18 55 48 81 EC ?? ?? ?? ?? 48 8B DA");
-		p_CModelLoader__Studio_LoadModel  = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 56 57 41 54 41 56 48 8D AC 24 ?? ?? ?? ??");
-		p_CModelLoader__Map_LoadModelGuts = g_GameDll.FindPatternSIMD("48 89 54 24 ?? 48 89 4C 24 ?? 55 53 41 54 41 55 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? FF 05 ?? ?? ?? ??"); // BSP.
-		p_CModelLoader__Map_IsValid       = g_GameDll.FindPatternSIMD("48 8B C4 53 48 81 EC ?? ?? ?? ?? 48 8B DA");
-		//p_GetSpriteInfo                   = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 54 41 55 41 56 41 57 48 83 EC 30 4C 8B AC 24 ?? ?? ?? ?? BE ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CModelLoader__FindModel         = g_GameDll.FindPatternSIMD("40 55 41 57 48 83 EC 48 80 3A 2A");
-		p_CModelLoader__LoadModel         = g_GameDll.FindPatternSIMD("40 53 57 41 57 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??");
-		p_CModelLoader__UnloadModel       = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 33 ED");
-		p_CModelLoader__Studio_LoadModel  = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 56 57 41 54 41 57 48 81 EC ?? ?? ?? ??");
-		p_CModelLoader__Map_LoadModelGuts = g_GameDll.FindPatternSIMD("48 89 54 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 57"); // BSP.
-		p_CModelLoader__Map_IsValid       = g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 48 8B DA 48 85 D2 0F 84 ?? ?? ?? ?? 80 3A ?? 0F 84 ?? ?? ?? ?? 4C 8B CA");
-		//p_GetSpriteInfo                   = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 54 41 55 41 56 41 57 48 83 EC 30 4C 8B BC 24 ?? ?? ?? ??");
-#endif
-		//p_BuildSpriteLoadName             = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 81 EC ?? ?? ?? ?? 4D 8B F1 48 8B F2");
+		g_GameDll.FindPatternSIMD("40 55 41 57 48 83 EC 48 80 3A 2A").GetPtr(CModelLoader__FindModel);
+		g_GameDll.FindPatternSIMD("40 53 57 41 57 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??").GetPtr(CModelLoader__LoadModel);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 33 ED").GetPtr(CModelLoader__UnloadModel);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 56 57 41 54 41 57 48 81 EC ?? ?? ?? ??").GetPtr(CModelLoader__Studio_LoadModel);
+		g_GameDll.FindPatternSIMD("48 89 54 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 57").GetPtr(CModelLoader__Map_LoadModelGuts); // BSP.
+		g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 48 8B DA 48 85 D2 0F 84 ?? ?? ?? ?? 80 3A ?? 0F 84 ?? ?? ?? ?? 4C 8B CA").GetPtr(CModelLoader__Map_IsValid);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 54 41 55 41 56 41 57 48 83 EC 30 4C 8B BC 24 ?? ?? ?? ??").GetPtr(v_GetSpriteInfo);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 81 EC ?? ?? ?? ?? 4D 8B F1 48 8B F2").GetPtr(v_BuildSpriteLoadName);
 		
-		p_CMapLoadHelper__CMapLoadHelper = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 7C 24 ?? 41 56 48 81 EC 60");
-		p_AddGameLump                    = g_GameDll.FindPatternSIMD("40 ?? 57 48 83 EC 48 33 ?? 48 8D");
-		p_Map_LoadModel                  = g_GameDll.FindPatternSIMD("48 83 EC 28 8B 05 ?? ?? ?? ?? FF C8");
-
-		CModelLoader__FindModel         = p_CModelLoader__FindModel.RCast<void* (*)(CModelLoader*, const char*)>();
-		CModelLoader__LoadModel         = p_CModelLoader__LoadModel.RCast<void(*)(CModelLoader*, model_t*)>();
-		CModelLoader__UnloadModel       = p_CModelLoader__UnloadModel.RCast<uint64_t(*)(CModelLoader*, model_t*)>();
-		CModelLoader__Studio_LoadModel  = p_CModelLoader__Studio_LoadModel.RCast<void* (*)(CModelLoader*)>();
-		CModelLoader__Map_LoadModelGuts = p_CModelLoader__Map_LoadModelGuts.RCast<uint64_t(*)(CModelLoader*, model_t* mod)>();
-		CModelLoader__Map_IsValid       = p_CModelLoader__Map_IsValid.RCast<bool(*)(CModelLoader*, const char*)>();
-
-		CMapLoadHelper__CMapLoadHelper  = p_CMapLoadHelper__CMapLoadHelper.RCast<void(*)(CMapLoadHelper*, int)>();
-		v_AddGameLump                   = p_AddGameLump.RCast<void(*)(void)>();
-		v_Map_LoadModel                 = p_Map_LoadModel.RCast<void(*)(void)>();
-
-		//GetSpriteInfo                   = p_GetSpriteInfo.RCast<void* (*)(const char*, bool, bool, int&, int&, int&, void*)>();
-		//BuildSpriteLoadName             = p_BuildSpriteLoadName.RCast<void* (*)(const char*, char*, int, bool&, bool&)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 7C 24 ?? 41 56 48 81 EC 60").GetPtr(CMapLoadHelper__CMapLoadHelper);
+		g_GameDll.FindPatternSIMD("40 ?? 57 48 83 EC 48 33 ?? 48 8D").GetPtr(v_AddGameLump);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 8B 05 ?? ?? ?? ?? FF C8").GetPtr(v_Map_LoadModel);
 	}
 	virtual void GetVar(void) const
 	{
 		g_pModelLoader = g_GameDll.FindPatternSIMD(
 			"48 89 4C 24 ?? 53 55 56 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ??").FindPatternSelf("48 ?? 0D", CMemory::Direction::DOWN).ResolveRelativeAddressSelf(3, 7).RCast<CModelLoader*>();
 
-		s_MapFileHandle = p_Map_LoadModel.FindPattern("48 8B").ResolveRelativeAddressSelf(0x3, 0x7).RCast<FileHandle_t*>();
-		s_MapHeader = p_Map_LoadModel.FindPattern("48 8D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<BSPHeader_t*>();
-		s_szMapPathName = p_CMapLoadHelper__CMapLoadHelper.FindPattern("4C 8D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<char*>();
+		s_MapFileHandle = CMemory(v_Map_LoadModel).FindPattern("48 8B").ResolveRelativeAddressSelf(0x3, 0x7).RCast<FileHandle_t*>();
+		s_MapHeader = CMemory(v_Map_LoadModel).FindPattern("48 8D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<BSPHeader_t*>();
+		s_szMapPathName = CMemory(CMapLoadHelper__CMapLoadHelper).FindPattern("4C 8D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<char*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/modelloader.h
+++ b/src/engine/modelloader.h
@@ -82,8 +82,10 @@ inline void(*CMapLoadHelper__CMapLoadHelper)(CMapLoadHelper * helper, int lumpTo
 inline void(*v_AddGameLump)(void);
 inline void(*v_Map_LoadModel)(void);
 
+#ifndef DEDICATED
 inline void*(*v_GetSpriteInfo)(const char* pName, bool bIsAVI, bool bIsBIK, int& nWidth, int& nHeight, int& nFrameCount, void* a7);
 inline void*(*v_BuildSpriteLoadName)(const char* pName, char* pOut, int outLen, bool& bIsAVI, bool& bIsBIK);
+#endif // !DEDICATED
 
 inline CModelLoader* g_pModelLoader;
 inline FileHandle_t* s_MapFileHandle;
@@ -106,8 +108,11 @@ class VModelLoader : public IDetour
 
 		LogFunAdr("AddGameLump", v_AddGameLump);
 		LogFunAdr("Map_LoadModel", v_Map_LoadModel);
+
+#ifndef DEDICATED
 		LogFunAdr("GetSpriteInfo", v_GetSpriteInfo);
 		LogFunAdr("BuildSpriteLoadName", v_BuildSpriteLoadName);
+#endif // !DEDICATED
 
 		LogVarAdr("g_pModelLoader", g_pModelLoader);
 		LogVarAdr("s_MapFileHandle", s_MapFileHandle);
@@ -122,8 +127,11 @@ class VModelLoader : public IDetour
 		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 56 57 41 54 41 57 48 81 EC ?? ?? ?? ??").GetPtr(CModelLoader__Studio_LoadModel);
 		g_GameDll.FindPatternSIMD("48 89 54 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 57").GetPtr(CModelLoader__Map_LoadModelGuts); // BSP.
 		g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 48 8B DA 48 85 D2 0F 84 ?? ?? ?? ?? 80 3A ?? 0F 84 ?? ?? ?? ?? 4C 8B CA").GetPtr(CModelLoader__Map_IsValid);
+
+#ifndef DEDICATED
 		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 54 41 55 41 56 41 57 48 83 EC 30 4C 8B BC 24 ?? ?? ?? ??").GetPtr(v_GetSpriteInfo);
 		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 81 EC ?? ?? ?? ?? 4D 8B F1 48 8B F2").GetPtr(v_BuildSpriteLoadName);
+#endif // !DEDICATED
 		
 		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 7C 24 ?? 41 56 48 81 EC 60").GetPtr(CMapLoadHelper__CMapLoadHelper);
 		g_GameDll.FindPatternSIMD("40 ?? 57 48 83 EC 48 33 ?? 48 8D").GetPtr(v_AddGameLump);

--- a/src/engine/net.h
+++ b/src/engine/net.h
@@ -19,25 +19,12 @@ constexpr unsigned int AES_128_B64_ENCODED_SIZE = 24;
 constexpr const char* DEFAULT_NET_ENCRYPTION_KEY = "WDNWLmJYQ2ZlM0VoTid3Yg==";
 
 /* ==== CNETCHAN ======================================================================================================================================================== */
-inline CMemory p_NET_Init;
 inline void*(*v_NET_Init)(bool bDeveloper);
-
-inline CMemory p_NET_SetKey;
 inline void(*v_NET_SetKey)(netkey_t* pKey, const char* szHash);
-
-inline CMemory p_NET_Config;
 inline void(*v_NET_Config)(void);
-
-inline CMemory p_NET_ReceiveDatagram;
 inline bool(*v_NET_ReceiveDatagram)(int iSocket, netpacket_s* pInpacket, bool bRaw);
-
-inline CMemory p_NET_SendDatagram;
 inline int(*v_NET_SendDatagram)(SOCKET s, void* pPayload, int iLenght, netadr_t* pAdr, bool bEncrypted);
-
-inline CMemory p_NET_Decompress;
 inline unsigned int(*v_NET_Decompress)(CLZSS* lzss, unsigned char* pInput, unsigned char* pOutput, unsigned int unBufSize);
-
-inline CMemory p_NET_PrintFunc;
 inline void(*v_NET_PrintFunc)(const char* fmt, ...);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -61,44 +48,32 @@ class VNet : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("NET_Init", p_NET_Init.GetPtr());
-		LogFunAdr("NET_Config", p_NET_Config.GetPtr());
-		LogFunAdr("NET_SetKey", p_NET_SetKey.GetPtr());
-		LogFunAdr("NET_ReceiveDatagram", p_NET_ReceiveDatagram.GetPtr());
-		LogFunAdr("NET_SendDatagram", p_NET_SendDatagram.GetPtr());
-		LogFunAdr("NET_Decompress", p_NET_Decompress.GetPtr());
-		LogFunAdr("NET_PrintFunc", p_NET_PrintFunc.GetPtr());
-		LogVarAdr("g_NetAdr", reinterpret_cast<uintptr_t>(g_pNetAdr));
-		LogVarAdr("g_NetKey", reinterpret_cast<uintptr_t>(g_pNetKey));
-		LogVarAdr("g_NetTime", reinterpret_cast<uintptr_t>(g_pNetTime));
+		LogFunAdr("NET_Init", v_NET_Init);
+		LogFunAdr("NET_Config", v_NET_Config);
+		LogFunAdr("NET_SetKey", v_NET_SetKey);
+		LogFunAdr("NET_ReceiveDatagram", v_NET_ReceiveDatagram);
+		LogFunAdr("NET_SendDatagram", v_NET_SendDatagram);
+		LogFunAdr("NET_Decompress", v_NET_Decompress);
+		LogFunAdr("NET_PrintFunc", v_NET_PrintFunc);
+		LogVarAdr("g_NetAdr", g_pNetAdr);
+		LogVarAdr("g_NetKey", g_pNetKey);
+		LogVarAdr("g_NetTime", g_pNetTime);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1) || defined (GAMEDLL_S2)
-		p_NET_Init     = g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 48 89 7C 24 20 41 54 41 56 41 57 48 81 EC C0 01 ??");
-#elif defined (GAMEDLL_S3)
-		p_NET_Init     = g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 48 89 7C 24 20 41 54 41 56 41 57 48 81 EC F0 01 ??");
-#endif
-		p_NET_Config          = g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? E8 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 0F 57 C0");
-		p_NET_SetKey          = g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B F9 41 B8");
-		p_NET_ReceiveDatagram = g_GameDll.FindPatternSIMD("48 89 74 24 18 48 89 7C 24 20 55 41 54 41 55 41 56 41 57 48 8D AC 24 50 EB");
-		p_NET_SendDatagram    = g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 41 56 41 57 48 81 EC ?? 05 ?? ??");
-		p_NET_Decompress      = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 41 56 45 33 F6");
-		p_NET_PrintFunc       = g_GameDll.FindPatternSIMD("48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 C3 48");
-
-		v_NET_Init            = p_NET_Init.RCast<void* (*)(bool)>();                                        /*48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 48 89 7C 24 20 41 54 41 56 41 57 48 81 EC F0 01 00*/
-		v_NET_Config          = p_NET_Config.RCast<void (*)(void)>();
-		v_NET_SetKey          = p_NET_SetKey.RCast<void (*)(netkey_t*, const char*)>();                     /*48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B F9 41 B8*/
-		v_NET_ReceiveDatagram = p_NET_ReceiveDatagram.RCast<bool (*)(int, netpacket_s*, bool)>();           /*E8 ?? ?? ?? ?? 84 C0 75 35 48 8B D3*/
-		v_NET_SendDatagram    = p_NET_SendDatagram.RCast<int (*)(SOCKET, void*, int, netadr_t*, bool)>();   /*48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 41 56 41 57 48 81 EC ?? 05 00 00*/
-		v_NET_Decompress      = p_NET_Decompress.RCast<unsigned int (*)(CLZSS*, unsigned char*, unsigned char*, unsigned int)>();
-		v_NET_PrintFunc       = p_NET_PrintFunc.RCast<void(*)(const char*, ...)>();                         /*48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 C3 48*/
+		g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 48 89 7C 24 20 41 54 41 56 41 57 48 81 EC F0 01 ??").GetPtr(v_NET_Init);
+		g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? E8 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 0F 57 C0").GetPtr(v_NET_Config);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B F9 41 B8").GetPtr(v_NET_SetKey);
+		g_GameDll.FindPatternSIMD("48 89 74 24 18 48 89 7C 24 20 55 41 54 41 55 41 56 41 57 48 8D AC 24 50 EB").GetPtr(v_NET_ReceiveDatagram);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 41 56 41 57 48 81 EC ?? 05 ?? ??").GetPtr(v_NET_SendDatagram);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 41 56 45 33 F6").GetPtr(v_NET_Decompress);
+		g_GameDll.FindPatternSIMD("48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 C3 48").GetPtr(v_NET_PrintFunc);
 	}
 	virtual void GetVar(void) const
 	{
 		g_pNetAdr = g_GameDll.FindPatternSIMD("C7 05 ?? ?? ?? ?? ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 66 89 05 ?? ?? ?? ?? 88 05 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 33 C0").ResolveRelativeAddressSelf(0x2, 0xA).RCast<netadr_t*>();
 		g_pNetKey = g_GameDll.FindString("client:NetEncryption_NewKey").FindPatternSelf("48 8D ?? ?? ?? ?? ?? 48 3B", CMemory::Direction::UP, 300).ResolveRelativeAddressSelf(0x3, 0x7).RCast<netkey_t*>();
-		g_pNetTime = p_NET_Init.Offset(0xA).FindPatternSelf("F2 0F").ResolveRelativeAddressSelf(0x4, 0x8).RCast<double*>();
+		g_pNetTime = CMemory(v_NET_Init).Offset(0xA).FindPatternSelf("F2 0F").ResolveRelativeAddressSelf(0x4, 0x8).RCast<double*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/net_chan.cpp
+++ b/src/engine/net_chan.cpp
@@ -324,7 +324,7 @@ void CNetChan::_FlowNewPacket(CNetChan* pChan, int flow, int outSeqNr, int inSeq
 //-----------------------------------------------------------------------------
 void CNetChan::_Shutdown(CNetChan* pChan, const char* szReason, uint8_t bBadRep, bool bRemoveNow)
 {
-	v_NetChan_Shutdown(pChan, szReason, bBadRep, bRemoveNow);
+	CNetChan__Shutdown(pChan, szReason, bBadRep, bRemoveNow);
 }
 
 //-----------------------------------------------------------------------------
@@ -575,7 +575,7 @@ bool CNetChan::HasPendingReliableData(void)
 ///////////////////////////////////////////////////////////////////////////////
 void VNetChan::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_NetChan_Shutdown, &CNetChan::_Shutdown, bAttach);
-	DetourSetup(&v_NetChan_FlowNewPacket, &CNetChan::_FlowNewPacket, bAttach);
-	DetourSetup(&v_NetChan_ProcessMessages, &CNetChan::_ProcessMessages, bAttach);
+	DetourSetup(&CNetChan__Shutdown, &CNetChan::_Shutdown, bAttach);
+	DetourSetup(&CNetChan__FlowNewPacket, &CNetChan::_FlowNewPacket, bAttach);
+	DetourSetup(&CNetChan__ProcessMessages, &CNetChan::_ProcessMessages, bAttach);
 }

--- a/src/engine/networkstringtable.cpp
+++ b/src/engine/networkstringtable.cpp
@@ -137,12 +137,10 @@ void CNetworkStringTableContainer::WriteUpdateMessage(CNetworkStringTableContain
 		}
 	}
 #endif // !CLIENT_DLL
-	v_CNetworkStringTableContainer__WriteUpdateMessage(thisp, pClient, nTickAck, pMsg);
+	CNetworkStringTableContainer__WriteUpdateMessage(thisp, pClient, nTickAck, pMsg);
 }
 
 void VNetworkStringTableContainer::Detour(const bool bAttach) const
 {
-#if !defined (CLIENT_DLL) && !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) // TODO: doesn't work properly for S0/S1 yet.
-	DetourSetup(&v_CNetworkStringTableContainer__WriteUpdateMessage, &CNetworkStringTableContainer::WriteUpdateMessage, bAttach);
-#endif // !CLIENT_DLL && !GAMEDLL_S0 && !GAMEDLL_S1
+	DetourSetup(&CNetworkStringTableContainer__WriteUpdateMessage, &CNetworkStringTableContainer::WriteUpdateMessage, bAttach);
 }

--- a/src/engine/networkstringtable.h
+++ b/src/engine/networkstringtable.h
@@ -54,24 +54,18 @@ private:
 	CUtlVector < CNetworkStringTable* > m_Tables; // the string tables
 };
 
-inline CMemory p_CNetworkStringTableContainer__WriteUpdateMessage;
-inline void (*v_CNetworkStringTableContainer__WriteUpdateMessage)(CNetworkStringTableContainer* thisp, CClient* client, unsigned int tick_ack, bf_write* msg);
+inline void (*CNetworkStringTableContainer__WriteUpdateMessage)(CNetworkStringTableContainer* thisp, CClient* client, unsigned int tick_ack, bf_write* msg);
 
 class VNetworkStringTableContainer : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CNetworkStringTableContainer::WriteUpdateMessage", p_CNetworkStringTableContainer__WriteUpdateMessage.GetPtr());
+		LogFunAdr("CNetworkStringTableContainer::WriteUpdateMessage", CNetworkStringTableContainer__WriteUpdateMessage);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CNetworkStringTableContainer__WriteUpdateMessage = g_GameDll.FindPatternSIMD("48 89 74 24 ?? 55 57 41 54 41 55 41 56 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CNetworkStringTableContainer__WriteUpdateMessage = g_GameDll.FindPatternSIMD("48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 45 33 ED");
-#endif
-		v_CNetworkStringTableContainer__WriteUpdateMessage =
-			p_CNetworkStringTableContainer__WriteUpdateMessage.RCast<void (*)(CNetworkStringTableContainer*, CClient*, unsigned int, bf_write*)>();
+		g_GameDll.FindPatternSIMD("48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 45 33 ED")
+			.GetPtr(CNetworkStringTableContainer__WriteUpdateMessage);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/server/datablock_sender.cpp
+++ b/src/engine/server/datablock_sender.cpp
@@ -11,7 +11,7 @@
 //-----------------------------------------------------------------------------
 ServerDataBlockSender::~ServerDataBlockSender()
 {
-	v_ServerDataBlockSender__Destructor(this);
+	ServerDataBlockSender__Destructor(this);
 }
 
 //-----------------------------------------------------------------------------
@@ -20,7 +20,7 @@ ServerDataBlockSender::~ServerDataBlockSender()
 void ServerDataBlockSender::SendDataBlock(short unk0, int unk1,
     short unk2, short unk3, const void* buffer, int length)
 {
-	v_ServerDataBlockSender__SendDataBlock(this, unk0, unk1,
+	ServerDataBlockSender__SendDataBlock(this, unk0, unk1,
         unk2, unk3, buffer, length);
 }
 

--- a/src/engine/server/datablock_sender.h
+++ b/src/engine/server/datablock_sender.h
@@ -52,11 +52,8 @@ struct ServerDataBlock
 	ServerDataBlockSender sender;
 };
 
-inline CMemory p_ServerDataBlockSender__Destructor;
-inline void*(*v_ServerDataBlockSender__Destructor)(ServerDataBlockSender* thisptr);
-
-inline CMemory p_ServerDataBlockSender__SendDataBlock;
-inline void* (*v_ServerDataBlockSender__SendDataBlock)(ServerDataBlockSender* thisptr,
+inline void*(*ServerDataBlockSender__Destructor)(ServerDataBlockSender* thisptr);
+inline void* (*ServerDataBlockSender__SendDataBlock)(ServerDataBlockSender* thisptr,
 	short unk0, int unk1, short unk2, short unk3, const void* buffer, int length);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -64,19 +61,16 @@ class VServerDataBlockSender : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("ServerDataBlockSender::~ServerDataBlockSender", p_ServerDataBlockSender__Destructor.GetPtr());
-		LogFunAdr("ServerDataBlockSender::SendDataBlock", p_ServerDataBlockSender__SendDataBlock.GetPtr());
+		LogFunAdr("ServerDataBlockSender::~ServerDataBlockSender", ServerDataBlockSender__Destructor);
+		LogFunAdr("ServerDataBlockSender::SendDataBlock", ServerDataBlockSender__SendDataBlock);
 	}
 	virtual void GetFun(void) const
 	{
-		p_ServerDataBlockSender__Destructor = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 8B DA 48 8B F9 E8 ?? ?? ?? ?? F6 C3 01 74"
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 8B DA 48 8B F9 E8 ?? ?? ?? ?? F6 C3 01 74"
 			" 0D BA ?? ?? ?? ?? 48 8B CF E8 ?? ?? ?? ?? 48 8B C7 48 8B 5C 24 ?? 48 83 C4 20 5F C3 CC CC CC CC CC CC CC CC CC CC CC CC 48 89 5C 24"
-			" ?? 48 89 74 24 ?? 57 48 83 EC 20 33 F6 66 C7 81 ?? ?? ?? ?? ?? ??");
-		v_ServerDataBlockSender__Destructor = p_ServerDataBlockSender__Destructor.RCast<void* (*)(ServerDataBlockSender*)>();
+			" ?? 48 89 74 24 ?? 57 48 83 EC 20 33 F6 66 C7 81 ?? ?? ?? ?? ?? ??").GetPtr(ServerDataBlockSender__Destructor);
 
-		p_ServerDataBlockSender__SendDataBlock = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 99 ?? ?? ?? ??");
-		v_ServerDataBlockSender__SendDataBlock = p_ServerDataBlockSender__SendDataBlock.RCast<void* (*)(ServerDataBlockSender*,
-			short, int, short, short, const void*, int)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 99 ?? ?? ?? ??").GetPtr(ServerDataBlockSender__SendDataBlock);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/server/persistence.cpp
+++ b/src/engine/server/persistence.cpp
@@ -2,17 +2,6 @@
 #include "vengineserver_impl.h"
 #include "persistence.h"
 
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-bool Persistence_SetXP(int a1, int* a2)
-{
-	g_pEngineServer->PersistenceAvailable(nullptr, a1);
-	return v_Persistence_SetXP(a1, a2);
-}
-#endif
-
 void VPersistence::Detour(const bool bAttach) const
 {
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-	Setup(&v_Persistence_SetXP, &Persistence_SetXP, bAttach);
-#endif
 }

--- a/src/engine/server/persistence.h
+++ b/src/engine/server/persistence.h
@@ -1,27 +1,11 @@
 #ifndef PERSISTENCE_H
 #define PERSISTENCE_H
 
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-inline CMemory p_Persistence_SetXP;
-inline bool(*v_Persistence_SetXP)(int a1, int* a2);
-#endif
-
 ///////////////////////////////////////////////////////////////////////////////
 class VPersistence : public IDetour
 {
-	virtual void GetAdr(void) const
-	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		LogFunAdr("Persistence_SetXP", p_Persistence_SetXP.GetPtr());
-#endif
-	}
-	virtual void GetFun(void) const
-	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_Persistence_SetXP = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 33 FF 48 8B F2 3B 0D ?? ?? ?? ??");
-		v_Persistence_SetXP = p_Persistence_SetXP.RCast<bool (*)(int a1, int* a2)>(); /*48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 33 FF 48 8B F2 3B 0D ?? ?? ?? ??*/
-#endif
-	}
+	virtual void GetAdr(void) const { }
+	virtual void GetFun(void) const { }
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -88,7 +88,7 @@ int CServer::GetNumClients(void) const
 //---------------------------------------------------------------------------------
 void CServer::RejectConnection(int iSocket, netadr_t* pNetAdr, const char* szMessage)
 {
-	v_CServer_RejectConnection(this, iSocket, pNetAdr, szMessage);
+	CServer__RejectConnection(this, iSocket, pNetAdr, szMessage);
 }
 
 //---------------------------------------------------------------------------------
@@ -156,7 +156,7 @@ CClient* CServer::ConnectClient(CServer* pServer, user_creds_s* pChallenge)
 		}
 	}
 
-	CClient* pClient = v_CServer_ConnectClient(pServer, pChallenge);
+	CClient* pClient = CServer__ConnectClient(pServer, pChallenge);
 
 	for (auto& callback : !g_pPluginSystem->GetConnectClientCallbacks())
 	{
@@ -187,7 +187,7 @@ CClient* CServer::ConnectClient(CServer* pServer, user_creds_s* pChallenge)
 //---------------------------------------------------------------------------------
 void CServer::BroadcastMessage(CNetMessage* const msg, const bool onlyActive, const bool reliable)
 {
-	v_CServer_BroadcastMessage(this, msg, onlyActive, reliable);
+	CServer__BroadcastMessage(this, msg, onlyActive, reliable);
 }
 
 //---------------------------------------------------------------------------------
@@ -198,7 +198,7 @@ void CServer::BroadcastMessage(CNetMessage* const msg, const bool onlyActive, co
 //---------------------------------------------------------------------------------
 void CServer::FrameJob(double flFrameTime, bool bRunOverlays, bool bUpdateFrame)
 {
-	v_CServer_FrameJob(flFrameTime, bRunOverlays, bUpdateFrame);
+	CServer__FrameJob(flFrameTime, bRunOverlays, bUpdateFrame);
 }
 
 //---------------------------------------------------------------------------------
@@ -207,17 +207,15 @@ void CServer::FrameJob(double flFrameTime, bool bRunOverlays, bool bUpdateFrame)
 //---------------------------------------------------------------------------------
 void CServer::RunFrame(CServer* pServer)
 {
-	v_CServer_RunFrame(pServer);
+	CServer__RunFrame(pServer);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 void VServer::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_CServer_RunFrame, &CServer::RunFrame, bAttach);
-#if	defined(GAMEDLL_S3)
-	DetourSetup(&v_CServer_ConnectClient, &CServer::ConnectClient, bAttach);
-	DetourSetup(&v_CServer_FrameJob, &CServer::FrameJob, bAttach);
-#endif // !TODO: S1 and S2 CServer functions require work.
+	DetourSetup(&CServer__RunFrame, &CServer::RunFrame, bAttach);
+	DetourSetup(&CServer__ConnectClient, &CServer::ConnectClient, bAttach);
+	DetourSetup(&CServer__FrameJob, &CServer::FrameJob, bAttach);
 }
 
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -107,30 +107,16 @@ private:
 	// structure in the engine.
 	static CClientExtended sm_ClientsExtended[MAX_PLAYERS];
 };
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-// !TODO: check if struct size is correct for S1!
-static_assert(sizeof(CServer) == 0x25220C0);
-#else
 static_assert(sizeof(CServer) == 0x25264C0);
-#endif
 
 extern CServer* g_pServer;
 
 /* ==== CSERVER ========================================================================================================================================================= */
-inline CMemory p_CServer_FrameJob;
-inline void(*v_CServer_FrameJob)(double flFrameTime, bool bRunOverlays, bool bUpdateFrame);
-
-inline CMemory p_CServer_RunFrame;
-inline void(*v_CServer_RunFrame)(CServer* pServer);
-
-inline CMemory p_CServer_ConnectClient;
-inline CClient*(*v_CServer_ConnectClient)(CServer* pServer, user_creds_s* pCreds);
-
-inline CMemory p_CServer_RejectConnection;
-inline void*(*v_CServer_RejectConnection)(CServer* pServer, int iSocket, netadr_t* pNetAdr, const char* szMessage);
-
-inline CMemory p_CServer_BroadcastMessage;
-inline void (*v_CServer_BroadcastMessage)(CServer* pServer, CNetMessage* const msg, const bool onlyActive, const bool reliable);
+inline void(*CServer__FrameJob)(double flFrameTime, bool bRunOverlays, bool bUpdateFrame);
+inline void(*CServer__RunFrame)(CServer* pServer);
+inline CClient*(*CServer__ConnectClient)(CServer* pServer, user_creds_s* pCreds);
+inline void*(*CServer__RejectConnection)(CServer* pServer, int iSocket, netadr_t* pNetAdr, const char* szMessage);
+inline void (*CServer__BroadcastMessage)(CServer* pServer, CNetMessage* const msg, const bool onlyActive, const bool reliable);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VServer : public IDetour
@@ -138,39 +124,23 @@ class VServer : public IDetour
 	virtual void GetAdr(void) const
 	{
 #ifndef CLIENT_DLL
-		LogFunAdr("CServer::FrameJob", p_CServer_FrameJob.GetPtr());
-		LogFunAdr("CServer::RunFrame", p_CServer_RunFrame.GetPtr());
-		LogFunAdr("CServer::ConnectClient", p_CServer_ConnectClient.GetPtr());
-		LogFunAdr("CServer::RejectConnection", p_CServer_RejectConnection.GetPtr());
-		LogFunAdr("CServer::BroadcastMessage", p_CServer_BroadcastMessage.GetPtr());
-		LogVarAdr("g_Server", reinterpret_cast<uintptr_t>(g_pServer));
+		LogFunAdr("CServer::FrameJob", CServer__FrameJob);
+		LogFunAdr("CServer::RunFrame", CServer__RunFrame);
+		LogFunAdr("CServer::ConnectClient", CServer__ConnectClient);
+		LogFunAdr("CServer::RejectConnection", CServer__RejectConnection);
+		LogFunAdr("CServer::BroadcastMessage", CServer__BroadcastMessage);
+		LogVarAdr("g_Server", g_pServer);
 #endif // !CLIENT_DLL
 	}
 	virtual void GetFun(void) const
 	{
 #ifndef CLIENT_DLL
-		p_CServer_FrameJob = g_GameDll.FindPatternSIMD("48 89 6C 24 ?? 56 41 54 41 56");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CServer_ConnectClient = g_GameDll.FindPatternSIMD("44 89 44 24 ?? 55 56 57 48 8D AC 24 ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2)
-		p_CServer_ConnectClient = g_GameDll.FindPatternSIMD("44 89 44 24 ?? 56 57 48 81 EC ?? ?? ?? ??");
-#else
-		p_CServer_ConnectClient = g_GameDll.FindPatternSIMD("40 55 57 41 55 41 57 48 8D AC 24 ?? ?? ?? ??");
-#endif
+		g_GameDll.FindPatternSIMD("48 89 6C 24 ?? 56 41 54 41 56").GetPtr(CServer__FrameJob);
+		g_GameDll.FindPatternSIMD("40 55 57 41 55 41 57 48 8D AC 24 ?? ?? ?? ??").GetPtr(CServer__ConnectClient);
 
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CServer_RunFrame = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 56 57 48 81 EC ?? ?? ?? ?? 0F 29 B4 24 ?? ?? ?? ??");
-#else
-		p_CServer_RunFrame = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 88 05 ?? ?? ?? ??").FollowNearCallSelf();
-#endif
-		p_CServer_RejectConnection = g_GameDll.FindPatternSIMD("4C 89 4C 24 ?? 53 55 56 57 48 81 EC ?? ?? ?? ?? 49 8B D9");
-		p_CServer_BroadcastMessage = g_GameDll.FindPatternSIMD("4C 8B DC 45 88 43 18 56");
-
-		v_CServer_FrameJob = p_CServer_FrameJob.RCast<void (*)(double, bool, bool)>();                                       /*48 89 6C 24 ?? 56 41 54 41 56*/
-		v_CServer_RunFrame = p_CServer_RunFrame.RCast<void (*)(CServer*)>();
-		v_CServer_ConnectClient = p_CServer_ConnectClient.RCast<CClient* (*)(CServer*, user_creds_s*)>();                     /*40 55 57 41 55 41 57 48 8D AC 24 ?? ?? ?? ??*/
-		v_CServer_RejectConnection = p_CServer_RejectConnection.RCast<void* (*)(CServer*, int, netadr_t*, const char*)>();   /*4C 89 4C 24 ?? 53 55 56 57 48 81 EC ?? ?? ?? ?? 49 8B D9*/
-		v_CServer_BroadcastMessage = p_CServer_BroadcastMessage.RCast<void (*) (CServer*, CNetMessage* const, const bool, const bool)>();
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 88 05 ?? ?? ?? ??").FollowNearCallSelf().GetPtr(CServer__RunFrame);
+		g_GameDll.FindPatternSIMD("4C 89 4C 24 ?? 53 55 56 57 48 81 EC ?? ?? ?? ?? 49 8B D9").GetPtr(CServer__RejectConnection);
+		g_GameDll.FindPatternSIMD("4C 8B DC 45 88 43 18 56").GetPtr(CServer__BroadcastMessage);
 #endif // !CLIENT_DLL
 	}
 	virtual void GetVar(void) const

--- a/src/engine/server/sv_main.h
+++ b/src/engine/server/sv_main.h
@@ -8,22 +8,11 @@ class CClient;
 class CClient;
 
 /* ==== SV_MAIN ======================================================================================================================================================= */
-inline CMemory p_SV_InitGameDLL;
-inline void(*v_SV_InitGameDLL)(void);
-
-inline CMemory p_SV_ShutdownGameDLL;
-inline void(*v_SV_ShutdownGameDLL)(void);
-
-inline CMemory p_SV_ActivateServer;
-inline bool(*v_SV_ActivateServer)(void);
-
-inline CMemory p_SV_CreateBaseline;
-inline bool(*v_SV_CreateBaseline)(void);
-
-inline CMemory p_CGameServer__SpawnServer;
 inline bool(*CGameServer__SpawnServer)(void* thisptr, const char* pszMapName, const char* pszMapGroupName);
-
-inline CMemory p_SV_BroadcastVoiceData;
+inline void(*v_SV_InitGameDLL)(void);
+inline void(*v_SV_ShutdownGameDLL)(void);
+inline bool(*v_SV_ActivateServer)(void);
+inline bool(*v_SV_CreateBaseline)(void);
 inline void(*v_SV_BroadcastVoiceData)(CClient* cl, int nBytes, char* data);
 
 inline bool* s_bIsDedicated = nullptr;
@@ -49,34 +38,22 @@ class HSV_Main : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CGameServer::SpawnServer", p_CGameServer__SpawnServer.GetPtr());
-		LogFunAdr("SV_InitGameDLL", p_SV_InitGameDLL.GetPtr());
-		LogFunAdr("SV_ShutdownGameDLL", p_SV_ShutdownGameDLL.GetPtr());
-		LogFunAdr("SV_ActivateServer", p_SV_ActivateServer.GetPtr());
-		LogFunAdr("SV_CreateBaseline", p_SV_CreateBaseline.GetPtr());
-		LogFunAdr("SV_BroadcastVoiceData", p_SV_BroadcastVoiceData.GetPtr());
-		LogVarAdr("s_bIsDedicated", reinterpret_cast<uintptr_t>(s_bIsDedicated));
+		LogFunAdr("CGameServer::SpawnServer", CGameServer__SpawnServer);
+		LogFunAdr("SV_InitGameDLL", v_SV_InitGameDLL);
+		LogFunAdr("SV_ShutdownGameDLL", v_SV_ShutdownGameDLL);
+		LogFunAdr("SV_ActivateServer", v_SV_ActivateServer);
+		LogFunAdr("SV_CreateBaseline", v_SV_CreateBaseline);
+		LogFunAdr("SV_BroadcastVoiceData", v_SV_BroadcastVoiceData);
+		LogVarAdr("s_bIsDedicated", s_bIsDedicated);
 	}
 	virtual void GetFun(void) const
 	{
-		p_SV_InitGameDLL     = g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? E8 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 0F 85 ?? ?? ?? ??");
-		p_SV_ShutdownGameDLL = g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 0F 84 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48");
-		p_SV_ActivateServer  = g_GameDll.FindPatternSIMD("48 8B C4 56 48 81 EC ?? ?? ?? ?? 48 89 ?? ?? 48 8D");
-		p_SV_CreateBaseline  = g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 0D ?? ?? ?? ?? 48 85 C9 75 07");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CGameServer__SpawnServer = g_GameDll.FindPatternSIMD("40 53 55 56 57 41 55 41 56 41 57 48 81 EC ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CGameServer__SpawnServer = g_GameDll.FindPatternSIMD("48 8B C4 53 55 56 57 41 54 41 55 41 57");
-#endif
-		p_SV_BroadcastVoiceData = g_GameDll.FindPatternSIMD("4C 8B DC 56 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ??");
-
-		v_SV_InitGameDLL           = p_SV_InitGameDLL.RCast<void(*)(void)>();
-		v_SV_ShutdownGameDLL       = p_SV_ShutdownGameDLL.RCast<void(*)(void)>();
-		v_SV_ActivateServer        = p_SV_ActivateServer.RCast<bool(*)(void)>();
-		v_SV_CreateBaseline        = p_SV_CreateBaseline.RCast<bool(*)(void)>();
-		v_SV_BroadcastVoiceData = p_SV_BroadcastVoiceData.RCast<void(*)(CClient* cl, int nBytes, char* data)>();
-
-		CGameServer__SpawnServer = p_CGameServer__SpawnServer.RCast<bool(*)(void*, const char*, const char*)>();
+		g_GameDll.FindPatternSIMD("48 8B C4 53 55 56 57 41 54 41 55 41 57").GetPtr(CGameServer__SpawnServer);
+		g_GameDll.FindPatternSIMD("48 81 EC ?? ?? ?? ?? E8 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 0F 85 ?? ?? ?? ??").GetPtr(v_SV_InitGameDLL);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 0F 84 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48").GetPtr(v_SV_ShutdownGameDLL);
+		g_GameDll.FindPatternSIMD("48 8B C4 56 48 81 EC ?? ?? ?? ?? 48 89 ?? ?? 48 8D").GetPtr(v_SV_ActivateServer);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 0D ?? ?? ?? ?? 48 85 C9 75 07").GetPtr(v_SV_CreateBaseline);
+		g_GameDll.FindPatternSIMD("4C 8B DC 56 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ??").GetPtr(v_SV_BroadcastVoiceData);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/engine/server/vengineserver_impl.cpp
+++ b/src/engine/server/vengineserver_impl.cpp
@@ -12,12 +12,12 @@
 bool CVEngineServer::PersistenceAvailable(void* entidx, int clientidx)
 {
 	///////////////////////////////////////////////////////////////////////////
-	return IVEngineServer__PersistenceAvailable(entidx, clientidx);
+	return CVEngineServer__PersistenceAvailable(entidx, clientidx);
 }
 
 void HVEngineServer::Detour(const bool bAttach) const
 {
-	DetourSetup(&IVEngineServer__PersistenceAvailable, &CVEngineServer::PersistenceAvailable, bAttach);
+	DetourSetup(&CVEngineServer__PersistenceAvailable, &CVEngineServer::PersistenceAvailable, bAttach);
 }
 
 IVEngineServer* g_pEngineServerVFTable = nullptr;

--- a/src/engine/server/vengineserver_impl.h
+++ b/src/engine/server/vengineserver_impl.h
@@ -3,8 +3,7 @@
 #include "public/eiface.h"
 
 /* ==== CVENGINESERVER ================================================================================================================================================== */
-inline CMemory p_IVEngineServer__PersistenceAvailable;
-inline bool(*IVEngineServer__PersistenceAvailable)(void* entidx, int clientidx);
+inline bool(*CVEngineServer__PersistenceAvailable)(void* entidx, int clientidx);
 
 inline bool* m_bIsDedicated = nullptr;
 
@@ -24,14 +23,13 @@ class HVEngineServer : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogConAdr("CVEngineServer::`vftable'", reinterpret_cast<uintptr_t>(g_pEngineServerVFTable));
-		LogFunAdr("CVEngineServer::PersistenceAvailable", p_IVEngineServer__PersistenceAvailable.GetPtr());
-		LogVarAdr("m_bIsDedicated", reinterpret_cast<uintptr_t>(m_bIsDedicated)); // !TODO: part of CServer!
+		LogConAdr("CVEngineServer::`vftable'", g_pEngineServerVFTable);
+		LogFunAdr("CVEngineServer::PersistenceAvailable", CVEngineServer__PersistenceAvailable);
+		LogVarAdr("m_bIsDedicated", m_bIsDedicated); // !TODO: part of CServer!
 	}
 	virtual void GetFun(void) const
 	{
-		p_IVEngineServer__PersistenceAvailable = g_GameDll.FindPatternSIMD("3B 15 ?? ?? ?? ?? 7D 33");
-		IVEngineServer__PersistenceAvailable = p_IVEngineServer__PersistenceAvailable.RCast<bool (*)(void*, int)>();
+		g_GameDll.FindPatternSIMD("3B 15 ?? ?? ?? ?? 7D 33").GetPtr(CVEngineServer__PersistenceAvailable);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/engine/staticpropmgr.cpp
+++ b/src/engine/staticpropmgr.cpp
@@ -5,7 +5,7 @@
 //-----------------------------------------------------------------------------
 // Purpose: initialises static props from the static prop gamelump
 //-----------------------------------------------------------------------------
-void* __fastcall CStaticProp_Init(int64_t thisptr, int64_t a2, unsigned int idx, unsigned int a4, StaticPropLump_t* lump, int64_t a6, int64_t a7)
+void* CStaticProp::Init(CStaticProp* thisptr, int64_t a2, unsigned int idx, unsigned int a4, StaticPropLump_t* lump, int64_t a6, int64_t a7)
 {
     MDLHandle_t handle = *reinterpret_cast<uint16_t*>(a7 + 0x140);
     studiohdr_t* pStudioHdr = g_pMDLCache->FindMDL(g_pMDLCache, handle, nullptr);
@@ -19,12 +19,12 @@ void* __fastcall CStaticProp_Init(int64_t thisptr, int64_t a2, unsigned int idx,
         lump->m_Skin = 0;
     }
 
-    return v_CStaticProp_Init(thisptr, a2, idx, a4, lump, a6, a7);
+    return CStaticProp__Init(thisptr, a2, idx, a4, lump, a6, a7);
 }
 
 void VStaticPropMgr::Detour(const bool bAttach) const
 {
 #ifndef DEDICATED
-    DetourSetup(&v_CStaticProp_Init, &CStaticProp_Init, bAttach);
+    DetourSetup(&CStaticProp__Init, &CStaticProp::Init, bAttach);
 #endif // !DEDICATED
 }

--- a/src/engine/staticpropmgr.h
+++ b/src/engine/staticpropmgr.h
@@ -1,23 +1,27 @@
 #pragma once
 #include "public/gamebspfile.h"
 
-inline CMemory p_CStaticProp_Init;
-inline void*(*v_CStaticProp_Init)(int64_t thisptr, int64_t a2, unsigned int idx, unsigned int a4, StaticPropLump_t* lump, int64_t a6, int64_t a7);
+class CStaticProp
+{
+public:
+	static void* Init(CStaticProp* thisptr, int64_t a2, unsigned int idx, unsigned int a4, StaticPropLump_t* lump, int64_t a6, int64_t a7);
 
-void* __fastcall CStaticProp_Init(int64_t thisptr, int64_t a2, unsigned int idx, unsigned int a4, StaticPropLump_t* lump, int64_t a6, int64_t a7);
+private: // TODO: reverse structure.
+};
+
+inline void*(*CStaticProp__Init)(CStaticProp* thisptr, int64_t a2, unsigned int idx, unsigned int a4, StaticPropLump_t* lump, int64_t a6, int64_t a7);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VStaticPropMgr : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CStaticProp::Init", p_CStaticProp_Init.GetPtr());
+		LogFunAdr("CStaticProp::Init", CStaticProp__Init);
 
 	}
 	virtual void GetFun(void) const
 	{
-		p_CStaticProp_Init = g_GameDll.FindPatternSIMD("48 8B C4 44 89 40 18 48 89 50 10 55"); /*48 8B C4 44 89 40 18 48 89 50 10 55*/
-		v_CStaticProp_Init = p_CStaticProp_Init.RCast<void*(*)(int64_t, int64_t, unsigned int, unsigned int, StaticPropLump_t*, int64_t, int64_t)>();
+		g_GameDll.FindPatternSIMD("48 8B C4 44 89 40 18 48 89 50 10 55").GetPtr(CStaticProp__Init);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/engine/sys_dll.cpp
+++ b/src/engine/sys_dll.cpp
@@ -72,10 +72,6 @@ int CModAppSystemGroup::StaticMain(CModAppSystemGroup* pModAppSystemGroup)
 	int nRunResult = RUN_OK;
 	HEbisuSDK_Init(); // Not here in retail. We init EbisuSDK here though.
 
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1) // !TODO: rebuild does not work for S1 (CModAppSystemGroup and CEngine member offsets do align with all other builds).
-	return CModAppSystemGroup_Main(pModAppSystemGroup);
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-
 	g_pEngine->SetQuitting(IEngine::QUIT_NOTQUITTING);
 	if (g_pEngine->Load(pModAppSystemGroup->IsServerOnly(), g_pEngineParms->baseDirectory))
 	{
@@ -90,7 +86,6 @@ int CModAppSystemGroup::StaticMain(CModAppSystemGroup* pModAppSystemGroup)
 #endif // !CLIENT_DLL
 	}
 	return nRunResult;
-#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -136,7 +131,7 @@ bool CModAppSystemGroup::StaticCreate(CModAppSystemGroup* pModAppSystemGroup)
 	g_FrameTasks.push_back(std::move(g_TaskScheduler));
 	g_bAppSystemInit = true;
 
-	return CModAppSystemGroup_Create(pModAppSystemGroup);
+	return CModAppSystemGroup__Create(pModAppSystemGroup);
 }
 
 //-----------------------------------------------------------------------------
@@ -182,8 +177,8 @@ void VSys_Dll::Detour(const bool bAttach) const
 	DetourSetup(&CSourceAppSystemGroup__PreInit, &CSourceAppSystemGroup::StaticPreInit, bAttach);
 	DetourSetup(&CSourceAppSystemGroup__Create, &CSourceAppSystemGroup::StaticCreate, bAttach);
 
-	DetourSetup(&CModAppSystemGroup_Main, &CModAppSystemGroup::StaticMain, bAttach);
-	DetourSetup(&CModAppSystemGroup_Create, &CModAppSystemGroup::StaticCreate, bAttach);
+	DetourSetup(&CModAppSystemGroup__Main, &CModAppSystemGroup::StaticMain, bAttach);
+	DetourSetup(&CModAppSystemGroup__Create, &CModAppSystemGroup::StaticCreate, bAttach);
 
 	DetourSetup(&Sys_Error_Internal, &HSys_Error_Internal, bAttach);
 }

--- a/src/engine/sys_dll.h
+++ b/src/engine/sys_dll.h
@@ -40,22 +40,14 @@ private:
 };
 
 /* ==== CAPPSYSTEMGROUP ================================================================================================================================================= */
-inline CMemory p_CModAppSystemGroup_Main;
-inline int(*CModAppSystemGroup_Main)(CModAppSystemGroup* pModAppSystemGroup);
-
-inline CMemory p_CModAppSystemGroup_Create;
-inline bool(*CModAppSystemGroup_Create)(CModAppSystemGroup* pModAppSystemGroup);
-
-inline CMemory p_CSourceAppSystemGroup__PreInit;
+inline int(*CModAppSystemGroup__Main)(CModAppSystemGroup* pModAppSystemGroup);
+inline bool(*CModAppSystemGroup__Create)(CModAppSystemGroup* pModAppSystemGroup);
 inline bool(*CSourceAppSystemGroup__PreInit)(CSourceAppSystemGroup* pModAppSystemGroup);
-
-inline CMemory p_CSourceAppSystemGroup__Create;
 inline bool(*CSourceAppSystemGroup__Create)(CSourceAppSystemGroup* pModAppSystemGroup);
 
 inline bool g_bAppSystemInit = false;
 
 /* ==== UTILITY ========================================================================================================================================================= */
-inline CMemory p_Sys_Error_Internal;
 inline int(*Sys_Error_Internal)(char* fmt, va_list args);
 
 inline bool* gfExtendedError = nullptr;
@@ -68,39 +60,27 @@ class VSys_Dll : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CModAppSystemGroup::Main", p_CModAppSystemGroup_Main.GetPtr());
-		LogFunAdr("CModAppSystemGroup::Create", p_CModAppSystemGroup_Create.GetPtr());
-		LogFunAdr("CSourceAppSystemGroup::PreInit", p_CSourceAppSystemGroup__PreInit.GetPtr());
-		LogFunAdr("CSourceAppSystemGroup::Create", p_CSourceAppSystemGroup__Create.GetPtr());
-		LogFunAdr("Sys_Error_Internal", p_Sys_Error_Internal.GetPtr());
-		LogVarAdr("gfExtendedError", reinterpret_cast<uintptr_t>(gfExtendedError));
+		LogFunAdr("CModAppSystemGroup::Main", CModAppSystemGroup__Main);
+		LogFunAdr("CModAppSystemGroup::Create", CModAppSystemGroup__Create);
+		LogFunAdr("CSourceAppSystemGroup::PreInit", CSourceAppSystemGroup__PreInit);
+		LogFunAdr("CSourceAppSystemGroup::Create", CSourceAppSystemGroup__Create);
+		LogFunAdr("Sys_Error_Internal", Sys_Error_Internal);
+		LogVarAdr("gfExtendedError", gfExtendedError);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CModAppSystemGroup_Main = g_GameDll.FindPatternSIMD("48 83 EC 28 80 B9 ?? ?? ?? ?? ?? 48 8B 15 ?? ?? ?? ??");
-		p_CModAppSystemGroup_Create = g_GameDll.FindPatternSIMD("48 8B C4 57 41 54 41 55 41 56 41 57 48 83 EC 60 48 C7 40 ?? ?? ?? ?? ?? 48 89 58 08");
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 80 B9 ?? ?? ?? ?? ?? BB ?? ?? ?? ??").GetPtr(CModAppSystemGroup__Main);
+		g_GameDll.FindPatternSIMD("48 8B C4 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 60").GetPtr(CModAppSystemGroup__Create);
 
-		p_CSourceAppSystemGroup__Create = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F9 E8 ?? ?? ?? ?? 33 C9");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CModAppSystemGroup_Main = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 80 B9 ?? ?? ?? ?? ?? BB ?? ?? ?? ??");
-		p_CModAppSystemGroup_Create = g_GameDll.FindPatternSIMD("48 8B C4 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 60");
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F9 E8 ?? ?? ?? ?? 33 C9").GetPtr(CSourceAppSystemGroup__Create);
+		g_GameDll.FindPatternSIMD("48 89 74 24 ?? 55 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??").GetPtr(CSourceAppSystemGroup__PreInit);
 
-		p_CSourceAppSystemGroup__Create = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F9 E8 ?? ?? ?? ?? 33 C9");
-#endif
-		p_CSourceAppSystemGroup__PreInit = g_GameDll.FindPatternSIMD("48 89 74 24 ?? 55 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??");
-
-		CModAppSystemGroup_Main = p_CModAppSystemGroup_Main.RCast<int(*)(CModAppSystemGroup*)>();
-		CModAppSystemGroup_Create = p_CModAppSystemGroup_Create.RCast<bool(*)(CModAppSystemGroup*)>();
-		CSourceAppSystemGroup__PreInit = p_CSourceAppSystemGroup__PreInit.RCast<bool(*)(CSourceAppSystemGroup*)>();
-		CSourceAppSystemGroup__Create = p_CSourceAppSystemGroup__Create.RCast<bool(*)(CSourceAppSystemGroup*)>();
-
-		p_Sys_Error_Internal = g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 74 24 10 57 48 81 EC 30 08 ?? ?? 48 8B DA 48 8B F9 E8 ?? ?? ?? FF 33 F6 48");
-		Sys_Error_Internal = p_Sys_Error_Internal.RCast<int (*)(char*, va_list)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 74 24 10 57 48 81 EC 30 08 ?? ?? 48 8B DA 48 8B F9 E8 ?? ?? ?? FF 33 F6 48").GetPtr(Sys_Error_Internal);
 	}
 	virtual void GetVar(void) const
 	{
-		gfExtendedError = p_COM_ExplainDisconnection.Offset(0x0).FindPatternSelf("C6 05", CMemory::Direction::DOWN, 300).ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
+		gfExtendedError = CMemory(v_COM_ExplainDisconnection).Offset(0x0)
+			.FindPatternSelf("C6 05", CMemory::Direction::DOWN, 300).ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/sys_dll2.cpp
+++ b/src/engine/sys_dll2.cpp
@@ -86,7 +86,7 @@ static void InitVPKSystem()
 
 InitReturnVal_t CEngineAPI::VInit(CEngineAPI* pEngineAPI)
 {
-    return CEngineAPI_Init(pEngineAPI);
+    return CEngineAPI__Init(pEngineAPI);
 }
 
 //-----------------------------------------------------------------------------
@@ -97,7 +97,7 @@ bool CEngineAPI::VModInit(CEngineAPI* pEngineAPI, const char* pModName, const ch
     // Register new Pak Assets here!
     //RTech_RegisterAsset(0, 1, "", nullptr, nullptr, nullptr, CMemory(0x1660AD0A8).RCast<void**>(), 8, 8, 8, 0, 0xFFFFFFC);
 
-	bool results = CEngineAPI_ModInit(pEngineAPI, pModName, pGameDir);
+	bool results = CEngineAPI__ModInit(pEngineAPI, pModName, pGameDir);
 	if (!IsValveMod(pModName) && !IsRespawnMod(pModName))
 	{
 #ifndef DEDICATED
@@ -114,7 +114,6 @@ bool CEngineAPI::VModInit(CEngineAPI* pEngineAPI, const char* pModName, const ch
 //-----------------------------------------------------------------------------
 void CEngineAPI::VSetStartupInfo(CEngineAPI* pEngineAPI, StartupInfo_t* pStartupInfo)
 {
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
     if (*g_bTextMode)
     {
         return;
@@ -152,10 +151,6 @@ void CEngineAPI::VSetStartupInfo(CEngineAPI* pEngineAPI, StartupInfo_t* pStartup
     v_COM_InitFilesystem(pEngineAPI->m_StartupInfo.m_szInitialMod);
 
     *g_bTextMode = true;
-#else
-    // !TODO: 'TRACEINIT' needs to be reimplemented in S0/S1 (inline).
-    v_CEngineAPI_SetStartupInfo(pEngineAPI, pStartupInfo);
-#endif // !(GAMEDLL_S0) || !(GAMEDLL_S1)
 }
 
 //-----------------------------------------------------------------------------
@@ -174,7 +169,7 @@ void CEngineAPI::PumpMessages()
     if (in_syncRT->GetBool())
         (*g_fnSyncRTWithIn)();
 
-    g_pInputSystem->PollInputState(UIEventDispatcher);
+    g_pInputSystem->PollInputState(v_UIEventDispatcher);
     g_pGame->DispatchAllStoredGameMessages();
 #endif // !DEDICATED
 }
@@ -265,9 +260,9 @@ bool CEngineAPI::MainLoop()
 ///////////////////////////////////////////////////////////////////////////////
 void VSys_Dll2::Detour(const bool bAttach) const
 {
-	DetourSetup(&CEngineAPI_Init, &CEngineAPI::VInit, bAttach);
-	DetourSetup(&CEngineAPI_ModInit, &CEngineAPI::VModInit, bAttach);
-	DetourSetup(&CEngineAPI_PumpMessages, &CEngineAPI::PumpMessages, bAttach);
-	DetourSetup(&CEngineAPI_MainLoop, &CEngineAPI::MainLoop, bAttach);
-	DetourSetup(&v_CEngineAPI_SetStartupInfo, &CEngineAPI::VSetStartupInfo, bAttach);
+	DetourSetup(&CEngineAPI__Init, &CEngineAPI::VInit, bAttach);
+	DetourSetup(&CEngineAPI__ModInit, &CEngineAPI::VModInit, bAttach);
+	DetourSetup(&CEngineAPI__PumpMessages, &CEngineAPI::PumpMessages, bAttach);
+	DetourSetup(&CEngineAPI__MainLoop, &CEngineAPI::MainLoop, bAttach);
+	DetourSetup(&CEngineAPI__SetStartupInfo, &CEngineAPI::VSetStartupInfo, bAttach);
 }

--- a/src/engine/sys_dll2.h
+++ b/src/engine/sys_dll2.h
@@ -45,32 +45,15 @@ public:
 	StartupInfo_t m_StartupInfo;
 };
 
-inline CMemory p_CEngineAPI_Init;
-inline InitReturnVal_t(*CEngineAPI_Init)(CEngineAPI* thisp);
-
-inline CMemory p_CEngineAPI_Shutdown;
-inline void(*CEngineAPI_Shutdown)(void);
-
-inline CMemory p_CEngineAPI_Connect;
-inline bool(*CEngineAPI_Connect)(CEngineAPI* thisptr, CreateInterfaceFn factory);
-
-inline CMemory p_CEngineAPI_ModInit;
-inline bool(*CEngineAPI_ModInit)(CEngineAPI* pEngineAPI, const char* pModName, const char* pGameDir);
-
-inline CMemory p_CEngineAPI_MainLoop;
-inline bool(*CEngineAPI_MainLoop)(void);
-
-inline CMemory p_CEngineAPI_PumpMessages;
-inline void(*CEngineAPI_PumpMessages)(void);
-
-inline CMemory p_CEngineAPI_SetStartupInfo;
-inline void(*v_CEngineAPI_SetStartupInfo)(CEngineAPI* pEngineAPI, StartupInfo_t* pStartupInfo);
-
-inline CMemory p_ResetMTVFTaskItem;
+inline InitReturnVal_t(*CEngineAPI__Init)(CEngineAPI* thisp);
+inline void(*CEngineAPI__Shutdown)(void);
+inline bool(*CEngineAPI__Connect)(CEngineAPI* thisptr, CreateInterfaceFn factory);
+inline bool(*CEngineAPI__ModInit)(CEngineAPI* pEngineAPI, const char* pModName, const char* pGameDir);
+inline bool(*CEngineAPI__MainLoop)(void);
+inline void(*CEngineAPI__PumpMessages)(void);
+inline void(*CEngineAPI__SetStartupInfo)(CEngineAPI* pEngineAPI, StartupInfo_t* pStartupInfo);
 inline void*(*v_ResetMTVFTaskItem)(void);
-
-inline CMemory p_PakFile_Init;
-inline void(*PakFile_Init)(char* buffer, char* source, char vpk_file);
+inline void(*v_PakFile_Init)(char* buffer, char* source, char vpk_file);
 
 inline bool* g_bTextMode = nullptr;
 inline char* g_szBaseDir = nullptr; // static size = 260
@@ -82,57 +65,39 @@ class VSys_Dll2 : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CEngineAPI::Init", p_CEngineAPI_Init.GetPtr());
-		LogFunAdr("CEngineAPI::Shutdown", p_CEngineAPI_Shutdown.GetPtr());
-		LogFunAdr("CEngineAPI::Connect", p_CEngineAPI_Connect.GetPtr());
-		LogFunAdr("CEngineAPI::ModInit", p_CEngineAPI_ModInit.GetPtr());
-		LogFunAdr("CEngineAPI::MainLoop", p_CEngineAPI_MainLoop.GetPtr());
-		LogFunAdr("CEngineAPI::PumpMessages", p_CEngineAPI_PumpMessages.GetPtr());
-#if defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		LogFunAdr("CEngineAPI::SetStartupInfo", p_CEngineAPI_SetStartupInfo.GetPtr());
-#endif
-		LogFunAdr("ResetMTVFTaskItem", p_ResetMTVFTaskItem.GetPtr());
-		LogFunAdr("PakFile_Init", p_PakFile_Init.GetPtr());
-		LogVarAdr("g_bTextMode", reinterpret_cast<uintptr_t>(g_bTextMode));
-		LogVarAdr("g_szBaseDir", reinterpret_cast<uintptr_t>(g_szBaseDir));
-		LogVarAdr("g_pMTVFTaskItem", reinterpret_cast<uintptr_t>(g_pMTVFTaskItem));
-		LogVarAdr("g_szMTVFItemName", reinterpret_cast<uintptr_t>(g_szMTVFItemName));
+		LogFunAdr("CEngineAPI::Init", CEngineAPI__Init);
+		LogFunAdr("CEngineAPI::Shutdown", CEngineAPI__Shutdown);
+		LogFunAdr("CEngineAPI::Connect", CEngineAPI__Connect);
+		LogFunAdr("CEngineAPI::ModInit", CEngineAPI__ModInit);
+		LogFunAdr("CEngineAPI::MainLoop", CEngineAPI__MainLoop);
+		LogFunAdr("CEngineAPI::PumpMessages", CEngineAPI__PumpMessages);
+		LogFunAdr("CEngineAPI::SetStartupInfo", CEngineAPI__SetStartupInfo);
+		LogFunAdr("ResetMTVFTaskItem", v_ResetMTVFTaskItem);
+		LogFunAdr("PakFile_Init", v_PakFile_Init);
+		LogVarAdr("g_bTextMode", g_bTextMode);
+		LogVarAdr("g_szBaseDir", g_szBaseDir);
+		LogVarAdr("g_pMTVFTaskItem", g_pMTVFTaskItem);
+		LogVarAdr("g_szMTVFItemName", g_szMTVFItemName);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CEngineAPI_Init    = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F1 48 8D 3D ?? ?? ?? ?? 33 DB 48 8D 15 ?? ?? ?? ??");
-		p_CEngineAPI_Connect = g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 05 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? 48 85 C0 48 89 15");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CEngineAPI_Shutdown = g_GameDll.FindPatternSIMD("41 54 41 56 48 83 EC 38 48 8B 0D ?? ?? ?? ??");
-		p_CEngineAPI_ModInit  = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? 4D 8B F0");
-		p_CEngineAPI_MainLoop = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 48 81 EC ?? ?? ?? ?? 45 33 C9");
-		p_PakFile_Init        = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 44 88 44 24 ?? 56 57 41 54 41 56 41 57 48 83 EC 20");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CEngineAPI_Shutdown = g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 0D ?? ?? ?? ?? 33 D2 48 8B 01 FF 90 ?? ?? ?? ?? B1 01");
-		p_CEngineAPI_ModInit  = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 4C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? 4D 8B F8");
-		p_CEngineAPI_MainLoop = g_GameDll.FindPatternSIMD("4C 8B DC 49 89 4B 08 48 81 EC ?? ?? ?? ?? 8B 05 ?? ?? ?? ??");
-		p_PakFile_Init        = g_GameDll.FindPatternSIMD("44 88 44 24 ?? 53 55 56 57");
-#endif
-		p_CEngineAPI_PumpMessages = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 48 81 EC ?? ?? ?? ?? 45 33 C9");
-		p_CEngineAPI_SetStartupInfo = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? ?? 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 48 8B DA");
-		p_ResetMTVFTaskItem = g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 15 ?? ?? ?? ?? 48 85 D2 0F 84 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B 01 FF 90 ?? ?? ?? ?? 33 C9 E8 ?? ?? ?? ?? 0F 28 05 ?? ?? ?? ?? 0F 28 0D ?? ?? ?? ?? 0F 11 05 ?? ?? ?? ?? 0F 28 05 ?? ?? ?? ?? 0F 11 0D ?? ?? ?? ?? 0F 28 0D ?? ?? ?? ?? 0F 11 05 ?? ?? ?? ?? 0F 11 0D ?? ?? ?? ?? 48 C7 05 ?? ?? ?? ?? ?? ?? ?? ?? FF 15 ?? ?? ?? ??");
-
-		CEngineAPI_Init     = p_CEngineAPI_Init.RCast<InitReturnVal_t(*)(CEngineAPI*)>();
-		CEngineAPI_Shutdown = p_CEngineAPI_Shutdown.RCast<void (*)(void)>();
-		CEngineAPI_Connect  = p_CEngineAPI_Connect.RCast<bool (*)(CEngineAPI*, CreateInterfaceFn)>();             /*48 83 EC 28 48 8B 05 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? 48 85 C0 48 89 15 ?? ?? ?? ??*/
-		CEngineAPI_ModInit  = p_CEngineAPI_ModInit.RCast<bool (*)(CEngineAPI*, const char*, const char*)>();      /*48 89 5C 24 ?? 48 89 4C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? 4D 8B F8*/
-		CEngineAPI_MainLoop = p_CEngineAPI_MainLoop.RCast<bool(*)(void)>();                                       /*E8 ?? ?? ?? ?? 48 8B 15 ?? ?? ?? ?? 84 C0 B9 ?? ?? ?? ??*/
-		CEngineAPI_PumpMessages = p_CEngineAPI_PumpMessages.RCast<void(*)(void)>();
-		v_CEngineAPI_SetStartupInfo = p_CEngineAPI_SetStartupInfo.RCast<void (*)(CEngineAPI*, StartupInfo_t*)>(); /*48 89 5C 24 ?? 57 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 48 8B DA*/
-		PakFile_Init = p_PakFile_Init.RCast<void (*)(char*, char*, char)>();                                      /*44 88 44 24 ?? 53 55 56 57*/
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F1 48 8D 3D ?? ?? ?? ?? 33 DB 48 8D 15 ?? ?? ?? ??").GetPtr(CEngineAPI__Init);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 05 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? 48 85 C0 48 89 15").GetPtr(CEngineAPI__Connect);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 0D ?? ?? ?? ?? 33 D2 48 8B 01 FF 90 ?? ?? ?? ?? B1 01").GetPtr(CEngineAPI__Shutdown);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 4C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? 4D 8B F8").GetPtr(CEngineAPI__ModInit);
+		g_GameDll.FindPatternSIMD("4C 8B DC 49 89 4B 08 48 81 EC ?? ?? ?? ?? 8B 05 ?? ?? ?? ??").GetPtr(CEngineAPI__MainLoop);
+		g_GameDll.FindPatternSIMD("44 88 44 24 ?? 53 55 56 57").GetPtr(v_PakFile_Init);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 48 81 EC ?? ?? ?? ?? 45 33 C9").GetPtr(CEngineAPI__PumpMessages);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? ?? 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 48 8B DA").GetPtr(CEngineAPI__SetStartupInfo);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 15 ?? ?? ?? ?? 48 85 D2 0F 84 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B 01 FF 90 ?? ?? ?? ?? 33 C9 E8 ?? ?? ?? ?? 0F 28 05 ?? ?? ?? ?? 0F 28 0D ?? ?? ?? ?? 0F 11 05 ?? ?? ?? ?? 0F 28 05 ?? ?? ?? ?? 0F 11 0D ?? ?? ?? ?? 0F 28 0D ?? ?? ?? ?? 0F 11 05 ?? ?? ?? ?? 0F 11 0D ?? ?? ?? ?? 48 C7 05 ?? ?? ?? ?? ?? ?? ?? ?? FF 15 ?? ?? ?? ??").GetPtr(v_ResetMTVFTaskItem);
 	}
 	virtual void GetVar(void) const
 	{
-		g_bTextMode = p_CEngineAPI_SetStartupInfo.FindPattern("80 3D", CMemory::Direction::DOWN, 250).ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
-		g_szBaseDir = p_CEngineAPI_SetStartupInfo.FindPattern("48 8D", CMemory::Direction::DOWN, 250).ResolveRelativeAddressSelf(0x3, 0x7).RCast<char*>();
+		g_bTextMode = CMemory(CEngineAPI__SetStartupInfo).FindPattern("80 3D", CMemory::Direction::DOWN, 250).ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
+		g_szBaseDir = CMemory(CEngineAPI__SetStartupInfo).FindPattern("48 8D", CMemory::Direction::DOWN, 250).ResolveRelativeAddressSelf(0x3, 0x7).RCast<char*>();
 
-		g_pMTVFTaskItem = p_ResetMTVFTaskItem.FindPattern("48 8B", CMemory::Direction::DOWN, 250).ResolveRelativeAddressSelf(0x3, 0x7).RCast<int64_t*>();
-		g_szMTVFItemName = p_ResetMTVFTaskItem.FindPattern("C6 05", CMemory::Direction::DOWN, 250).ResolveRelativeAddressSelf(0x2, 0x7).RCast<char*>();
+		g_pMTVFTaskItem = CMemory(v_ResetMTVFTaskItem).FindPattern("48 8B", CMemory::Direction::DOWN, 250).ResolveRelativeAddressSelf(0x3, 0x7).RCast<int64_t*>();
+		g_szMTVFItemName = CMemory(v_ResetMTVFTaskItem).FindPattern("C6 05", CMemory::Direction::DOWN, 250).ResolveRelativeAddressSelf(0x2, 0x7).RCast<char*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/sys_engine.cpp
+++ b/src/engine/sys_engine.cpp
@@ -28,10 +28,10 @@ bool CEngine::_Frame(CEngine* thisp)
 	}
 
 #endif // DEDICATED
-	return v_CEngine_Frame(thisp);
+	return CEngine__Frame(thisp);
 }
 
 void VEngine::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_CEngine_Frame, &CEngine::_Frame, bAttach);
+	DetourSetup(&CEngine__Frame, &CEngine::_Frame, bAttach);
 }

--- a/src/engine/sys_engine.h
+++ b/src/engine/sys_engine.h
@@ -4,8 +4,7 @@
 class CEngine;
 
 /* ==== CENGINE ======================================================================================================================================================= */
-inline CMemory p_CEngine_Frame;
-inline bool(*v_CEngine_Frame)(CEngine* thisp);
+inline bool(*CEngine__Frame)(CEngine* thisp);
 
 extern CEngine* g_pEngine;
 extern IEngine::QuitState_t* gsm_Quitting;
@@ -40,28 +39,17 @@ class VEngine : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CEngine::Frame", p_CEngine_Frame.GetPtr());
-		LogVarAdr("g_Engine", reinterpret_cast<uintptr_t>(g_pEngine));
-		LogVarAdr("sm_Quitting", reinterpret_cast<uintptr_t>(gsm_Quitting));
+		LogFunAdr("CEngine::Frame", CEngine__Frame);
+		LogVarAdr("g_Engine", g_pEngine);
+		LogVarAdr("sm_Quitting", gsm_Quitting);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CEngine_Frame = g_GameDll.FindPatternSIMD("40 55 53 56 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 8B F1");
-#elif defined (GAMEDLL_S2)
-		p_CEngine_Frame = g_GameDll.FindPatternSIMD("48 8B C4 56 48 81 EC ?? ?? ?? ?? 0F 29 70 B8");
-#else
-		p_CEngine_Frame = g_GameDll.FindPatternSIMD("48 8B C4 55 56 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 0F 29 70 B8");
-#endif
-		v_CEngine_Frame = p_CEngine_Frame.RCast<bool(*)(CEngine* thisp)>();
+		g_GameDll.FindPatternSIMD("48 8B C4 55 56 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 0F 29 70 B8").GetPtr(CEngine__Frame);
 	}
 	virtual void GetVar(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		g_pEngine = g_GameDll.FindPatternSIMD("48 83 EC 28 80 B9 ?? ?? ?? ?? ?? 48 8B 15 ?? ?? ?? ??").FindPatternSelf("48 8D ?? ?? ?? ?? 01", CMemory::Direction::DOWN, 300).ResolveRelativeAddressSelf(0x3, 0x7).RCast<CEngine*>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 		g_pEngine = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 80 B9 ?? ?? ?? ?? ?? BB ?? ?? ?? ??").FindPatternSelf("48 8B ?? ?? ?? ?? 01", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x3, 0x7).RCast<CEngine*>();
-#endif
 		gsm_Quitting = g_GameDll.FindPatternSIMD("89 15 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC CC 83 C1 F4").ResolveRelativeAddressSelf(0x2, 0x6).RCast<IEngine::QuitState_t*>();
 	}
 	virtual void GetCon(void) const { }

--- a/src/engine/sys_getmodes.h
+++ b/src/engine/sys_getmodes.h
@@ -3,10 +3,7 @@
 //-------------------------------------------------------------------------
 // CGAME
 //-------------------------------------------------------------------------
-inline CMemory p_CVideoMode_Common__CreateGameWindow;
 inline bool(*CVideoMode_Common__CreateGameWindow)(int* pnRect);
-
-inline CMemory p_CVideoMode_Common__CreateWindowClass;
 inline HWND(*CVideoMode_Common__CreateWindowClass)(vrect_t* pnRect);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -14,20 +11,13 @@ class HVideoMode_Common : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CVideoMode_Common::CreateGameWindow", p_CVideoMode_Common__CreateGameWindow.GetPtr());
-		LogFunAdr("CVideoMode_Common::CreateWindowClass", p_CVideoMode_Common__CreateWindowClass.GetPtr());
+		LogFunAdr("CVideoMode_Common::CreateGameWindow", CVideoMode_Common__CreateGameWindow);
+		LogFunAdr("CVideoMode_Common::CreateWindowClass", CVideoMode_Common__CreateWindowClass);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CVideoMode_Common__CreateGameWindow = g_GameDll.FindPatternSIMD("40 56 57 48 83 EC 38 48 8B F9 E8 ?? ?? ?? ??");
-		p_CVideoMode_Common__CreateWindowClass = g_GameDll.FindPatternSIMD("40 55 53 57 41 56 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 4C 8B F1");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CVideoMode_Common__CreateGameWindow = g_GameDll.FindPatternSIMD("40 56 57 48 83 EC 28 48 8B F9 E8 ?? ?? ?? ?? 48 8B F0");
-		p_CVideoMode_Common__CreateWindowClass = g_GameDll.FindPatternSIMD("40 55 53 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B F9 FF 15 ?? ?? ?? ??");
-#endif
-		CVideoMode_Common__CreateGameWindow = p_CVideoMode_Common__CreateGameWindow.RCast<bool (*)(int*)>();      /*40 56 57 48 83 EC 28 48 8B F9 E8 ?? ?? ?? ?? 48 8B F0*/
-		CVideoMode_Common__CreateWindowClass = p_CVideoMode_Common__CreateWindowClass.RCast<HWND(*)(vrect_t*)>(); /*40 55 53 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B F9 FF 15 ?? ?? ?? ??*/
+		g_GameDll.FindPatternSIMD("40 56 57 48 83 EC 28 48 8B F9 E8 ?? ?? ?? ?? 48 8B F0").GetPtr(CVideoMode_Common__CreateGameWindow);
+		g_GameDll.FindPatternSIMD("40 55 53 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B F9 FF 15 ?? ?? ?? ??").GetPtr(CVideoMode_Common__CreateWindowClass);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/engine/sys_mainwind.cpp
+++ b/src/engine/sys_mainwind.cpp
@@ -20,7 +20,7 @@ void CGame::PlayStartupVideos(void)
 {
 	if (!CommandLine()->CheckParm("-novid"))
 	{
-		v_CGame__PlayStartupVideos();
+		CGame__PlayStartupVideos();
 	}
 }
 
@@ -30,13 +30,13 @@ void CGame::PlayStartupVideos(void)
 int CGame::WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	if (!g_bImGuiInitialized)
-		return v_CGame__WindowProc(hWnd, uMsg, wParam, lParam);
+		return CGame__WindowProc(hWnd, uMsg, wParam, lParam);
 
 	const IEngine::EngineState_t state = g_pEngine->GetState();
 
 	if (state == IEngine::DLL_CLOSE ||
 		state == IEngine::DLL_RESTART)
-		return v_CGame__WindowProc(hWnd, uMsg, wParam, lParam);
+		return CGame__WindowProc(hWnd, uMsg, wParam, lParam);
 
 	ImGui_ImplWin32_WndProcHandler(hWnd, uMsg, wParam, lParam);
 
@@ -92,7 +92,7 @@ int CGame::WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		g_bBlockInput = false;
 	}
 
-	return v_CGame__WindowProc(hWnd, uMsg, wParam, lParam);
+	return CGame__WindowProc(hWnd, uMsg, wParam, lParam);
 }
 
 //-----------------------------------------------------------------------------
@@ -158,6 +158,6 @@ void CGame::DispatchAllStoredGameMessages() const
 ///////////////////////////////////////////////////////////////////////////////
 void VGame::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_CGame__PlayStartupVideos, &CGame::PlayStartupVideos, bAttach);
-	DetourSetup(&v_CGame__WindowProc, &CGame::WindowProc, bAttach);
+	DetourSetup(&CGame__PlayStartupVideos, &CGame::PlayStartupVideos, bAttach);
+	DetourSetup(&CGame__WindowProc, &CGame::WindowProc, bAttach);
 }

--- a/src/engine/sys_mainwind.h
+++ b/src/engine/sys_mainwind.h
@@ -7,14 +7,9 @@
 #define SYS_MAINWIND_H
 #include "inputsystem/iinputsystem.h"
 
-inline CMemory p_CGame__AttachToWindow;
-inline void (*v_CGame__AttachToWindow)(void);
-
-inline CMemory p_CGame__PlayStartupVideos;
-inline void(*v_CGame__PlayStartupVideos)(void);
-
-inline CMemory p_CGame__WindowProc;
-inline int(*v_CGame__WindowProc)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+inline void (*CGame__AttachToWindow)(void);
+inline void(*CGame__PlayStartupVideos)(void);
+inline int(*CGame__WindowProc)(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 //-----------------------------------------------------------------------------
 // Purpose: Main game interface, including message pump and window creation
 //-----------------------------------------------------------------------------
@@ -61,29 +56,19 @@ class VGame : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CGame::AttachToWindow", p_CGame__AttachToWindow.GetPtr());
-		LogFunAdr("CGame::PlayStartupVideos", p_CGame__PlayStartupVideos.GetPtr());
-		LogVarAdr("g_Game", reinterpret_cast<uintptr_t>(g_pGame));
+		LogFunAdr("CGame::AttachToWindow", CGame__AttachToWindow);
+		LogFunAdr("CGame::PlayStartupVideos", CGame__PlayStartupVideos);
+		LogVarAdr("g_Game", g_pGame);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CGame__AttachToWindow    = g_GameDll.FindPatternSIMD("48 83 EC 38 48 8B 0D ?? ?? ?? ?? 48 85 C9 0F 84 ?? ?? ?? ??");
-		p_CGame__PlayStartupVideos = g_GameDll.FindPatternSIMD("48 8B C4 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 0F 85 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ??");
-		p_CGame__WindowProc = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 41 54 41 56 48 81 EC ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CGame__AttachToWindow    = g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 0D ?? ?? ?? ?? 48 85 C9 0F 84 ?? ?? ?? ?? BA ?? ?? ?? ??");
-		p_CGame__PlayStartupVideos = g_GameDll.FindPatternSIMD("48 8B C4 55 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ??");
-		p_CGame__WindowProc = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 33 F6");
-#endif
-
-		v_CGame__AttachToWindow = p_CGame__AttachToWindow.RCast<void (*)(void)>();
-		v_CGame__PlayStartupVideos = p_CGame__PlayStartupVideos.RCast<void (*)(void)>();
-		v_CGame__WindowProc = p_CGame__WindowProc.RCast<int (*)(HWND, UINT, WPARAM, LPARAM)>();
+		g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 0D ?? ?? ?? ?? 48 85 C9 0F 84 ?? ?? ?? ?? BA ?? ?? ?? ??").GetPtr(CGame__AttachToWindow);
+		g_GameDll.FindPatternSIMD("48 8B C4 55 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ??").GetPtr(CGame__PlayStartupVideos);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 33 F6").GetPtr(CGame__WindowProc);
 	}
 	virtual void GetVar(void) const
 	{
-		g_pGame = p_CGame__AttachToWindow.FindPattern("48 8B 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<CGame*>();
+		g_pGame = CMemory(CGame__AttachToWindow).FindPattern("48 8B 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<CGame*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/engine/sys_utils.h
+++ b/src/engine/sys_utils.h
@@ -1,16 +1,10 @@
 #pragma once
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-inline CMemory p_Error;
 inline void(*v_Error)(const char* fmt, ...);
-
-inline CMemory p_Warning;
-inline void(*v_Warning)(int, const char* fmt, ...); 
-
-inline CMemory p_Sys_GetProcessUpTime;
+inline void(*v_Warning)(int, const char* fmt, ...);
 inline int(*v_Sys_GetProcessUpTime)(char* szBuffer);
 #ifndef DEDICATED
-inline CMemory p_Con_NPrintf;
 inline void(*v_Con_NPrintf)(int pos, const char* fmt, ...);
 #endif // !DEDICATED
 /* ==== ------- ========================================================================================================================================================= */
@@ -23,26 +17,20 @@ class VSys_Utils : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Error", p_Error.GetPtr());
-		LogFunAdr("Warning", p_Warning.GetPtr());
-		LogFunAdr("Sys_GetProcessUpTime", p_Sys_GetProcessUpTime.GetPtr());
+		LogFunAdr("Error", v_Error);
+		LogFunAdr("Warning", v_Warning);
+		LogFunAdr("Sys_GetProcessUpTime", v_Sys_GetProcessUpTime);
 #ifndef DEDICATED
-		LogFunAdr("Con_NPrintf", p_Con_NPrintf.GetPtr());
+		LogFunAdr("Con_NPrintf", v_Con_NPrintf);
 #endif // !DEDICATED
 	}
 	virtual void GetFun(void) const
 	{
-		p_Error            = g_GameDll.FindPatternSIMD("48 89 4C 24 08 48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 53 55 41 54 41 56 B8 58 10 ?? ?? E8");
-		p_Warning          = g_GameDll.FindPatternSIMD("48 89 54 24 ?? 4C 89 44 24 ?? 4C 89 4C 24 ?? 48 83 EC 28 4C 8D 44 24 ?? E8 ?? ?? ?? ?? 48 83 C4 28 C3 CC CC CC CC CC CC CC CC CC CC CC CC CC CC 48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 8B 05 ?? ?? ?? ??");
-		p_Sys_GetProcessUpTime = g_GameDll.FindPatternSIMD("40 57 48 83 EC 30 48 8B F9 8B 0D ?? ?? ?? ??");
+		g_GameDll.FindPatternSIMD("48 89 4C 24 08 48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 53 55 41 54 41 56 B8 58 10 ?? ?? E8").GetPtr(v_Error);
+		g_GameDll.FindPatternSIMD("48 89 54 24 ?? 4C 89 44 24 ?? 4C 89 4C 24 ?? 48 83 EC 28 4C 8D 44 24 ?? E8 ?? ?? ?? ?? 48 83 C4 28 C3 CC CC CC CC CC CC CC CC CC CC CC CC CC CC 48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 8B 05 ?? ?? ?? ??").GetPtr(v_Warning);
+		g_GameDll.FindPatternSIMD("40 57 48 83 EC 30 48 8B F9 8B 0D ?? ?? ?? ??").GetPtr(v_Sys_GetProcessUpTime);
 #ifndef DEDICATED
-		p_Con_NPrintf          = g_GameDll.FindPatternSIMD("48 89 4C 24 ?? 48 89 54 24 ?? 4C 89 44 24 ?? 4C 89 4C 24 ?? C3");
-#endif // !DEDICATED
-		v_Error            = p_Error.RCast<void (*)(const char*, ...)>();
-		v_Warning          = p_Warning.RCast<void (*)(int, const char*, ...)>();
-		v_Sys_GetProcessUpTime = p_Sys_GetProcessUpTime.RCast<int (*)(char*)>();
-#ifndef DEDICATED
-		v_Con_NPrintf          = p_Con_NPrintf.RCast<void (*)(int, const char*, ...)>();
+		g_GameDll.FindPatternSIMD("48 89 4C 24 ?? 48 89 54 24 ?? 4C 89 44 24 ?? 4C 89 4C 24 ?? C3").GetPtr(v_Con_NPrintf);
 #endif // !DEDICATED
 	}
 	virtual void GetVar(void) const { }

--- a/src/engine/traceinit.h
+++ b/src/engine/traceinit.h
@@ -1,7 +1,6 @@
 #ifndef TRACEINIT_H
 #define TRACEINIT_H
 
-inline CMemory p_TRACEINIT;
 inline void(*v_TRACEINIT)(void* undef, const char* initfunc, const char* shutdownfunc);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9,12 +8,11 @@ class VTraceInit : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("TRACEINIT", p_TRACEINIT.GetPtr());
+		LogFunAdr("TRACEINIT", v_TRACEINIT);
 	}
 	virtual void GetFun(void) const
 	{
-		p_TRACEINIT = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 05 ?? ?? ?? ?? 49 8B F8 48 8B F2 48 85 C0");
-		v_TRACEINIT = p_TRACEINIT.RCast<void (*)(void*, const char*, const char*)>(); /*48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 20 48 8B 05 ? ? ? ? 49 8B F8 48 8B F2 48 85 C0*/
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 05 ?? ?? ?? ?? 49 8B F8 48 8B F2 48 85 C0").GetPtr(v_TRACEINIT);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/filesystem/basefilesystem.cpp
+++ b/src/filesystem/basefilesystem.cpp
@@ -77,7 +77,7 @@ FileHandle_t CBaseFileSystem::VReadFromVPK(CBaseFileSystem* pFileSystem, FileHan
 		return pResults;
 	}
 
-	return v_CBaseFileSystem_LoadFromVPK(pFileSystem, pResults, pszFilePath);
+	return CBaseFileSystem__LoadFromVPK(pFileSystem, pResults, pszFilePath);
 }
 
 //---------------------------------------------------------------------------------
@@ -94,7 +94,7 @@ bool CBaseFileSystem::VReadFromCache(CBaseFileSystem* pFileSystem, const char* p
 		return false;
 	}
 
-	bool result = v_CBaseFileSystem_LoadFromCache(pFileSystem, pszFilePath, pCache);
+	bool result = CBaseFileSystem__LoadFromCache(pFileSystem, pszFilePath, pCache);
 	return result;
 }
 
@@ -131,7 +131,7 @@ void CBaseFileSystem::VAddMapPackFile(CBaseFileSystem* pFileSystem, const char* 
 		pPath = lumpPathBuf;
 	}
 
-	v_CBaseFileSystem_AddMapPackFile(pFileSystem, pPath, pPathID, addType);
+	CBaseFileSystem__AddMapPackFile(pFileSystem, pPath, pPathID, addType);
 }
 
 //---------------------------------------------------------------------------------
@@ -142,8 +142,8 @@ void CBaseFileSystem::VAddMapPackFile(CBaseFileSystem* pFileSystem, const char* 
 //---------------------------------------------------------------------------------
 VPKData_t* CBaseFileSystem::VMountVPKFile(CBaseFileSystem* pFileSystem, const char* pszVpkPath)
 {
-	int nHandle = v_CBaseFileSystem_GetMountedVPKHandle(pFileSystem, pszVpkPath);
-	VPKData_t* pPakData = v_CBaseFileSystem_MountVPKFile(pFileSystem, pszVpkPath);
+	int nHandle = CBaseFileSystem__GetMountedVPKHandle(pFileSystem, pszVpkPath);
+	VPKData_t* pPakData = CBaseFileSystem__MountVPKFile(pFileSystem, pszVpkPath);
 
 	if (pPakData)
 	{
@@ -168,8 +168,8 @@ VPKData_t* CBaseFileSystem::VMountVPKFile(CBaseFileSystem* pFileSystem, const ch
 //---------------------------------------------------------------------------------
 const char* CBaseFileSystem::VUnmountVPKFile(CBaseFileSystem* pFileSystem, const char* pszVpkPath)
 {
-	int nHandle = v_CBaseFileSystem_GetMountedVPKHandle(pFileSystem, pszVpkPath);
-	const char* pRet = v_CBaseFileSystem_UnmountVPKFile(pFileSystem, pszVpkPath);
+	int nHandle = CBaseFileSystem__GetMountedVPKHandle(pFileSystem, pszVpkPath);
+	const char* pRet = CBaseFileSystem__UnmountVPKFile(pFileSystem, pszVpkPath);
 
 	if (nHandle >= 0)
 	{
@@ -203,12 +203,12 @@ CUtlString CBaseFileSystem::ReadString(FileHandle_t pFile)
 
 void VBaseFileSystem::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_CBaseFileSystem_Warning, &CBaseFileSystem::Warning, bAttach);
-	DetourSetup(&v_CBaseFileSystem_LoadFromVPK, &CBaseFileSystem::VReadFromVPK, bAttach);
-	DetourSetup(&v_CBaseFileSystem_LoadFromCache, &CBaseFileSystem::VReadFromCache, bAttach);
-	DetourSetup(&v_CBaseFileSystem_AddMapPackFile, &CBaseFileSystem::VAddMapPackFile, bAttach);
-	DetourSetup(&v_CBaseFileSystem_MountVPKFile, &CBaseFileSystem::VMountVPKFile, bAttach);
-	DetourSetup(&v_CBaseFileSystem_UnmountVPKFile, &CBaseFileSystem::VUnmountVPKFile, bAttach);
+	DetourSetup(&CBaseFileSystem__Warning, &CBaseFileSystem::Warning, bAttach);
+	DetourSetup(&CBaseFileSystem__LoadFromVPK, &CBaseFileSystem::VReadFromVPK, bAttach);
+	DetourSetup(&CBaseFileSystem__LoadFromCache, &CBaseFileSystem::VReadFromCache, bAttach);
+	DetourSetup(&CBaseFileSystem__AddMapPackFile, &CBaseFileSystem::VAddMapPackFile, bAttach);
+	DetourSetup(&CBaseFileSystem__MountVPKFile, &CBaseFileSystem::VMountVPKFile, bAttach);
+	DetourSetup(&CBaseFileSystem__UnmountVPKFile, &CBaseFileSystem::VUnmountVPKFile, bAttach);
 }
 
 CBaseFileSystem* g_pFileSystem = nullptr;

--- a/src/filesystem/basefilesystem.h
+++ b/src/filesystem/basefilesystem.h
@@ -43,26 +43,13 @@ protected:
 };
 
 /* ==== CBASEFILESYSTEM ================================================================================================================================================= */
-inline CMemory p_CBaseFileSystem_Warning;
-inline void(*v_CBaseFileSystem_Warning)(CBaseFileSystem* pFileSystem, FileWarningLevel_t level, const char* fmt, ...);
-
-inline CMemory p_CBaseFileSystem_LoadFromVPK;
-inline FileHandle_t(*v_CBaseFileSystem_LoadFromVPK)(CBaseFileSystem* pFileSystem, FileHandle_t pResults, const char* pszAssetName);
-
-inline CMemory p_CBaseFileSystem_LoadFromCache;
-inline bool(*v_CBaseFileSystem_LoadFromCache)(CBaseFileSystem* pFileSystem, const char* pszAssetName, FileSystemCache* pCache);
-
-inline CMemory p_CBaseFileSystem_AddMapPackFile;
-inline void(*v_CBaseFileSystem_AddMapPackFile)(CBaseFileSystem* pFileSystem, const char* pPath, const char* pPathID, SearchPathAdd_t addType);
-
-inline CMemory p_CBaseFileSystem_MountVPKFile;
-inline VPKData_t*(*v_CBaseFileSystem_MountVPKFile)(CBaseFileSystem* pFileSystem, const char* pszVpkPath);
-
-inline CMemory p_CBaseFileSystem_UnmountVPKFile;
-inline const char* (*v_CBaseFileSystem_UnmountVPKFile)(CBaseFileSystem* pFileSystem, const char* pszVpkPath);
-
-inline CMemory p_CBaseFileSystem_GetMountedVPKHandle;
-inline int(*v_CBaseFileSystem_GetMountedVPKHandle)(CBaseFileSystem* pFileSystem, const char* pszVpkPath);
+inline void(*CBaseFileSystem__Warning)(CBaseFileSystem* pFileSystem, FileWarningLevel_t level, const char* fmt, ...);
+inline FileHandle_t(*CBaseFileSystem__LoadFromVPK)(CBaseFileSystem* pFileSystem, FileHandle_t pResults, const char* pszAssetName);
+inline bool(*CBaseFileSystem__LoadFromCache)(CBaseFileSystem* pFileSystem, const char* pszAssetName, FileSystemCache* pCache);
+inline void(*CBaseFileSystem__AddMapPackFile)(CBaseFileSystem* pFileSystem, const char* pPath, const char* pPathID, SearchPathAdd_t addType);
+inline VPKData_t*(*CBaseFileSystem__MountVPKFile)(CBaseFileSystem* pFileSystem, const char* pszVpkPath);
+inline const char* (*CBaseFileSystem__UnmountVPKFile)(CBaseFileSystem* pFileSystem, const char* pszVpkPath);
+inline int(*CBaseFileSystem__GetMountedVPKHandle)(CBaseFileSystem* pFileSystem, const char* pszVpkPath);
 
 extern CBaseFileSystem* g_pFileSystem;
 
@@ -71,32 +58,24 @@ class VBaseFileSystem : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CBaseFileSystem::Warning", p_CBaseFileSystem_Warning.GetPtr());
-		LogFunAdr("CBaseFileSystem::LoadFromVPK", p_CBaseFileSystem_LoadFromVPK.GetPtr());
-		LogFunAdr("CBaseFileSystem::LoadFromCache", p_CBaseFileSystem_LoadFromCache.GetPtr());
-		LogFunAdr("CBaseFileSystem::AddMapPackFile", p_CBaseFileSystem_AddMapPackFile.GetPtr());
-		LogFunAdr("CBaseFileSystem::MountVPKFile", p_CBaseFileSystem_MountVPKFile.GetPtr());
-		LogFunAdr("CBaseFileSystem::UnmountVPKFile", p_CBaseFileSystem_UnmountVPKFile.GetPtr());
-		LogFunAdr("CBaseFileSystem::GetMountedVPKHandle", p_CBaseFileSystem_GetMountedVPKHandle.GetPtr());
-		LogVarAdr("g_pFileSystem", reinterpret_cast<uintptr_t>(g_pFileSystem));
+		LogFunAdr("CBaseFileSystem::Warning", CBaseFileSystem__Warning);
+		LogFunAdr("CBaseFileSystem::LoadFromVPK", CBaseFileSystem__LoadFromVPK);
+		LogFunAdr("CBaseFileSystem::LoadFromCache", CBaseFileSystem__LoadFromCache);
+		LogFunAdr("CBaseFileSystem::AddMapPackFile", CBaseFileSystem__AddMapPackFile);
+		LogFunAdr("CBaseFileSystem::MountVPKFile", CBaseFileSystem__MountVPKFile);
+		LogFunAdr("CBaseFileSystem::UnmountVPKFile", CBaseFileSystem__UnmountVPKFile);
+		LogFunAdr("CBaseFileSystem::GetMountedVPKHandle", CBaseFileSystem__GetMountedVPKHandle);
+		LogVarAdr("g_pFileSystem", g_pFileSystem);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CBaseFileSystem_Warning             = g_GameDll.FindPatternSIMD("4C 89 4C 24 20 C3 CC CC CC CC CC CC CC CC CC CC 48");
-		p_CBaseFileSystem_LoadFromVPK         = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 81 EC ?? ?? ?? ?? 49 8B C0 4C 8D 8C 24 ?? ?? ?? ??");
-		p_CBaseFileSystem_LoadFromCache       = g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 49 8B D8");
-		p_CBaseFileSystem_AddMapPackFile      = g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 48 89 54 24 ?? 55 ?? 41 54 41 55 48 8D AC 24 ?? ?? ?? ??");
-		p_CBaseFileSystem_MountVPKFile        = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 4C 8D 05 ?? ?? ?? ??");
-		p_CBaseFileSystem_UnmountVPKFile      = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 48 8B DA 48 8B F9 48 8B CB 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 85 C0");
-		p_CBaseFileSystem_GetMountedVPKHandle = g_GameDll.FindPatternSIMD("48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 4C 8D 05 ?? ?? ?? ??");
-
-		v_CBaseFileSystem_Warning             = p_CBaseFileSystem_Warning.RCast<void(*)(CBaseFileSystem*, FileWarningLevel_t, const char*, ...)>();  /*4C 89 4C 24 20 C3 ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? 48*/
-		v_CBaseFileSystem_LoadFromVPK         = p_CBaseFileSystem_LoadFromVPK.RCast<FileHandle_t(*)(CBaseFileSystem*, FileHandle_t, const char*)>(); /*48 89 5C 24 ?? 57 48 81 EC ?? ?? ?? ?? 49 8B C0 4C 8D 8C 24 ?? ?? ?? ??*/
-		v_CBaseFileSystem_LoadFromCache       = p_CBaseFileSystem_LoadFromCache.RCast<bool(*)(CBaseFileSystem*, const char*, FileSystemCache*)>();   /*40 53 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 49 8B D8*/
-		v_CBaseFileSystem_AddMapPackFile      = p_CBaseFileSystem_AddMapPackFile.RCast<void (*)(CBaseFileSystem*, const char*, const char*, SearchPathAdd_t)>();
-		v_CBaseFileSystem_MountVPKFile        = p_CBaseFileSystem_MountVPKFile.RCast<VPKData_t*(*)(CBaseFileSystem*, const char*)>();                /*48 89 5C 24 ?? 48 89 6C 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 4C 8D 05 ?? ?? ?? ??*/
-		v_CBaseFileSystem_UnmountVPKFile      = p_CBaseFileSystem_UnmountVPKFile.RCast<const char*(*)(CBaseFileSystem*, const char*)>();             /*48 89 5C 24 ?? 57 48 83 EC 20 48 8B DA 48 8B F9 48 8B CB 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 85 C0*/
-		v_CBaseFileSystem_GetMountedVPKHandle = p_CBaseFileSystem_GetMountedVPKHandle.RCast<int (*)(CBaseFileSystem*, const char*)>();               /*48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 4C 8D 05 ?? ?? ?? ??*/
+		g_GameDll.FindPatternSIMD("4C 89 4C 24 20 C3 CC CC CC CC CC CC CC CC CC CC 48").GetPtr(CBaseFileSystem__Warning);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 81 EC ?? ?? ?? ?? 49 8B C0 4C 8D 8C 24 ?? ?? ?? ??").GetPtr(CBaseFileSystem__LoadFromVPK);
+		g_GameDll.FindPatternSIMD("40 53 48 81 EC ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 49 8B D8").GetPtr(CBaseFileSystem__LoadFromCache);
+		g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 48 89 54 24 ?? 55 ?? 41 54 41 55 48 8D AC 24 ?? ?? ?? ??").GetPtr(CBaseFileSystem__AddMapPackFile);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 4C 8D 05 ?? ?? ?? ??").GetPtr(CBaseFileSystem__MountVPKFile);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 48 8B DA 48 8B F9 48 8B CB 48 8D 15 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 85 C0").GetPtr(CBaseFileSystem__UnmountVPKFile);
+		g_GameDll.FindPatternSIMD("48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 4C 8D 05 ?? ?? ?? ??").GetPtr(CBaseFileSystem__GetMountedVPKHandle);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/filesystem/filesystem.h
+++ b/src/filesystem/filesystem.h
@@ -46,8 +46,8 @@ class VFileSystem_Stdio : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogVarAdr("g_pFullFileSystem", reinterpret_cast<uintptr_t>(g_pFullFileSystem));
-		LogVarAdr("g_pFileSystem_Stdio", reinterpret_cast<uintptr_t>(g_pFileSystem_Stdio));
+		LogVarAdr("g_pFullFileSystem", g_pFullFileSystem);
+		LogVarAdr("g_pFileSystem_Stdio", g_pFileSystem_Stdio);
 	}
 	virtual void GetFun(void) const { }
 	virtual void GetVar(void) const

--- a/src/game/client/input.h
+++ b/src/game/client/input.h
@@ -9,7 +9,6 @@ public:
 private:
 };
 
-inline CMemory p_CInput__SetCustomWeaponActivity;
 inline void(*v_CInput__SetCustomWeaponActivity)(CInput* pInput, int weaponActivity);
 
 inline IInput* g_pInput_VFTable = nullptr;
@@ -20,15 +19,14 @@ class VInput : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogConAdr("CInput::`vftable'", reinterpret_cast<uintptr_t>(g_pInput_VFTable));
-		LogFunAdr("CInput::SetCustomWeaponActivity", p_CInput__SetCustomWeaponActivity.GetPtr());
-		LogVarAdr("g_Input", reinterpret_cast<uintptr_t>(g_pInput));
+		LogConAdr("CInput::`vftable'", g_pInput_VFTable);
+		LogFunAdr("CInput::SetCustomWeaponActivity", v_CInput__SetCustomWeaponActivity);
+		LogVarAdr("g_Input", g_pInput);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CInput__SetCustomWeaponActivity = g_GameDll.
-			FindPatternSIMD("89 91 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC CC F3 0F 11 89 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC F3 0F 10 81 ?? ?? ?? ??");
-		v_CInput__SetCustomWeaponActivity = p_CInput__SetCustomWeaponActivity.RCast<void (*)(CInput*, int)>();
+		g_GameDll.FindPatternSIMD("89 91 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC CC F3 0F 11 89 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC F3 0F 10 81 ?? ?? ?? ??")
+			.GetPtr(v_CInput__SetCustomWeaponActivity);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/game/client/movehelper_client.h
+++ b/src/game/client/movehelper_client.h
@@ -35,12 +35,12 @@ class VMoveHelperClient : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogVarAdr("s_MoveHelperClient", reinterpret_cast<uintptr_t>(s_MoveHelperClient));
+		LogVarAdr("s_MoveHelperClient", s_MoveHelperClient);
 	}
 	virtual void GetFun(void) const { }
 	virtual void GetVar(void) const
 	{
-		CMemory pFunc = g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 80 3D ?? ?? ?? ?? ?? 48 8B D9 74 1A");
+		const CMemory pFunc = g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 80 3D ?? ?? ?? ?? ?? 48 8B D9 74 1A");
 		s_MoveHelperClient = pFunc.FindPattern("4C 8D 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<CMoveHelperClient*>();
 	}
 	virtual void GetCon(void) const { }

--- a/src/game/client/viewrender.cpp
+++ b/src/game/client/viewrender.cpp
@@ -10,7 +10,7 @@
 
 VMatrix* CViewRender::GetWorldMatrixForView(int8_t slot)
 {
-	return CViewRender_GetWorldMatrixForView(this, slot);
+	return CViewRender__GetWorldMatrixForView(this, slot);
 }
 
 const Vector3D& MainViewOrigin()

--- a/src/game/client/viewrender.h
+++ b/src/game/client/viewrender.h
@@ -15,30 +15,28 @@ public:
 const Vector3D& MainViewOrigin();
 const QAngle& MainViewAngles();
 
-inline CMemory p_CViewRender_GetWorldMatrixForView;
-inline VMatrix*(*CViewRender_GetWorldMatrixForView)(CViewRender*, int8_t);
+inline VMatrix*(*CViewRender__GetWorldMatrixForView)(CViewRender*, int8_t);
 
 inline Vector3D* g_vecRenderOrigin = nullptr;
 inline QAngle* g_vecRenderAngles = nullptr;
 
 inline CViewRender* g_pViewRender = nullptr;
-inline CMemory g_pViewRender_VFTable;
+inline void* g_pViewRender_VFTable;
 
 ///////////////////////////////////////////////////////////////////////////////
 class V_ViewRender : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogConAdr("CViewRender::`vftable'", g_pViewRender_VFTable.GetPtr());
-		LogFunAdr("CViewRender::GetWorldMatrixForView", p_CViewRender_GetWorldMatrixForView.GetPtr());
-		LogVarAdr("g_ViewRender", reinterpret_cast<uintptr_t>(g_pViewRender));
-		LogVarAdr("g_vecRenderOrigin", reinterpret_cast<uintptr_t>(g_vecRenderOrigin));
-		LogVarAdr("g_vecRenderAngles", reinterpret_cast<uintptr_t>(g_vecRenderAngles));
+		LogConAdr("CViewRender::`vftable'", g_pViewRender_VFTable);
+		LogFunAdr("CViewRender::GetWorldMatrixForView", CViewRender__GetWorldMatrixForView);
+		LogVarAdr("g_ViewRender", g_pViewRender);
+		LogVarAdr("g_vecRenderOrigin", g_vecRenderOrigin);
+		LogVarAdr("g_vecRenderAngles", g_vecRenderAngles);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CViewRender_GetWorldMatrixForView = g_pViewRender_VFTable.WalkVTable(16).Deref(); // 16th vfunc.
-		CViewRender_GetWorldMatrixForView = p_CViewRender_GetWorldMatrixForView.RCast<VMatrix* (*)(CViewRender*, int8_t)>();
+		CMemory(g_pViewRender_VFTable).WalkVTable(16).Deref().GetPtr(CViewRender__GetWorldMatrixForView); // 16th vfunc.
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/game/server/ai_network.cpp
+++ b/src/game/server/ai_network.cpp
@@ -139,7 +139,7 @@ CAI_Node* CAI_Network::GetPathNode(int id) const
 //-----------------------------------------------------------------------------
 CAI_Node* CAI_Network::AddPathNode(const Vector3D* origin, const float jaw)
 {
-	return v_CAI_Network__AddPathNode(this, origin, jaw);
+	return CAI_Network__AddPathNode(this, origin, jaw);
 }
 
 //-----------------------------------------------------------------------------
@@ -150,11 +150,11 @@ CAI_Node* CAI_Network::AddPathNode(const Vector3D* origin, const float jaw)
 //-----------------------------------------------------------------------------
 CAI_NodeLink* CAI_Network::CreateNodeLink(int srcID, int destID)
 {
-	return v_CAI_Network__CreateNodeLink(this, srcID, destID);
+	return CAI_Network__CreateNodeLink(this, srcID, destID);
 }
 
 //-----------------------------------------------------------------------------
 void VAI_Network::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_CAI_Network__DebugConnectMsg, &CAI_Network::DebugConnectMsg, bAttach);
+	DetourSetup(&CAI_Network__DebugConnectMsg, &CAI_Network::DebugConnectMsg, bAttach);
 }

--- a/src/game/server/ai_network.h
+++ b/src/game/server/ai_network.h
@@ -55,35 +55,25 @@ public:
 };
 inline CAI_Network** g_pAINetwork = nullptr;
 
-inline CMemory p_CAI_Network__AddPathNode;
-inline CAI_Node*(*v_CAI_Network__AddPathNode)(CAI_Network* pNetwork, const Vector3D* origin, float yaw);
-
-inline CMemory p_CAI_Network__CreateNodeLink;
-inline CAI_NodeLink* (*v_CAI_Network__CreateNodeLink)(CAI_Network* pNetwork, int srcID, int destID);
-
-inline CMemory p_CAI_Network__DebugConnectMsg;
-inline void(*v_CAI_Network__DebugConnectMsg)(int node1, int node2, const char* pszformat, ...);
+inline CAI_Node*(*CAI_Network__AddPathNode)(CAI_Network* pNetwork, const Vector3D* origin, float yaw);
+inline CAI_NodeLink* (*CAI_Network__CreateNodeLink)(CAI_Network* pNetwork, int srcID, int destID);
+inline void(*CAI_Network__DebugConnectMsg)(int node1, int node2, const char* pszformat, ...);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VAI_Network : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CAI_Network::AddPathNode", p_CAI_Network__AddPathNode.GetPtr());
-		LogFunAdr("CAI_Network::CreateNodeLink", p_CAI_Network__CreateNodeLink.GetPtr());
-		LogFunAdr("CAI_Network::DebugConnectMsg", p_CAI_Network__DebugConnectMsg.GetPtr());
-		LogVarAdr("g_pAINetwork", reinterpret_cast<uintptr_t>(g_pAINetwork));
+		LogFunAdr("CAI_Network::AddPathNode", CAI_Network__AddPathNode);
+		LogFunAdr("CAI_Network::CreateNodeLink", CAI_Network__CreateNodeLink);
+		LogFunAdr("CAI_Network::DebugConnectMsg", CAI_Network__DebugConnectMsg);
+		LogVarAdr("g_pAINetwork", g_pAINetwork);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CAI_Network__AddPathNode = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 48 8B B9 ?? ?? ?? ?? 48 8B F2 0F 29 74 24 ??");
-		v_CAI_Network__AddPathNode = p_CAI_Network__AddPathNode.RCast<CAI_Node*(*)(CAI_Network*, const Vector3D*, float)>();
-
-		p_CAI_Network__CreateNodeLink = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 57 41 56 48 83 EC 20 49 63 E8");
-		v_CAI_Network__CreateNodeLink = p_CAI_Network__CreateNodeLink.RCast<CAI_NodeLink* (*)(CAI_Network*, int, int)>();
-
-		p_CAI_Network__DebugConnectMsg = g_GameDll.FindPatternSIMD("4C 89 4C 24 ?? 48 83 EC 18");
-		v_CAI_Network__DebugConnectMsg = p_CAI_Network__DebugConnectMsg.RCast<void (*)(int, int, const char*, ...)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 48 8B B9 ?? ?? ?? ?? 48 8B F2 0F 29 74 24 ??").GetPtr(CAI_Network__AddPathNode);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 57 41 56 48 83 EC 20 49 63 E8").GetPtr(CAI_Network__CreateNodeLink);
+		g_GameDll.FindPatternSIMD("4C 89 4C 24 ?? 48 83 EC 18").GetPtr(CAI_Network__DebugConnectMsg);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/game/server/ai_networkmanager.cpp
+++ b/src/game/server/ai_networkmanager.cpp
@@ -519,11 +519,7 @@ CAI_NetworkManager::LoadNetworkGraphEx
 */
 void CAI_NetworkManager::LoadNetworkGraphEx(CAI_NetworkManager* pManager, CUtlBuffer* pBuffer, const char* szAIGraphFile)
 {
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
 	CAI_NetworkManager__LoadNetworkGraph(pManager, pBuffer, szAIGraphFile);
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-	CAI_NetworkManager__LoadNetworkGraph(pManager, pBuffer, szAIGraphFile);
-#endif
 
 	if (ai_ainDumpOnLoad->GetBool())
 	{

--- a/src/game/server/ai_networkmanager.h
+++ b/src/game/server/ai_networkmanager.h
@@ -15,20 +15,11 @@ class CAI_NetworkBuilder;
 class CAI_NetworkManager;
 
 /* ==== CAI_NETWORKMANAGER ============================================================================================================================================== */
-inline CMemory p_CAI_NetworkManager__InitializeAINetworks = nullptr;
 inline void (*CAI_NetworkManager__InitializeAINetworks)(void); // Static
-
-inline CMemory p_CAI_NetworkManager__DelayedInit = nullptr;
 inline void (*CAI_NetworkManager__DelayedInit)(CAI_NetworkManager* thisptr, CAI_Network* pNetwork);
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-inline CMemory p_CAI_NetworkManager__LoadNetworkGraph = nullptr;
 inline void (*CAI_NetworkManager__LoadNetworkGraph)(CAI_NetworkManager* thisptr, CUtlBuffer* pBuffer, const char* pszFileName);
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-inline CMemory p_CAI_NetworkManager__LoadNetworkGraph = nullptr;
-inline void (*CAI_NetworkManager__LoadNetworkGraph)(CAI_NetworkManager* thisptr, CUtlBuffer* pBuffer, const char* pszFileName);
-#endif
+
 /* ==== CAI_NETWORKBUILDER ============================================================================================================================================== */
-inline CMemory p_CAI_NetworkBuilder__Build;
 inline void (*CAI_NetworkBuilder__Build)(CAI_NetworkBuilder* thisptr, CAI_Network* pNetwork);
 
 inline CAI_NetworkManager** g_ppAINetworkManager = nullptr;
@@ -131,39 +122,25 @@ class VAI_NetworkManager : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CAI_NetworkManager::InitializeAINetworks", p_CAI_NetworkManager__InitializeAINetworks.GetPtr());
-		LogFunAdr("CAI_NetworkManager::LoadNetworkGraph", p_CAI_NetworkManager__LoadNetworkGraph.GetPtr());
-		LogFunAdr("CAI_NetworkManager::DelayedInit", p_CAI_NetworkManager__DelayedInit.GetPtr());
-		LogFunAdr("CAI_NetworkBuilder::Build", p_CAI_NetworkBuilder__Build.GetPtr());
-		LogVarAdr("g_pAINetworkManager", reinterpret_cast<uintptr_t>(g_ppAINetworkManager));
-		LogVarAdr("g_AIPathClusters< CAI_Cluster* >", reinterpret_cast<uintptr_t>(g_pAIPathClusters));
-		LogVarAdr("g_AIClusterLinks< CAI_ClusterLink* >", reinterpret_cast<uintptr_t>(g_pAIClusterLinks));
-		LogVarAdr("g_AITraverseNodes< CAI_TraverseNode >", reinterpret_cast<uintptr_t>(g_pAITraverseNodes));
+		LogFunAdr("CAI_NetworkManager::InitializeAINetworks", CAI_NetworkManager__InitializeAINetworks);
+		LogFunAdr("CAI_NetworkManager::LoadNetworkGraph", CAI_NetworkManager__LoadNetworkGraph);
+		LogFunAdr("CAI_NetworkManager::DelayedInit", CAI_NetworkManager__DelayedInit);
+		LogFunAdr("CAI_NetworkBuilder::Build", CAI_NetworkBuilder__Build);
+		LogVarAdr("g_pAINetworkManager", g_ppAINetworkManager);
+		LogVarAdr("g_AIPathClusters< CAI_Cluster* >", g_pAIPathClusters);
+		LogVarAdr("g_AIClusterLinks< CAI_ClusterLink* >", g_pAIClusterLinks);
+		LogVarAdr("g_AITraverseNodes< CAI_TraverseNode >", g_pAITraverseNodes);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CAI_NetworkManager__InitializeAINetworks = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 4C 89 74 24 ?? 55 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? E8 ?? ?? ?? ??");
-		CAI_NetworkManager__InitializeAINetworks = p_CAI_NetworkManager__InitializeAINetworks.RCast<void (*)(void)>();
-
-		p_CAI_NetworkManager__DelayedInit = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B D9 48 8B 0D ?? ?? ?? ?? 8B 41 6C");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CAI_NetworkManager__LoadNetworkGraph = g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 48 89 4C 24 ?? 55 53 57 41 54 41 55 41 56");
-		CAI_NetworkManager__LoadNetworkGraph = p_CAI_NetworkManager__LoadNetworkGraph.RCast<void (*)(CAI_NetworkManager*, CUtlBuffer*, const char*)>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CAI_NetworkManager__LoadNetworkGraph = g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 48 8B FA");
-		CAI_NetworkManager__LoadNetworkGraph = p_CAI_NetworkManager__LoadNetworkGraph.RCast<void (*)(CAI_NetworkManager*, CUtlBuffer*, const char*)>();
-#endif
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CAI_NetworkBuilder__Build = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 4C 24 ?? 57 41 54 41 55 41 56 41 57 48 83 EC 30 48 63 BA ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CAI_NetworkBuilder__Build = g_GameDll.FindPatternSIMD("48 89 54 24 ?? 48 89 4C 24 ?? 53 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 38 8B B2 ?? ?? ?? ??");
-#endif
-		CAI_NetworkManager__DelayedInit = p_CAI_NetworkManager__DelayedInit.RCast<void (*)(CAI_NetworkManager*, CAI_Network*)>();
-		CAI_NetworkBuilder__Build       = p_CAI_NetworkBuilder__Build.RCast<void (*)(CAI_NetworkBuilder*, CAI_Network*)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 4C 89 74 24 ?? 55 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? E8 ?? ?? ?? ??").GetPtr(CAI_NetworkManager__InitializeAINetworks);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B D9 48 8B 0D ?? ?? ?? ?? 8B 41 6C").GetPtr(CAI_NetworkManager__DelayedInit);
+		g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 48 8B FA").GetPtr(CAI_NetworkManager__LoadNetworkGraph);
+		g_GameDll.FindPatternSIMD("48 89 54 24 ?? 48 89 4C 24 ?? 53 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 38 8B B2 ?? ?? ?? ??").GetPtr(CAI_NetworkBuilder__Build);
 	}
 	virtual void GetVar(void) const
 	{
-		g_ppAINetworkManager = p_CAI_NetworkManager__InitializeAINetworks.FindPattern("48 89 05", CMemory::Direction::DOWN)
+		g_ppAINetworkManager = CMemory(CAI_NetworkManager__InitializeAINetworks).FindPattern("48 89 05", CMemory::Direction::DOWN)
 			.ResolveRelativeAddressSelf(0x3, 0x7).RCast<CAI_NetworkManager**>();
 		g_pAIPathClusters = g_GameDll.FindPatternSIMD("F3 0F 10 52 ?? 4C 8B CA")
 			.FindPatternSelf("48 8B 35", CMemory::Direction::DOWN).ResolveRelativeAddressSelf(0x3, 0x7).RCast<CUtlVector<CAI_Cluster*>*>();

--- a/src/game/server/ai_utility.cpp
+++ b/src/game/server/ai_utility.cpp
@@ -72,7 +72,7 @@ uint8_t IsGoalPolyReachable(dtNavMesh* nav, dtPolyRef fromRef, dtPolyRef goalRef
     if (navmesh_always_reachable->GetBool())
         return true;
 
-    return v_dtNavMesh__isPolyReachable(nav, fromRef, goalRef, hullId);
+    return dtNavMesh__isPolyReachable(nav, fromRef, goalRef, hullId);
 }
 
 //-----------------------------------------------------------------------------
@@ -135,6 +135,6 @@ void Detour_HotSwap()
 ///////////////////////////////////////////////////////////////////////////////
 void VRecast::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_dtNavMesh__isPolyReachable, &IsGoalPolyReachable, bAttach);
+	DetourSetup(&dtNavMesh__isPolyReachable, &IsGoalPolyReachable, bAttach);
 	DetourSetup(&v_Detour_LevelInit, &Detour_LevelInit, bAttach);
 }

--- a/src/game/server/baseanimating.cpp
+++ b/src/game/server/baseanimating.cpp
@@ -70,7 +70,7 @@ void CBaseAnimating::HitboxToWorldTransforms(uint32_t iBone, matrix3x4_t* transf
 void CBaseAnimating::LockStudioHdr()
 {
 	// Populates the 'm_pStudioHdr' field.
-	v_CBaseAnimating__LockStudioHdr(this);
+	CBaseAnimating__LockStudioHdr(this);
 }
 
 CStudioHdr* CBaseAnimating::GetModelPtr(void)

--- a/src/game/server/baseanimating.h
+++ b/src/game/server/baseanimating.h
@@ -135,20 +135,18 @@ protected:
 	int m_numAnimSyncScriptProps;
 };
 
-inline CMemory p_CBaseAnimating__LockStudioHdr;
-inline CBaseAnimating*(*v_CBaseAnimating__LockStudioHdr)(CBaseAnimating* thisp);
+inline CBaseAnimating*(*CBaseAnimating__LockStudioHdr)(CBaseAnimating* thisp);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VBaseAnimating : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CBaseAnimating::LockStudioHdr", p_CBaseAnimating__LockStudioHdr.GetPtr());
+		LogFunAdr("CBaseAnimating::LockStudioHdr", CBaseAnimating__LockStudioHdr);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CBaseAnimating__LockStudioHdr = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 41 56 48 83 EC 20 0F BF 41 58");
-		v_CBaseAnimating__LockStudioHdr = p_CBaseAnimating__LockStudioHdr.RCast<CBaseAnimating* (*)(CBaseAnimating* thisp)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 41 56 48 83 EC 20 0F BF 41 58").GetPtr(CBaseAnimating__LockStudioHdr);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/game/server/baseentity.h
+++ b/src/game/server/baseentity.h
@@ -276,25 +276,23 @@ protected:
 };
 static_assert(sizeof(CBaseEntity) == 2824);
 
-inline CMemory p_CBaseEntity__GetBaseEntity;
-inline CBaseEntity*(*v_CBaseEntity__GetBaseEntity)(CBaseEntity* thisp);
+inline CBaseEntity*(*CBaseEntity__GetBaseEntity)(CBaseEntity* thisp);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VBaseEntity : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CBaseEntity::GetBaseEntity", p_CBaseEntity__GetBaseEntity.GetPtr());
-		LogVarAdr("g_pEntityList", reinterpret_cast<uintptr_t>(g_pEntityList));
+		LogFunAdr("CBaseEntity::GetBaseEntity", CBaseEntity__GetBaseEntity);
+		LogVarAdr("g_pEntityList", g_pEntityList);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CBaseEntity__GetBaseEntity = g_GameDll.FindPatternSIMD("8B 91 ?? ?? ?? ?? 83 FA FF 74 1F 0F B7 C2 48 8D 0D ?? ?? ?? ?? C1 EA 10 48 8D 04 40 48 03 C0 39 54 C1 08 75 05 48 8B 04 C1 C3 33 C0 C3 CC CC CC 48 8B 41 30");
-		v_CBaseEntity__GetBaseEntity = p_CBaseEntity__GetBaseEntity.RCast<CBaseEntity* (*)(CBaseEntity* thisp)>();
+		g_GameDll.FindPatternSIMD("8B 91 ?? ?? ?? ?? 83 FA FF 74 1F 0F B7 C2 48 8D 0D ?? ?? ?? ?? C1 EA 10 48 8D 04 40 48 03 C0 39 54 C1 08 75 05 48 8B 04 C1 C3 33 C0 C3 CC CC CC 48 8B 41 30").GetPtr(CBaseEntity__GetBaseEntity);
 	}
 	virtual void GetVar(void) const
 	{
-		g_pEntityList = p_CBaseEntity__GetBaseEntity.FindPattern("48 8D 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<CEntInfo**>();
+		g_pEntityList = CMemory(CBaseEntity__GetBaseEntity).FindPattern("48 8D 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<CEntInfo**>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const { }

--- a/src/game/server/detour_impl.h
+++ b/src/game/server/detour_impl.h
@@ -6,20 +6,11 @@
 //-------------------------------------------------------------------------
 // RUNTIME: DETOUR
 //-------------------------------------------------------------------------
-inline CMemory p_Detour_LevelInit;
 inline void(*v_Detour_LevelInit)(void);
-
-inline CMemory p_Detour_FreeNavMesh;
 inline void(*v_Detour_FreeNavMesh)(dtNavMesh* mesh);
-
-inline CMemory p_dtNavMesh__Init;
-inline dtStatus(*v_dtNavMesh__Init)(dtNavMesh* thisptr, unsigned char* data, int flags);
-
-inline CMemory p_dtNavMesh__addTile;
-inline dtStatus(*v_dtNavMesh__addTile)(dtNavMesh* thisptr, unsigned char* data, dtMeshHeader* header, int dataSize, int flags, dtTileRef lastRef);
-
-inline CMemory p_dtNavMesh__isPolyReachable;
-inline uint8_t(*v_dtNavMesh__isPolyReachable)(dtNavMesh* thisptr, dtPolyRef poly_1, dtPolyRef poly_2, int hull_type);
+inline dtStatus(*dtNavMesh__Init)(dtNavMesh* thisptr, unsigned char* data, int flags);
+inline dtStatus(*dtNavMesh__addTile)(dtNavMesh* thisptr, unsigned char* data, dtMeshHeader* header, int dataSize, int flags, dtTileRef lastRef);
+inline uint8_t(*dtNavMesh__isPolyReachable)(dtNavMesh* thisptr, dtPolyRef poly_1, dtPolyRef poly_2, int hull_type);
 
 
 constexpr const char* NAVMESH_PATH = "maps/navmesh/";
@@ -58,33 +49,21 @@ class VRecast : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Detour_LevelInit", p_Detour_LevelInit.GetPtr());
-		LogFunAdr("Detour_FreeNavMesh", p_Detour_FreeNavMesh.GetPtr());
-		LogFunAdr("dtNavMesh::Init", p_dtNavMesh__Init.GetPtr());
-		LogFunAdr("dtNavMesh::addTile", p_dtNavMesh__addTile.GetPtr());
-		LogFunAdr("dtNavMesh::isPolyReachable", p_dtNavMesh__isPolyReachable.GetPtr());
-		LogVarAdr("g_pNavMesh[ MAX_HULLS ]", reinterpret_cast<uintptr_t>(g_pNavMesh));
-		LogVarAdr("g_pNavMeshQuery", reinterpret_cast<uintptr_t>(g_pNavMeshQuery));
+		LogFunAdr("Detour_LevelInit", v_Detour_LevelInit);
+		LogFunAdr("Detour_FreeNavMesh", v_Detour_FreeNavMesh);
+		LogFunAdr("dtNavMesh::Init", dtNavMesh__Init);
+		LogFunAdr("dtNavMesh::addTile", dtNavMesh__addTile);
+		LogFunAdr("dtNavMesh::isPolyReachable", dtNavMesh__isPolyReachable);
+		LogVarAdr("g_pNavMesh[ MAX_HULLS ]", g_pNavMesh);
+		LogVarAdr("g_pNavMeshQuery", g_pNavMeshQuery);
 	}
 	virtual void GetFun(void) const
 	{
-
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_Detour_LevelInit           = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? 45 33 F6 48 8D 3D ?? ?? ?? ??");
-		p_Detour_FreeNavMesh         = g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 48 89 6C 24 ?? 48 89 74 24 ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_Detour_LevelInit           = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 45 33 E4");
-		p_Detour_FreeNavMesh         = g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 48 89 6C 24 ?? 48 8B D9");
-#endif
-		p_dtNavMesh__Init            = g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 53 41 56 48 81 EC ?? ?? ?? ?? 0F 10 11");
-		p_dtNavMesh__addTile         = g_GameDll.FindPatternSIMD("44 89 4C 24 ?? 41 55");
-		p_dtNavMesh__isPolyReachable = g_GameDll.FindPatternSIMD("48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 49 63 F1");
-
-		v_Detour_LevelInit           = p_Detour_LevelInit.RCast<void(*)(void)>(); /*48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 45 33 E4*/
-		v_Detour_FreeNavMesh         = p_Detour_FreeNavMesh.RCast<void(*)(dtNavMesh*)>();
-		v_dtNavMesh__Init            = p_dtNavMesh__Init.RCast<dtStatus(*)(dtNavMesh*, unsigned char*, int)>();                                   /*4C 89 44 24 ?? 53 41 56 48 81 EC ?? ?? ?? ?? 0F 10 11*/
-		v_dtNavMesh__addTile         = p_dtNavMesh__addTile.RCast<dtStatus(*)(dtNavMesh*, unsigned char*, dtMeshHeader*, int, int, dtTileRef)>(); /*44 89 4C 24 ?? 41 55*/
-		v_dtNavMesh__isPolyReachable = p_dtNavMesh__isPolyReachable.RCast<uint8_t(*)(dtNavMesh*, dtPolyRef, dtPolyRef, int)>();                      /*48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 49 63 F1*/
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 45 33 E4").GetPtr(v_Detour_LevelInit);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 48 89 6C 24 ?? 48 8B D9").GetPtr(v_Detour_FreeNavMesh);
+		g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 53 41 56 48 81 EC ?? ?? ?? ?? 0F 10 11").GetPtr(dtNavMesh__Init);
+		g_GameDll.FindPatternSIMD("44 89 4C 24 ?? 41 55").GetPtr(dtNavMesh__addTile);
+		g_GameDll.FindPatternSIMD("48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 49 63 F1").GetPtr(dtNavMesh__isPolyReachable);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -79,11 +79,9 @@ ServerClass* CServerGameDLL::GetAllServerClasses(void)
 
 void __fastcall CServerGameDLL::OnReceivedSayTextMessage(void* thisptr, int senderId, const char* text, bool isTeamChat)
 {
-#if defined(GAMEDLL_S3)
 	// set isTeamChat to false so that we can let the convar sv_forceChatToTeamOnly decide whether team chat should be enforced
 	// this isn't a great way of doing it but it works so meh
 	CServerGameDLL__OnReceivedSayTextMessage(thisptr, senderId, text, false);
-#endif
 }
 
 void DrawServerHitbox(int iEntity)
@@ -171,10 +169,8 @@ void RunFrameServer(double flFrameTime, bool bRunOverlays, bool bUniformUpdate)
 
 void VServerGameDLL::Detour(const bool bAttach) const
 {
-#if defined(GAMEDLL_S3)
 	DetourSetup(&CServerGameDLL__OnReceivedSayTextMessage, &CServerGameDLL::OnReceivedSayTextMessage, bAttach);
-	DetourSetup(&v_CServerGameClients__ProcessUserCmds, CServerGameClients::ProcessUserCmds, bAttach);
-#endif
+	DetourSetup(&CServerGameClients__ProcessUserCmds, CServerGameClients::ProcessUserCmds, bAttach);
 	DetourSetup(&v_RunFrameServer, &RunFrameServer, bAttach);
 }
 

--- a/src/game/server/gameinterface.h
+++ b/src/game/server/gameinterface.h
@@ -47,14 +47,10 @@ class CServerGameEnts : public IServerGameEnts
 {
 };
 
-inline CMemory p_CServerGameDLL__OnReceivedSayTextMessage;
 inline void(*CServerGameDLL__OnReceivedSayTextMessage)(void* thisptr, int senderId, const char* text, bool isTeamChat);
-
-inline CMemory p_CServerGameClients__ProcessUserCmds;
-inline void(*v_CServerGameClients__ProcessUserCmds)(CServerGameClients* thisp, edict_t edict, bf_read* buf,
+inline void(*CServerGameClients__ProcessUserCmds)(CServerGameClients* thisp, edict_t edict, bf_read* buf,
 	int numCmds, int totalCmds, int droppedPackets, bool ignore, bool paused);
 
-inline CMemory p_RunFrameServer;
 inline void(*v_RunFrameServer)(double flFrameTime, bool bRunOverlays, bool bUniformUpdate);
 
 extern CServerGameDLL* g_pServerGameDLL;
@@ -68,27 +64,19 @@ class VServerGameDLL : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CServerGameDLL::OnReceivedSayTextMessage", p_CServerGameDLL__OnReceivedSayTextMessage.GetPtr());
-		LogFunAdr("CServerGameClients::ProcessUserCmds", p_CServerGameClients__ProcessUserCmds.GetPtr());
-		LogFunAdr("RunFrameServer", p_RunFrameServer.GetPtr());
-		LogVarAdr("g_pServerGameDLL", reinterpret_cast<uintptr_t>(g_pServerGameDLL));
-		LogVarAdr("g_pServerGameClients", reinterpret_cast<uintptr_t>(g_pServerGameClients));
-		LogVarAdr("g_pServerGameEntities", reinterpret_cast<uintptr_t>(g_pServerGameEntities));
-		LogVarAdr("g_pGlobals", reinterpret_cast<uintptr_t>(g_pGlobals));
+		LogFunAdr("CServerGameDLL::OnReceivedSayTextMessage", CServerGameDLL__OnReceivedSayTextMessage);
+		LogFunAdr("CServerGameClients::ProcessUserCmds", CServerGameClients__ProcessUserCmds);
+		LogFunAdr("RunFrameServer", v_RunFrameServer);
+		LogVarAdr("g_pServerGameDLL", g_pServerGameDLL);
+		LogVarAdr("g_pServerGameClients", g_pServerGameClients);
+		LogVarAdr("g_pServerGameEntities", g_pServerGameEntities);
+		LogVarAdr("g_pGlobals", g_pGlobals);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CServerGameDLL__OnReceivedSayTextMessage = g_GameDll.FindPatternSIMD("40 55 57 41 55 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 4C 8B 15 ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CServerGameDLL__OnReceivedSayTextMessage = g_GameDll.FindPatternSIMD("85 D2 0F 8E ?? ?? ?? ?? 4C 8B DC");
-#endif
-		p_CServerGameClients__ProcessUserCmds = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 55 41 57");
-		p_RunFrameServer = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 30 0F 29 74 24 ?? 48 8D 0D ?? ?? ?? ??");
-
-		CServerGameDLL__OnReceivedSayTextMessage = p_CServerGameDLL__OnReceivedSayTextMessage.RCast<void(*)(void*, int, const char*, bool)>();
-		v_CServerGameClients__ProcessUserCmds = p_CServerGameClients__ProcessUserCmds.RCast<void(*)(CServerGameClients*, edict_t, bf_read*, int, int, int, bool, bool)>();
-		v_RunFrameServer = p_RunFrameServer.RCast<void(*)(double, bool, bool)>();
+		g_GameDll.FindPatternSIMD("85 D2 0F 8E ?? ?? ?? ?? 4C 8B DC").GetPtr(CServerGameDLL__OnReceivedSayTextMessage);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 55 41 57").GetPtr(CServerGameClients__ProcessUserCmds);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 30 0F 29 74 24 ?? 48 8D 0D ?? ?? ?? ??").GetPtr(v_RunFrameServer);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/game/server/movehelper_server.h
+++ b/src/game/server/movehelper_server.h
@@ -34,12 +34,12 @@ class VMoveHelperServer : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogVarAdr("s_MoveHelperServer", reinterpret_cast<uintptr_t>(s_MoveHelperServer));
+		LogVarAdr("s_MoveHelperServer", s_MoveHelperServer);
 	}
 	virtual void GetFun(void) const { }
 	virtual void GetVar(void) const
 	{
-		CMemory pFunc = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 85 C0 0F 84 ?? ?? ?? ?? 48 8B 47 10").FollowNearCallSelf();
+		const CMemory pFunc = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 85 C0 0F 84 ?? ?? ?? ?? 48 8B 47 10").FollowNearCallSelf();
 		s_MoveHelperServer = pFunc.FindPattern("48 8D 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<CMoveHelperServer*>();
 	}
 	virtual void GetCon(void) const { }

--- a/src/game/server/physics_main.h
+++ b/src/game/server/physics_main.h
@@ -7,7 +7,6 @@
 #ifndef PHYSICS_MAIN_H
 #define PHYSICS_MAIN_H
 
-inline CMemory p_Physics_RunThinkFunctions;
 inline void(*v_Physics_RunThinkFunctions)(bool bSimulating);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -15,12 +14,11 @@ class VPhysics_Main : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Physics_RunThinkFunctions", p_Physics_RunThinkFunctions.GetPtr());
+		LogFunAdr("Physics_RunThinkFunctions", v_Physics_RunThinkFunctions);
 	}
 	virtual void GetFun(void) const
 	{
-		p_Physics_RunThinkFunctions = g_GameDll.FindPatternSIMD("88 4C 24 08 55 56 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ??");
-		v_Physics_RunThinkFunctions = p_Physics_RunThinkFunctions.RCast<void (*)(bool)>();
+		g_GameDll.FindPatternSIMD("88 4C 24 08 55 56 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ??").GetPtr(v_Physics_RunThinkFunctions);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -48,7 +48,7 @@ void CPlayer::RunNullCommand(void)
 //------------------------------------------------------------------------------
 QAngle* CPlayer::EyeAngles(QAngle* pAngles)
 {
-	return v_CPlayer__EyeAngles(this, pAngles);
+	return CPlayer__EyeAngles(this, pAngles);
 }
 
 //------------------------------------------------------------------------------
@@ -224,7 +224,7 @@ void CPlayer::ProcessUserCmds(CUserCmd* cmds, int numCmds, int totalCmds,
 //------------------------------------------------------------------------------
 void CPlayer::PlayerRunCommand(CUserCmd* pUserCmd, IMoveHelper* pMover)
 {
-	v_CPlayer__PlayerRunCommand(this, pUserCmd, pMover);
+	CPlayer__PlayerRunCommand(this, pUserCmd, pMover);
 }
 
 //------------------------------------------------------------------------------

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -794,27 +794,21 @@ private:
 };
 static_assert(sizeof(CPlayer) == 0x7EF0); // !TODO: backwards compatibility.
 
-inline CMemory p_CPlayer__EyeAngles;
-inline QAngle*(*v_CPlayer__EyeAngles)(CPlayer* pPlayer, QAngle* pAngles);
-
-inline CMemory p_CPlayer__PlayerRunCommand;
-inline void(*v_CPlayer__PlayerRunCommand)(CPlayer* pPlayer, CUserCmd* pUserCmd, IMoveHelper* pMover);
+inline QAngle*(*CPlayer__EyeAngles)(CPlayer* pPlayer, QAngle* pAngles);
+inline void(*CPlayer__PlayerRunCommand)(CPlayer* pPlayer, CUserCmd* pUserCmd, IMoveHelper* pMover);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VPlayer : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CPlayer::EyeAngles", p_CPlayer__EyeAngles.GetPtr());
-		LogFunAdr("CPlayer::PlayerRunCommand", p_CPlayer__PlayerRunCommand.GetPtr());
+		LogFunAdr("CPlayer::EyeAngles", CPlayer__EyeAngles);
+		LogFunAdr("CPlayer::PlayerRunCommand", CPlayer__PlayerRunCommand);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CPlayer__EyeAngles = g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 F2 0F 10 05 ?? ?? ?? ??");
-		v_CPlayer__EyeAngles = p_CPlayer__EyeAngles.RCast<QAngle* (*)(CPlayer*, QAngle*)>();
-
-		p_CPlayer__PlayerRunCommand = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 8B 03 49 81 C6 ?? ?? ?? ??").FollowNearCallSelf();
-		v_CPlayer__PlayerRunCommand = p_CPlayer__PlayerRunCommand.RCast<void (*)(CPlayer*, CUserCmd*, IMoveHelper*)>();
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 F2 0F 10 05 ?? ?? ?? ??").GetPtr(CPlayer__EyeAngles);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 8B 03 49 81 C6 ?? ?? ?? ??").FollowNearCallSelf().GetPtr(CPlayer__PlayerRunCommand);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/game/shared/animation.cpp
+++ b/src/game/shared/animation.cpp
@@ -16,10 +16,10 @@ int CStudioHdr::LookupSequence(CStudioHdr* pStudio, const char* pszName)
 	if (!pStudio->m_pMDLCache)
 		return -1; // animations are unavailable for missing dynamic props! (mdl/error.rmdl).
 
-	return v_CStudioHdr__LookupSequence(pStudio, pszName);
+	return CStudioHdr__LookupSequence(pStudio, pszName);
 }
 
 void VAnimation::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_CStudioHdr__LookupSequence, &CStudioHdr::LookupSequence, bAttach);
+	DetourSetup(&CStudioHdr__LookupSequence, &CStudioHdr::LookupSequence, bAttach);
 }

--- a/src/game/shared/animation.h
+++ b/src/game/shared/animation.h
@@ -81,21 +81,18 @@ struct Player_AnimViewEntityData
 	Vector3D animViewEntityBlendStartEyeAngles;
 };
 
-
-inline CMemory p_CStudioHdr__LookupSequence;
-inline int(*v_CStudioHdr__LookupSequence)(CStudioHdr* pStudio, const char* pszName);
+inline int(*CStudioHdr__LookupSequence)(CStudioHdr* pStudio, const char* pszName);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VAnimation : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CStudioHdr::LookupSequence", p_CStudioHdr__LookupSequence.GetPtr());
+		LogFunAdr("CStudioHdr::LookupSequence", CStudioHdr__LookupSequence);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CStudioHdr__LookupSequence = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B D9 4C 8B C2 48 8B 89 ?? ?? ?? ??");
-		v_CStudioHdr__LookupSequence = p_CStudioHdr__LookupSequence.RCast<int(*)(CStudioHdr*, const char*)>(); /*40 53 48 83 EC 20 48 8B D9 4C 8B C2 48 8B 89 ?? ?? ?? ??*/
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B D9 4C 8B C2 48 8B 89 ?? ?? ?? ??").GetPtr(CStudioHdr__LookupSequence);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/game/shared/r1/weapon_bolt.h
+++ b/src/game/shared/r1/weapon_bolt.h
@@ -13,7 +13,6 @@
 CBaseEntity* CreateWeaponBolt(Vector3D* origin, Vector3D* end, __int64 unused, float scale, CPlayer* unkEnt,
 	int a6, int modelindex, int a8, unsigned __int8 a9, unsigned int a10, CBaseEntity* weaponEnt);
 
-inline CMemory p_CreateWeaponBolt;
 inline CBaseEntity*(*v_CreateWeaponBolt)(
 	Vector3D* origin, Vector3D* end, __int64 unused, float scale, CPlayer* player,
 	int a6, int modelindex, int a8, unsigned __int8 a9, unsigned int a10, CBaseEntity* weapon);
@@ -24,19 +23,12 @@ class V_Weapon_Bolt : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CreateWeaponBolt", p_CreateWeaponBolt.GetPtr());
+		LogFunAdr("CreateWeaponBolt", v_CreateWeaponBolt);
 	}
 	virtual void GetFun(void) const { }
 	virtual void GetVar(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CreateWeaponBolt = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 54 41 55 41 56 48 81 EC ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CreateWeaponBolt = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 41 56 41 57 48 83 EC 70");
-#endif
-		v_CreateWeaponBolt = p_CreateWeaponBolt.RCast<CBaseEntity* (*)(
-			Vector3D*, Vector3D*, __int64, float, CPlayer*,
-			int, int, int, unsigned __int8, unsigned int, CBaseEntity*)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 41 56 41 57 48 83 EC 70").GetPtr(v_CreateWeaponBolt);
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/game/shared/usercmd.h
+++ b/src/game/shared/usercmd.h
@@ -18,16 +18,9 @@
 //-------------------------------------------------------------------------------------
 class CUserCmd;
 
-inline CMemory p_CUserCmd__CUserCmd;
-inline CUserCmd*(*v_CUserCmd__CUserCmd)(CUserCmd* pUserCmd);
-
-inline CMemory p_CUserCmd__Reset;
-inline void(*v_CUserCmd__Reset)(CUserCmd* pUserCmd);
-
-inline CMemory p_CUserCmd__Copy;
-inline CUserCmd*(*v_CUserCmd__Copy)(CUserCmd* pDest, CUserCmd* pSource);
-
-inline CMemory p_ReadUserCmd;
+inline CUserCmd*(*CUserCmd__CUserCmd)(CUserCmd* pUserCmd);
+inline void(*CUserCmd__Reset)(CUserCmd* pUserCmd);
+inline CUserCmd*(*CUserCmd__Copy)(CUserCmd* pDest, CUserCmd* pSource);
 inline int(*v_ReadUserCmd)(bf_read* buf, CUserCmd* move, CUserCmd* from);
 
 //-------------------------------------------------------------------------------------
@@ -38,11 +31,11 @@ class CUserCmd
 public:
 	CUserCmd() // Cannot be constructed during DLL init.
 	{
-		v_CUserCmd__CUserCmd(this);
+		CUserCmd__CUserCmd(this);
 	}
 
-	inline CUserCmd* Copy(CUserCmd* pSource) { return v_CUserCmd__Copy(this, pSource); }
-	inline void Reset() { v_CUserCmd__Reset(this); }
+	inline CUserCmd* Copy(CUserCmd* pSource) { return CUserCmd__Copy(this, pSource); }
+	inline void Reset() { CUserCmd__Reset(this); }
 
 	int32_t command_number;
 	int32_t tick_count;
@@ -99,24 +92,17 @@ class VUserCmd : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CUserCmd::CUserCmd", p_CUserCmd__CUserCmd.GetPtr());
-		LogFunAdr("CUserCmd::Reset", p_CUserCmd__Reset.GetPtr());
-		LogFunAdr("CUserCmd::Copy", p_CUserCmd__Copy.GetPtr());
-		LogFunAdr("ReadUserCmd", p_ReadUserCmd.GetPtr());
+		LogFunAdr("CUserCmd::CUserCmd", CUserCmd__CUserCmd);
+		LogFunAdr("CUserCmd::Reset", CUserCmd__Reset);
+		LogFunAdr("CUserCmd::Copy", CUserCmd__Copy);
+		LogFunAdr("ReadUserCmd", v_ReadUserCmd);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CUserCmd__CUserCmd = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 81 C3 ?? ?? ?? ?? 48 83 EF 01 75 EB 33 C0").FollowNearCallSelf();
-		v_CUserCmd__CUserCmd = p_CUserCmd__CUserCmd.RCast<CUserCmd* (*)(CUserCmd*)>();
-
-		p_CUserCmd__Reset = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 8B DF 66 83 FE FF").FollowNearCallSelf();
-		v_CUserCmd__Reset = p_CUserCmd__Reset.RCast<void(*)(CUserCmd*)>();
-
-		p_CUserCmd__Copy = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 4C 8B 9B ?? ?? ?? ??").FollowNearCallSelf();
-		v_CUserCmd__Copy = p_CUserCmd__Copy.RCast<CUserCmd* (*)(CUserCmd*, CUserCmd*)>();
-
-		p_ReadUserCmd = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 4C 8B C6 48 81 C6 ?? ?? ?? ??").FollowNearCallSelf();
-		v_ReadUserCmd = p_ReadUserCmd.RCast<int (*)(bf_read*, CUserCmd*, CUserCmd*)>();
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 81 C3 ?? ?? ?? ?? 48 83 EF 01 75 EB 33 C0").FollowNearCallSelf().GetPtr(CUserCmd__CUserCmd);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 8B DF 66 83 FE FF").FollowNearCallSelf().GetPtr(CUserCmd__Reset);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 4C 8B 9B ?? ?? ?? ??").FollowNearCallSelf().GetPtr(CUserCmd__Copy);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 4C 8B C6 48 81 C6 ?? ?? ?? ??").FollowNearCallSelf().GetPtr(v_ReadUserCmd);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/game/shared/util_shared.h
+++ b/src/game/shared/util_shared.h
@@ -10,7 +10,6 @@
 class CTraceFilterSimple;
 const char* UTIL_GetEntityScriptInfo(CBaseEntity* pEnt);
 
-inline CMemory p_UTIL_GetEntityScriptInfo;
 inline const char*(*v_UTIL_GetEntityScriptInfo)(CBaseEntity* pEnt);
 
 inline CTraceFilterSimple* g_pTraceFilterSimpleVFTable = nullptr;
@@ -44,14 +43,13 @@ class VUtil_Shared : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogConAdr("CTraceFilterSimple::`vftable'", reinterpret_cast<uintptr_t>(g_pTraceFilterSimpleVFTable));
-		LogFunAdr("UTIL_GetEntityScriptInfo", p_UTIL_GetEntityScriptInfo.GetPtr());
+		LogConAdr("CTraceFilterSimple::`vftable'", g_pTraceFilterSimpleVFTable);
+		LogFunAdr("UTIL_GetEntityScriptInfo", v_UTIL_GetEntityScriptInfo);
 	}
 	virtual void GetFun(void) const { }
 	virtual void GetVar(void) const
 	{
-		p_UTIL_GetEntityScriptInfo = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 4C 8B 5E ??").FollowNearCallSelf();
-		v_UTIL_GetEntityScriptInfo = p_UTIL_GetEntityScriptInfo.RCast<const char* (*)(CBaseEntity* pEnt)>();
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 4C 8B 5E ??").FollowNearCallSelf().GetPtr(v_UTIL_GetEntityScriptInfo);
 	}
 	virtual void GetCon(void) const
 	{

--- a/src/game/shared/vscript_shared.h
+++ b/src/game/shared/vscript_shared.h
@@ -3,11 +3,8 @@
 #include "vscript/languages/squirrel_re/include/squirrel.h"
 #include "vscript/languages/squirrel_re/vsquirrel.h"
 
-inline CMemory p_Script_Remote_BeginRegisteringFunctions;
-inline void*(*Script_Remote_BeginRegisteringFunctions)(void);
-
-inline CMemory p_RestoreRemoteChecksumsFromSaveGame;
-inline void*(*RestoreRemoteChecksumsFromSaveGame)(void* a1, void* a2);
+inline void*(*v_Script_Remote_BeginRegisteringFunctions)(void);
+inline void*(*v_RestoreRemoteChecksumsFromSaveGame)(void* a1, void* a2);
 
 inline uint32_t* g_nServerRemoteChecksum = nullptr;
 inline uint32_t* g_nClientRemoteChecksum = nullptr;
@@ -35,23 +32,20 @@ class VScriptShared : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Remote_BeginRegisteringFunctions", p_Script_Remote_BeginRegisteringFunctions.GetPtr());
-		LogFunAdr("RestoreRemoteChecksumsFromSaveGame", p_RestoreRemoteChecksumsFromSaveGame.GetPtr());
-		LogVarAdr("g_nServerRemoteChecksum", reinterpret_cast<uintptr_t>(g_nServerRemoteChecksum));
-		LogVarAdr("g_nClientRemoteChecksum", reinterpret_cast<uintptr_t>(g_nClientRemoteChecksum));
+		LogFunAdr("Remote_BeginRegisteringFunctions", v_Script_Remote_BeginRegisteringFunctions);
+		LogFunAdr("RestoreRemoteChecksumsFromSaveGame", v_RestoreRemoteChecksumsFromSaveGame);
+		LogVarAdr("g_nServerRemoteChecksum", g_nServerRemoteChecksum);
+		LogVarAdr("g_nClientRemoteChecksum", g_nClientRemoteChecksum);
 	}
 	virtual void GetFun(void) const
 	{
-		p_Script_Remote_BeginRegisteringFunctions = g_GameDll.FindPatternSIMD("48 83 EC 28 83 3D ?? ?? ?? ?? ?? 74 10");
-		p_RestoreRemoteChecksumsFromSaveGame      = g_GameDll.FindPatternSIMD("48 89 4C 24 ?? 41 54 48 83 EC 40");
-
-		Script_Remote_BeginRegisteringFunctions = p_Script_Remote_BeginRegisteringFunctions.RCast<void* (*)(void)>();          /*48 83 EC 28 83 3D ?? ?? ?? ?? ?? 74 10*/
-		RestoreRemoteChecksumsFromSaveGame      = p_RestoreRemoteChecksumsFromSaveGame.RCast<void* (*)(void* a1, void* a2)>(); /*48 89 4C 24 ?? 41 54 48 83 EC 40*/
+		g_GameDll.FindPatternSIMD("48 83 EC 28 83 3D ?? ?? ?? ?? ?? 74 10").GetPtr(v_Script_Remote_BeginRegisteringFunctions);
+		g_GameDll.FindPatternSIMD("48 89 4C 24 ?? 41 54 48 83 EC 40").GetPtr(v_RestoreRemoteChecksumsFromSaveGame);
 	}
 	virtual void GetVar(void) const
 	{
-		g_nServerRemoteChecksum = p_RestoreRemoteChecksumsFromSaveGame.Offset(0x1C0).FindPatternSelf("48 8D 15", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x3, 0x7).RCast<uint32_t*>();
-		g_nClientRemoteChecksum = p_Script_Remote_BeginRegisteringFunctions.Offset(0x0).FindPatternSelf("89 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x6).RCast<uint32_t*>();
+		g_nServerRemoteChecksum = CMemory(v_RestoreRemoteChecksumsFromSaveGame).Offset(0x1C0).FindPatternSelf("48 8D 15", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x3, 0x7).RCast<uint32_t*>();
+		g_nClientRemoteChecksum = CMemory(v_Script_Remote_BeginRegisteringFunctions).Offset(0x0).FindPatternSelf("89 05", CMemory::Direction::DOWN, 150).ResolveRelativeAddressSelf(0x2, 0x6).RCast<uint32_t*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const { }

--- a/src/gameui/IBrowser.cpp
+++ b/src/gameui/IBrowser.cpp
@@ -602,7 +602,7 @@ void CBrowser::HostPanel(void)
         {
             g_TaskScheduler->Dispatch([]()
                 {
-                    _DownloadPlaylists_f();
+                    v__DownloadPlaylists_f();
                     KeyValues::InitPlaylists(); // Re-Init playlist.
                 }, 0);
         }
@@ -745,7 +745,7 @@ void CBrowser::UpdateHostingStatus(void)
                 g_pServerListManager->m_Server.m_svDescription,
                 g_pServerListManager->m_Server.m_bHidden,
                 g_pHostState->m_levelName,
-                KeyValues_GetCurrentPlaylist(),
+                KeyValues__GetCurrentPlaylist(),
                 hostip->GetString(),
                 hostport->GetInt(),
                 g_pNetKey->GetBase64NetKey(),

--- a/src/inputsystem/inputsystem.cpp
+++ b/src/inputsystem/inputsystem.cpp
@@ -64,13 +64,13 @@ LRESULT CInputSystem::WindowProc(void* unused, HWND hwnd, UINT uMsg, WPARAM wPar
 		}
 	}
 
-	return v_CInputSystem__WindowProc(unused, hwnd, uMsg, wParam, lParam);
+	return CInputSystem__WindowProc(unused, hwnd, uMsg, wParam, lParam);
 }
 
 
 void VInputSystem::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_CInputSystem__WindowProc, &CInputSystem::WindowProc, bAttach);
+	DetourSetup(&CInputSystem__WindowProc, &CInputSystem::WindowProc, bAttach);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/inputsystem/inputsystem.h
+++ b/src/inputsystem/inputsystem.h
@@ -165,7 +165,7 @@ private:
 static_assert(sizeof(CInputSystem) == 0x18E8);
 
 ///////////////////////////////////////////////////////////////////////////////
-inline LRESULT (*v_CInputSystem__WindowProc)(void* thisptr, HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+inline LRESULT (*CInputSystem__WindowProc)(void* thisptr, HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 extern CInputSystem* g_pInputSystem;
 extern bool(**g_fnSyncRTWithIn)(void); // Belongs to an array of functions, see CMaterialSystem::MatsysMode_Init().
@@ -175,13 +175,13 @@ class VInputSystem : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CInputSystem::WindowProc", reinterpret_cast<uintptr_t>(v_CInputSystem__WindowProc));
-		LogVarAdr("g_pInputSystem", reinterpret_cast<uintptr_t>(g_pInputSystem));
-		LogVarAdr("g_fnSyncRTWithIn", reinterpret_cast<uintptr_t>(g_fnSyncRTWithIn));
+		LogFunAdr("CInputSystem::WindowProc", CInputSystem__WindowProc);
+		LogVarAdr("g_pInputSystem", g_pInputSystem);
+		LogVarAdr("g_fnSyncRTWithIn", g_fnSyncRTWithIn);
 	}
 	virtual void GetFun(void) const
 	{
-		g_GameDll.FindPatternSIMD("48 89 4C 24 ?? 55 56 41 54 41 55 48 83 EC 48", v_CInputSystem__WindowProc);
+		g_GameDll.FindPatternSIMD("48 89 4C 24 ?? 55 56 41 54 41 55 48 83 EC 48").GetPtr(CInputSystem__WindowProc);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/launcher/launcher.cpp
+++ b/src/launcher/launcher.cpp
@@ -25,7 +25,6 @@ int LauncherMain(HINSTANCE hInstance)
 	return results;
 }
 
-#if !defined (GAMEDLL_S0) || !defined (GAMEDLL_S1)
 // Remove all but the last -game parameter.
 // This is for mods based off something other than Half-Life 2 (like HL2MP mods).
 // The Steam UI does 'steam -applaunch 320 -game c:\steam\steamapps\sourcemods\modname', but applaunch inserts
@@ -52,7 +51,6 @@ void RemoveSpuriousGameParameters()
 		CommandLine()->AppendParm("-game", lastGameArg);
 	}
 }
-#endif
 
 const char* ExitCodeToString(int nCode)
 {
@@ -83,7 +81,5 @@ void VLauncher::Detour(const bool bAttach) const
 {
 	DetourSetup(&v_LauncherMain, &LauncherMain, bAttach);
 	DetourSetup(&v_TopLevelExceptionFilter, &TopLevelExceptionFilter, bAttach);
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
 	DetourSetup(&v_RemoveSpuriousGameParameters, &RemoveSpuriousGameParameters, bAttach);
-#endif
 }

--- a/src/launcher/launcher.h
+++ b/src/launcher/launcher.h
@@ -1,16 +1,9 @@
 #ifndef LAUNCHER_H
 #define LAUNCHER_H
 
-inline CMemory p_LauncherMain;
 inline int(*v_LauncherMain)(HINSTANCE hInstance);
-
-inline CMemory p_TopLevelExceptionFilter;
 inline LONG(*v_TopLevelExceptionFilter)(EXCEPTION_POINTERS* pExceptionPointer);
-
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
-inline CMemory p_RemoveSpuriousGameParameters;
 inline void(*v_RemoveSpuriousGameParameters)(void);
-#endif // !GAMEDLL_S0 || !GAMEDLL_S1
 
 const char* ExitCodeToString(int nCode);
 
@@ -19,24 +12,15 @@ class VLauncher : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("LauncherMain", p_LauncherMain.GetPtr());
-		LogFunAdr("TopLevelExceptionFilter", p_TopLevelExceptionFilter.GetPtr());
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
-		LogFunAdr("RemoveSpuriousGameParameters", p_RemoveSpuriousGameParameters.GetPtr());
-#endif // !GAMEDLL_S0 || !GAMEDLL_S1
+		LogFunAdr("LauncherMain", v_LauncherMain);
+		LogFunAdr("TopLevelExceptionFilter", v_TopLevelExceptionFilter);
+		LogFunAdr("RemoveSpuriousGameParameters", v_RemoveSpuriousGameParameters);
 	}
 	virtual void GetFun(void) const
 	{
-		p_LauncherMain = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 8B C8 E8 ?? ?? ?? ?? CC").FollowNearCallSelf();
-		v_LauncherMain = p_LauncherMain.RCast<int(*)(HINSTANCE)>();
-
-		p_TopLevelExceptionFilter = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B 05 ?? ?? ?? ?? 48 8B D9 48 85 C0 74 06");
-		v_TopLevelExceptionFilter = p_TopLevelExceptionFilter.RCast<LONG(*)(EXCEPTION_POINTERS*)>();
-
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
-		p_RemoveSpuriousGameParameters = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 33 ED 48 8D 3D ?? ?? ?? ??");
-		v_RemoveSpuriousGameParameters = p_RemoveSpuriousGameParameters.RCast<void (*)(void)>();
-#endif // !GAMEDLL_S0 || !GAMEDLL_S1
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 8B C8 E8 ?? ?? ?? ?? CC").FollowNearCallSelf().GetPtr(v_LauncherMain);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B 05 ?? ?? ?? ?? 48 8B D9 48 85 C0 74 06").GetPtr(v_TopLevelExceptionFilter);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 33 ED 48 8D 3D ?? ?? ?? ??").GetPtr(v_RemoveSpuriousGameParameters);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/launcher/prx.h
+++ b/src/launcher/prx.h
@@ -1,7 +1,6 @@
 #pragma once
 
 /* ==== PRX ============================================================================================================================================================= */
-inline CMemory p_exit_or_terminate_process;
 inline void(*v_exit_or_terminate_process)(UINT uExitCode);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9,12 +8,11 @@ class VPRX : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("exit_or_terminate_process", p_exit_or_terminate_process.GetPtr());
+		LogFunAdr("exit_or_terminate_process", v_exit_or_terminate_process);
 	}
 	virtual void GetFun(void) const
 	{
-		p_exit_or_terminate_process = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 8B D9 E8 ?? ?? ?? ?? 84 C0");
-		v_exit_or_terminate_process = p_exit_or_terminate_process.RCast<void(*)(UINT uExitCode)>(); /*40 53 48 83 EC 20 8B D9 E8 ? ? ? ? 84 C0 */
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 8B D9 E8 ?? ?? ?? ?? 84 C0").GetPtr(v_exit_or_terminate_process);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/localize/localize.cpp
+++ b/src/localize/localize.cpp
@@ -5,7 +5,7 @@
 
 bool Localize_LoadLocalizationFileLists(CLocalize* thisptr)
 {
-	v_CLocalize__LoadLocalizationFileLists(thisptr);
+	CLocalize__LoadLocalizationFileLists(thisptr);
 
 	const CUtlVector<CModSystem::ModInstance_t*>&
 		modList = g_pModSystem->GetModList();
@@ -22,7 +22,7 @@ bool Localize_LoadLocalizationFileLists(CLocalize* thisptr)
 		{
 			const char* localizationFile = mod->m_LocalizationFiles.Element(j).Get();
 
-			if (!v_CLocalize__AddFile(thisptr, localizationFile, "PLATFORM"))
+			if (!CLocalize__AddFile(thisptr, localizationFile, "PLATFORM"))
 				Warning(eDLL_T::ENGINE, "Failed to add localization file '%s'\n", localizationFile);
 		}
 	}
@@ -43,5 +43,5 @@ bool Localize_IsLanguageSupported(const char* pLocaleName)
 
 void VLocalize::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_CLocalize__LoadLocalizationFileLists, &Localize_LoadLocalizationFileLists, bAttach);
+	DetourSetup(&CLocalize__LoadLocalizationFileLists, &Localize_LoadLocalizationFileLists, bAttach);
 }

--- a/src/localize/localize.h
+++ b/src/localize/localize.h
@@ -13,12 +13,8 @@ class CLocalize : public CBaseAppSystem< ILocalize >
 	bool m_bQueuedChangeCallback;
 };
 
-inline CMemory p_CLocalize__AddFile;
-inline bool(*v_CLocalize__AddFile)(CLocalize * thisptr, const char* szFileName, const char* pPathID);
-
-inline CMemory p_CLocalize__LoadLocalizationFileLists;
-inline bool(*v_CLocalize__LoadLocalizationFileLists)(CLocalize * thisptr);
-
+inline bool(*CLocalize__AddFile)(CLocalize * thisptr, const char* szFileName, const char* pPathID);
+inline bool(*CLocalize__LoadLocalizationFileLists)(CLocalize * thisptr);
 
 inline CLocalize** g_ppVGuiLocalize;
 inline CLocalize** g_ppLocalize;
@@ -28,17 +24,14 @@ class VLocalize : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CLocalize::AddFile", p_CLocalize__AddFile.GetPtr());
-		LogFunAdr("CLocalize::LoadLocalizationFileLists", p_CLocalize__LoadLocalizationFileLists.GetPtr());
-		LogFunAdr("g_Localize", reinterpret_cast<uintptr_t>(g_ppLocalize));
+		LogFunAdr("CLocalize::AddFile", CLocalize__AddFile);
+		LogFunAdr("CLocalize::LoadLocalizationFileLists", CLocalize__LoadLocalizationFileLists);
+		LogFunAdr("g_Localize", g_ppLocalize);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CLocalize__AddFile = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 49 FF C4").FollowNearCallSelf();
-		v_CLocalize__AddFile = p_CLocalize__AddFile.RCast<bool(*)(CLocalize*, const char*, const char*)>();
-
-		p_CLocalize__LoadLocalizationFileLists = g_GameDll.FindPatternSIMD("4C 8B DC 53 48 81 EC ?? ?? ?? ?? 33 C0");
-		v_CLocalize__LoadLocalizationFileLists = p_CLocalize__LoadLocalizationFileLists.RCast<bool(*)(CLocalize*)>();
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 49 FF C4").FollowNearCallSelf().GetPtr(CLocalize__AddFile);
+		g_GameDll.FindPatternSIMD("4C 8B DC 53 48 81 EC ?? ?? ?? ?? 33 C0").GetPtr(CLocalize__LoadLocalizationFileLists);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/materialsystem/cmaterialglue.h
+++ b/src/materialsystem/cmaterialglue.h
@@ -68,8 +68,7 @@ inline void* g_pMaterialGlueVFTable = nullptr;
 
 /* ==== CMATERIALGLUE ================================================================================================================================================== */
 #ifndef DEDICATED
-inline CMemory p_GetMaterialAtCrossHair;
-inline CMaterialGlue*(*GetMaterialAtCrossHair)(void);
+inline CMaterialGlue*(*v_GetMaterialAtCrossHair)(void);
 #endif // !DEDICATED
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -77,16 +76,15 @@ class VMaterialGlue : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogConAdr("CMaterialGlue::`vftable'", reinterpret_cast<uintptr_t>(g_pMaterialGlueVFTable));
+		LogConAdr("CMaterialGlue::`vftable'", g_pMaterialGlueVFTable);
 #ifndef DEDICATED
-		LogFunAdr("CMaterialGlue::GetMaterialAtCrossHair", p_GetMaterialAtCrossHair.GetPtr());
+		LogFunAdr("CMaterialGlue::GetMaterialAtCrossHair", v_GetMaterialAtCrossHair);
 #endif // !DEDICATED
 	}
 	virtual void GetFun(void) const
 	{
 #ifndef DEDICATED
-		p_GetMaterialAtCrossHair = g_GameDll.FindPatternSIMD("48 8B C4 48 83 EC 58 48 83 3D ?? ?? ?? ?? ??");
-		GetMaterialAtCrossHair = p_GetMaterialAtCrossHair.RCast<CMaterialGlue* (*)(void)>(); /*48 8B C4 48 83 EC 58 48 83 3D ? ? ? ? ?*/
+		g_GameDll.FindPatternSIMD("48 8B C4 48 83 EC 58 48 83 3D ?? ?? ?? ?? ??").GetPtr(v_GetMaterialAtCrossHair);
 #endif // !DEDICATED
 	}
 	virtual void GetVar(void) const { }

--- a/src/materialsystem/cmaterialsystem.cpp
+++ b/src/materialsystem/cmaterialsystem.cpp
@@ -95,22 +95,15 @@ void StreamDB_Init(const char* pszLevelName)
 //---------------------------------------------------------------------------------
 // Purpose: draw frame
 //---------------------------------------------------------------------------------
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-void* __fastcall DispatchDrawCall(int64_t a1, uint64_t a2, int a3, int a4, char a5, int a6, uint8_t a7, int64_t a8, uint32_t a9, uint32_t a10, __m128* a11, int a12)
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 void* __fastcall DispatchDrawCall(int64_t a1, uint64_t a2, int a3, int a4, int64_t a5, int a6, uint8_t a7, int64_t a8, uint32_t a9, uint32_t a10, int a11, __m128* a12, int a13, int64_t a14)
-#endif
 {
 	// This only happens when the BSP is in a horrible condition (bad depth buffer draw calls!)
 	// but allows you to load BSP's with virtually all missing shaders/materials and models 
 	// being replaced with 'material_for_aspect/error.rpak' and 'mdl/error.rmdl'.
-	if (!s_pRenderContext.GetValue<void*>())
+	if (!*s_pRenderContext)
 		return nullptr;
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-	return v_DispatchDrawCall(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
+
 	return v_DispatchDrawCall(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
-#endif
 }
 
 //---------------------------------------------------------------------------------
@@ -165,7 +158,7 @@ Vector2D CMaterialSystem::GetScreenSize(CMaterialSystem* pMatSys)
 {
 	Vector2D vecScreenSize;
 
-	CMaterialSystem_GetScreenSize(pMatSys, &vecScreenSize.x, &vecScreenSize.y);
+	CMaterialSystem__GetScreenSize(pMatSys, &vecScreenSize.x, &vecScreenSize.y);
 
 	return vecScreenSize;
 }

--- a/src/materialsystem/cmaterialsystem.h
+++ b/src/materialsystem/cmaterialsystem.h
@@ -57,41 +57,22 @@ inline CMaterialDeviceMgr* g_pMaterialAdapterMgr = nullptr;
 #endif // !MATERIALSYSTEM_NODX
 
 /* ==== MATERIALSYSTEM ================================================================================================================================================== */
-inline CMemory p_CMaterialSystem__Init;
 inline InitReturnVal_t(*CMaterialSystem__Init)(CMaterialSystem* thisptr);
-
-inline CMemory p_CMaterialSystem__Shutdown;
 inline int(*CMaterialSystem__Shutdown)(CMaterialSystem* thisptr);
-
-inline CMemory p_CMaterialSystem__Disconnect;
 inline void(*CMaterialSystem__Disconnect)(void);
 
 inline CMaterialSystem* g_pMaterialSystem = nullptr;
 inline void* g_pMaterialVFTable = nullptr;
 #ifndef MATERIALSYSTEM_NODX
-inline CMemory p_CMaterialSystem__FindMaterialEx;
 inline CMaterialGlue*(*CMaterialSystem__FindMaterialEx)(CMaterialSystem* pMatSys, const char* pMaterialName, uint8_t nMaterialType, int nUnk, bool bComplain);
+inline void(*CMaterialSystem__GetScreenSize)(CMaterialSystem* pMatSys, float* outX, float* outY);
 
-inline CMemory p_CMaterialSystem_GetScreenSize;
-inline void(*CMaterialSystem_GetScreenSize)(CMaterialSystem* pMatSys, float* outX, float* outY);
-
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-inline CMemory p_DispatchDrawCall;
-inline void*(*v_DispatchDrawCall)(int64_t a1, uint64_t a2, int a3, int a4, char a5, int a6, uint8_t a7, int64_t a8, uint32_t a9, uint32_t a10, __m128* a11, int a12);
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-inline CMemory p_DispatchDrawCall;
 inline void*(*v_DispatchDrawCall)(int64_t a1, uint64_t a2, int a3, int a4, int64_t a5, int a6, uint8_t a7, int64_t a8, uint32_t a9, uint32_t a10, int a11, __m128* a12, int a13, int64_t a14);
-#endif
-inline CMemory p_SpinPresent;
 inline ssize_t(*v_SpinPresent)(void);
+inline void(*CMaterialSystem__GetStreamOverlay)(const char* mode, char* buf, size_t bufSize);
+inline const char*(*CMaterialSystem__DrawStreamOverlay)(void* thisptr, uint8_t* a2, void* unused, void* a4);
 
-inline CMemory p_GetStreamOverlay;
-inline void(*v_GetStreamOverlay)(const char* mode, char* buf, size_t bufSize);
-
-inline CMemory p_DrawStreamOverlay;
-inline const char*(*v_DrawStreamOverlay)(void* thisptr, uint8_t* a2, void* unused, void* a4);
-
-inline CMemory s_pRenderContext; // NOTE: This is some CMaterial instance or array.
+inline void** s_pRenderContext; // NOTE: This is some CMaterial instance or array.
 
 inline int* g_nTotalStreamingTextureMemory    = nullptr;
 inline int* g_nUnfreeStreamingTextureMemory   = nullptr;
@@ -110,67 +91,49 @@ class VMaterialSystem : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogConAdr("CMaterial::`vftable'", reinterpret_cast<uintptr_t>(g_pMaterialVFTable));
-		LogFunAdr("CMaterialSystem::Init", p_CMaterialSystem__Init.GetPtr());
-		LogFunAdr("CMaterialSystem::Shutdown", p_CMaterialSystem__Shutdown.GetPtr());
-		LogFunAdr("CMaterialSystem::Disconnect", p_CMaterialSystem__Disconnect.GetPtr());
+		LogConAdr("CMaterial::`vftable'", g_pMaterialVFTable);
+		LogFunAdr("CMaterialSystem::Init", CMaterialSystem__Init);
+		LogFunAdr("CMaterialSystem::Shutdown", CMaterialSystem__Shutdown);
+		LogFunAdr("CMaterialSystem::Disconnect", CMaterialSystem__Disconnect);
 #ifndef MATERIALSYSTEM_NODX
-		LogFunAdr("CMaterialSystem::FindMaterialEx", p_CMaterialSystem__FindMaterialEx.GetPtr());
-		LogFunAdr("CMaterialSystem::GetScreenSize", p_CMaterialSystem_GetScreenSize.GetPtr());
-		LogFunAdr("CMaterialSystem::GetStreamOverlay", p_GetStreamOverlay.GetPtr());
-		LogFunAdr("CMaterialSystem::DrawStreamOverlay", p_DrawStreamOverlay.GetPtr());
-		LogFunAdr("DispatchDrawCall", p_DispatchDrawCall.GetPtr());
-		LogFunAdr("SpinPresent", p_SpinPresent.GetPtr());
-		LogVarAdr("g_nTotalStreamingTextureMemory", reinterpret_cast<uintptr_t>(g_nTotalStreamingTextureMemory));
-		LogVarAdr("g_nUnfreeStreamingTextureMemory", reinterpret_cast<uintptr_t>(g_nUnfreeStreamingTextureMemory));
-		LogVarAdr("g_nUnusableStreamingTextureMemory", reinterpret_cast<uintptr_t>(g_nUnusableStreamingTextureMemory));
-		LogVarAdr("s_pRenderContext", s_pRenderContext.GetPtr());
-		LogVarAdr("g_MaterialAdapterMgr", reinterpret_cast<uintptr_t>(g_pMaterialAdapterMgr));
+		LogFunAdr("CMaterialSystem::FindMaterialEx", CMaterialSystem__FindMaterialEx);
+		LogFunAdr("CMaterialSystem::GetScreenSize", CMaterialSystem__GetScreenSize);
+		LogFunAdr("CMaterialSystem::GetStreamOverlay", CMaterialSystem__GetStreamOverlay);
+		LogFunAdr("CMaterialSystem::DrawStreamOverlay", CMaterialSystem__DrawStreamOverlay);
+		LogFunAdr("DispatchDrawCall", v_DispatchDrawCall);
+		LogFunAdr("SpinPresent", v_SpinPresent);
+		LogVarAdr("g_nTotalStreamingTextureMemory", g_nTotalStreamingTextureMemory);
+		LogVarAdr("g_nUnfreeStreamingTextureMemory", g_nUnfreeStreamingTextureMemory);
+		LogVarAdr("g_nUnusableStreamingTextureMemory", g_nUnusableStreamingTextureMemory);
+		LogVarAdr("s_pRenderContext", s_pRenderContext);
+		LogVarAdr("g_MaterialAdapterMgr", g_pMaterialAdapterMgr);
 #endif // !MATERIALSYSTEM_NODX
-		LogVarAdr("g_pMaterialSystem", reinterpret_cast<uintptr_t>(g_pMaterialSystem));
+		LogVarAdr("g_pMaterialSystem", g_pMaterialSystem);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CMaterialSystem__Init = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 70 48 83 3D ?? ?? ?? ?? ??");
-		CMaterialSystem__Init = p_CMaterialSystem__Init.RCast<InitReturnVal_t(*)(CMaterialSystem*)>(); /*48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 70 48 83 3D ?? ?? ?? ?? ??*/
-
-		p_CMaterialSystem__Shutdown = g_GameDll.FindPatternSIMD("48 83 EC 58 48 89 6C 24 ??");
-		CMaterialSystem__Shutdown = p_CMaterialSystem__Shutdown.RCast<int(*)(CMaterialSystem*)>(); /*48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 70 48 83 3D ?? ?? ?? ?? ??*/
-
-		p_CMaterialSystem__Disconnect = g_GameDll.FindPatternSIMD("48 83 EC 28 8B 0D ?? ?? ?? ?? 48 89 6C 24 ??");
-		CMaterialSystem__Disconnect = p_CMaterialSystem__Disconnect.RCast<void(*)(void)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 70 48 83 3D ?? ?? ?? ?? ??").GetPtr(CMaterialSystem__Init);
+		g_GameDll.FindPatternSIMD("48 83 EC 58 48 89 6C 24 ??").GetPtr(CMaterialSystem__Shutdown);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 8B 0D ?? ?? ?? ?? 48 89 6C 24 ??").GetPtr(CMaterialSystem__Disconnect);
 #ifndef MATERIALSYSTEM_NODX
-		p_CMaterialSystem__FindMaterialEx = g_GameDll.FindPatternSIMD("44 89 4C 24 ?? 44 88 44 24 ?? 48 89 4C 24 ??");
-		CMaterialSystem__FindMaterialEx = p_CMaterialSystem__FindMaterialEx.RCast<CMaterialGlue*(*)(CMaterialSystem*, const char*, uint8_t, int, bool)>(); /*44 89 4C 24 ?? 44 88 44 24 ?? 48 89 4C 24 ??*/
+		g_GameDll.FindPatternSIMD("44 89 4C 24 ?? 44 88 44 24 ?? 48 89 4C 24 ??").GetPtr(CMaterialSystem__FindMaterialEx);
+		g_GameDll.FindPatternSIMD("8B 05 ?? ?? ?? ?? 89 02 8B 05 ?? ?? ?? ?? 41 89 ?? C3 CC CC CC CC CC CC CC CC CC CC CC CC CC CC 8B 05 ?? ?? ?? ??").GetPtr(CMaterialSystem__GetScreenSize);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 80 7C 24 ?? ?? 0F 84 ?? ?? ?? ?? 48 89 9C 24 ?? ?? ?? ??").FollowNearCallSelf().GetPtr(CMaterialSystem__GetStreamOverlay);
+		g_GameDll.FindPatternSIMD("41 56 B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 C6 02 ??").GetPtr(CMaterialSystem__DrawStreamOverlay);
 
-		p_CMaterialSystem_GetScreenSize = g_GameDll.FindPatternSIMD("8B 05 ?? ?? ?? ?? 89 02 8B 05 ?? ?? ?? ?? 41 89 ?? C3 CC CC CC CC CC CC CC CC CC CC CC CC CC CC 8B 05 ?? ?? ?? ??");
-		CMaterialSystem_GetScreenSize = p_CMaterialSystem_GetScreenSize.RCast<void(*)(CMaterialSystem* pMatSys, float* outX, float* outY)>(); /*8B 05 ? ? ? ? 89 02 8B 05 ? ? ? ? 41 89 00 C3 CC CC CC CC CC CC CC CC CC CC CC CC CC CC 8B 05 ? ? ? ?*/
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_DispatchDrawCall = g_GameDll.FindPatternSIMD("44 89 4C 24 ?? 44 89 44 24 ?? 48 89 4C 24 ?? 55 53");
-		v_DispatchDrawCall = p_DispatchDrawCall.RCast<void*(*)(int64_t, uint64_t, int, int, char, int, uint8_t, int64_t, uint32_t, uint32_t, __m128*, int)>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_DispatchDrawCall = g_GameDll.FindPatternSIMD("44 89 4C 24 ?? 44 89 44 24 ?? 48 89 4C 24 ?? 55 53 56");
-		v_DispatchDrawCall = p_DispatchDrawCall.RCast<void*(*)(int64_t, uint64_t, int, int, int64_t, int, uint8_t, int64_t, uint32_t, uint32_t, int, __m128*, int, int64_t )>();
-#endif
-		p_SpinPresent = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 8B 15 ?? ?? ?? ??");
-		v_SpinPresent = p_SpinPresent.RCast<ssize_t(*)(void)>();
-
-		p_GetStreamOverlay = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 80 7C 24 ?? ?? 0F 84 ?? ?? ?? ?? 48 89 9C 24 ?? ?? ?? ??").FollowNearCallSelf();
-		v_GetStreamOverlay = p_GetStreamOverlay.RCast<void(*)(const char*, char*, size_t)>(); /*E8 ? ? ? ? 80 7C 24 ? ? 0F 84 ? ? ? ? 48 89 9C 24 ? ? ? ?*/
-
-		p_DrawStreamOverlay = g_GameDll.FindPatternSIMD("41 56 B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 C6 02 ??");
-		v_DrawStreamOverlay = p_DrawStreamOverlay.RCast<const char*(*)(void*, uint8_t*, void*, void*)>(); // 41 56 B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 C6 02 00 //
+		g_GameDll.FindPatternSIMD("44 89 4C 24 ?? 44 89 44 24 ?? 48 89 4C 24 ?? 55 53 56").GetPtr(v_DispatchDrawCall);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 8B 15 ?? ?? ?? ??").GetPtr(v_SpinPresent);
 #endif // !MATERIALSYSTEM_NODX
 	}
 	virtual void GetVar(void) const
 	{
 #ifndef MATERIALSYSTEM_NODX
-		g_nTotalStreamingTextureMemory = p_DrawStreamOverlay.Offset(0x1C).FindPatternSelf("48 8B 05", CMemory::Direction::DOWN).ResolveRelativeAddressSelf(0x3, 0x7).RCast<int*>();
-		g_nUnfreeStreamingTextureMemory = p_DrawStreamOverlay.Offset(0x2D).FindPatternSelf("48 8B 05", CMemory::Direction::DOWN).ResolveRelativeAddressSelf(0x3, 0x7).RCast<int*>();
-		g_nUnusableStreamingTextureMemory = p_DrawStreamOverlay.Offset(0x50).FindPatternSelf("48 8B 05", CMemory::Direction::DOWN).ResolveRelativeAddressSelf(0x3, 0x7).RCast<int*>();
+		g_nTotalStreamingTextureMemory = CMemory(CMaterialSystem__DrawStreamOverlay).Offset(0x1C).FindPatternSelf("48 8B 05", CMemory::Direction::DOWN).ResolveRelativeAddressSelf(0x3, 0x7).RCast<int*>();
+		g_nUnfreeStreamingTextureMemory = CMemory(CMaterialSystem__DrawStreamOverlay).Offset(0x2D).FindPatternSelf("48 8B 05", CMemory::Direction::DOWN).ResolveRelativeAddressSelf(0x3, 0x7).RCast<int*>();
+		g_nUnusableStreamingTextureMemory = CMemory(CMaterialSystem__DrawStreamOverlay).Offset(0x50).FindPatternSelf("48 8B 05", CMemory::Direction::DOWN).ResolveRelativeAddressSelf(0x3, 0x7).RCast<int*>();
 
-		s_pRenderContext = p_DispatchDrawCall.FindPattern("48 8B ?? ?? ?? ?? 01").ResolveRelativeAddressSelf(0x3, 0x7);
-		g_pMaterialAdapterMgr = p_CMaterialSystem__Disconnect.FindPattern("48 8D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<CMaterialDeviceMgr*>();
+		CMemory(v_DispatchDrawCall).FindPattern("48 8B ?? ?? ?? ?? 01").ResolveRelativeAddressSelf(0x3, 0x7).GetPtr(s_pRenderContext);
+		CMemory(CMaterialSystem__Disconnect).FindPattern("48 8D").ResolveRelativeAddressSelf(0x3, 0x7).GetPtr(g_pMaterialAdapterMgr);
 #endif // !MATERIALSYSTEM_NODX
 		g_pMaterialSystem = g_GameDll.FindPatternSIMD("8B 41 28 85 C0 7F 18").FindPatternSelf("48 8D 0D").ResolveRelativeAddressSelf(3, 7).RCast<CMaterialSystem*>();
 	}

--- a/src/materialsystem/cshaderglue.h
+++ b/src/materialsystem/cshaderglue.h
@@ -33,7 +33,6 @@ static_assert(sizeof(CShaderGlue) == 0x40); // [ PIXIE ]: All vars have proper d
 /* ==== CSHADERGLUE ================================================================================================================================================== */
 inline int(*CShaderGlue_SetupShader)(CShaderGlue* thisptr, uint64_t nCount, uint64_t a3, void* pRawMaterialGlueWithoutVTable);
 
-inline CMemory CShaderGlue_VTable;
 inline void* g_pShaderGlueVFTable = nullptr;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -41,18 +40,17 @@ class VShaderGlue : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogConAdr("CShaderGlue::`vftable'", reinterpret_cast<uintptr_t>(g_pShaderGlueVFTable));
-		LogFunAdr("CShaderGlue::SetupShader", reinterpret_cast<uintptr_t>(CShaderGlue_SetupShader));
+		LogConAdr("CShaderGlue::`vftable'", g_pShaderGlueVFTable);
+		LogFunAdr("CShaderGlue::SetupShader", CShaderGlue_SetupShader);
 	}
 	virtual void GetFun(void) const 
 	{
-		CShaderGlue_SetupShader = CShaderGlue_VTable.WalkVTable(4).Deref().RCast<int(*)(CShaderGlue*, uint64_t, uint64_t, void*)>();
+		CShaderGlue_SetupShader = CMemory(g_pShaderGlueVFTable).WalkVTable(4).Deref().RCast<int(*)(CShaderGlue*, uint64_t, uint64_t, void*)>();
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const
 	{
-		CShaderGlue_VTable = g_GameDll.GetVirtualMethodTable(".?AVCShaderGlue@@");
-		g_pShaderGlueVFTable = CShaderGlue_VTable.RCast<void*>();
+		g_pShaderGlueVFTable = g_GameDll.GetVirtualMethodTable(".?AVCShaderGlue@@");
 	}
 	virtual void Detour(const bool bAttach) const { }
 };

--- a/src/public/appframework/IAppSystemGroup.h
+++ b/src/public/appframework/IAppSystemGroup.h
@@ -98,24 +98,18 @@ protected:
 };
 static_assert(sizeof(CAppSystemGroup) == 0xA8);
 
-inline CMemory p_CAppSystemGroup_Destroy;
-inline void(*CAppSystemGroup_Destroy)(CAppSystemGroup* pAppSystemGroup);
+inline void(*CAppSystemGroup__Destroy)(CAppSystemGroup* pAppSystemGroup);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VAppSystemGroup : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CAppSystemGroup::Destroy", p_CAppSystemGroup_Destroy.GetPtr());
+		LogFunAdr("CAppSystemGroup::Destroy", CAppSystemGroup__Destroy);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CAppSystemGroup_Destroy = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 54 41 55 41 56 41 57 48 83 EC 20 8B 81 ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CAppSystemGroup_Destroy = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 8B 81 ?? ?? ?? ?? 48 8B F9");
-#endif
-		CAppSystemGroup_Destroy = p_CAppSystemGroup_Destroy.RCast<void(*)(CAppSystemGroup*)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 8B 81 ?? ?? ?? ?? 48 8B F9").GetPtr(CAppSystemGroup__Destroy);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/public/edict.h
+++ b/src/public/edict.h
@@ -50,10 +50,10 @@ class VEdict : public IDetour
 	virtual void GetAdr(void) const
 	{
 #ifndef CLIENT_DLL
-		LogVarAdr("g_ServerGlobalVariables", reinterpret_cast<uintptr_t>(g_ServerGlobalVariables));
+		LogVarAdr("g_ServerGlobalVariables", g_ServerGlobalVariables);
 #endif // !CLIENT_DLL
 #ifndef DEDICATED
-		LogVarAdr("g_ClientGlobalVariables", reinterpret_cast<uintptr_t>(g_ClientGlobalVariables));
+		LogVarAdr("g_ClientGlobalVariables", g_ClientGlobalVariables);
 #endif // !DEDICATED
 	}
 	virtual void GetFun(void) const { }
@@ -64,13 +64,8 @@ class VEdict : public IDetour
 			.FindPatternSelf("48 8D ?? ?? ?? ?? 01", CMemory::Direction::DOWN).ResolveRelativeAddressSelf(0x3, 0x7).RCast<CGlobalVars*>();
 #endif // !CLIENT_DLL
 #ifndef DEDICATED
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		g_ClientGlobalVariables = g_GameDll.FindPatternSIMD("48 8B C4 57 41 54 41 55 41 56 41 57 48 83 EC 60 48 C7 40 ?? ?? ?? ?? ?? 48 89 58 08")
-			.FindPatternSelf("4C 8D ?? ?? ?? ?? 01", CMemory::Direction::DOWN, 8000).ResolveRelativeAddressSelf(0x3, 0x7).RCast<CGlobalVarsBase*>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 		g_ClientGlobalVariables = g_GameDll.FindPatternSIMD("48 8B C4 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 60")
 			.FindPatternSelf("4C 8D ?? ?? ?? ?? 01", CMemory::Direction::DOWN, 8000).ResolveRelativeAddressSelf(0x3, 0x7).RCast<CGlobalVarsBase*>();
-#endif // GAME_DLL
 #endif // !DEDICATED
 	}
 	virtual void GetCon(void) const { }

--- a/src/public/eiface.h
+++ b/src/public/eiface.h
@@ -154,11 +154,6 @@ public:
 	// Get a convar keyvalue for specified client
 	virtual const char* GetClientConVarValue(int nClientIndex, const char* szConVarName) = 0;
 
-
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-	virtual void NullSub1(void) = 0; // Additional nullsub only present in s0 and s1 gamedll's
-#endif // GAMEDLL_S0 || GAMEDLL_S1
-
 	// Returns the name as represented on the server of specified client
 	virtual const char* GetClientServerName(int nClientIndex) = 0;
 	// Returns the network address of specified client

--- a/src/public/ifilesystem.h
+++ b/src/public/ifilesystem.h
@@ -231,10 +231,8 @@ public:
 	// at load time, so the dedicated couldn't pass it in that way).
 	virtual	FilesystemMountRetval_t MountSteamContent(int nExtraAppId = -1) = 0;
 
-#if !defined(GAMEDLL_S0) && !defined(GAMEDLL_S1) && !defined (GAMEDLL_S2)
 	virtual bool InitFeatureFlags() = 0;
 	virtual bool InitFeatureFlags(const char* pszFlagSetFile) = 0;
-#endif // !GAMEDLL_S0 || !GAMEDLL_S1 || GAMEDLL_S2
 
 	virtual void AddSearchPath(const char* pPath, const char* pPathID, SearchPathAdd_t addType) = 0;
 	virtual bool RemoveSearchPath(const char* pPath, const char* pPathID) = 0;

--- a/src/public/imaterial.h
+++ b/src/public/imaterial.h
@@ -95,11 +95,8 @@ private:
 	virtual void stub_74() const = 0;
 	virtual void stub_75() const = 0;
 	virtual void stub_76() const = 0;
-	// s0 and s1 builds have a smaller vtable size (2 methods less).
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
 	virtual void stub_77() const = 0;
 	virtual void stub_78() const = 0;
-#endif // !GAMEDLL_S0 && !GAMEDLL_S1
 	// STUB_138 should be GetShaderGlue.
 };
 

--- a/src/public/rendersystem/schema/texture.g.h
+++ b/src/public/rendersystem/schema/texture.g.h
@@ -29,9 +29,7 @@
 	uint8_t unknown_5[3];
 	uint8_t m_nTotalStreamedMipCount; // Does not get set until after RTech::CreateDXTexture.
 	uint8_t unk4[228];
-#ifdef GAMEDLL_S3
 	uint8_t unk5[57];
-#endif // GAMEDLL_S3
 	ID3D11Texture2D* m_ppTexture;
 	ID3D11ShaderResourceView* m_ppShaderResourceView;
 	uint8_t m_nTextureMipLevels;

--- a/src/public/rtech/ipakfile.h
+++ b/src/public/rtech/ipakfile.h
@@ -172,7 +172,6 @@ public:
 	char* m_fileName; //0x0018
 	void* m_allocator; //0x0020
 	uint64_t* m_assetGuids; //0x0028 size of the array is m_nAssetCount
-#if defined (GAMEDLL_S3)
 	void* m_virtualSegmentBuffers[4]; //0x0030
 	char pad_0050[16]; //0x0050
 	void* m_pakInfo; //0x0060
@@ -182,11 +181,6 @@ public:
 	char pad_0075[51]; //0x0075
 	uint32_t m_nUnk4; //0x00A8
 	uint8_t m_nUnk5; //0x00AC
-#endif
-#if !defined (GAMEDLL_S3)
-	char pad_0030[128]; //0x0030
-	char pad_00B0[48];  //0x00B0
-#endif // !GAMEDLL_S3
 	uint64_t m_nUnkEnd; //0x00B0/0x00E8
 }; //Size: 0x00B8/0x00E8
 
@@ -308,15 +302,7 @@ struct PakFile_t
 	PakMemoryData_t m_memoryData;
 };
 
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
-#if !defined (GAMEDLL_S2)
 static_assert(sizeof(PakFile_t) == 2208); // S3+
-#else
-static_assert(sizeof(PakFile_t) == 2200); // S2
-#endif // !GAMEDLL_S2
-#else
-static_assert(sizeof(PakFile_t) == 1944); // S0/S1
-#endif // !GAMEDLL_S0 && !GAMEDLL_S1
 
 static_assert(sizeof(PakDecompState_t) == 136);
 static_assert(sizeof(PakPatchFileHeader_t) == 16);

--- a/src/public/tier0/basetypes.h
+++ b/src/public/tier0/basetypes.h
@@ -4,15 +4,6 @@
  * _basetypes
  *-----------------------------------------------------------------------------*/
 
-// These are set from CMake now.
-//#define GAMEDLL_S0 /*[r]*/
-//#define GAMEDLL_S1 /*[r]*/
-//#define GAMEDLL_S2 /*[i]*/
-//#define GAMEDLL_S3 /*[r]*/
-//#define GAMEDLL_S4 /*[i]*/
-//#define GAMEDLL_S5 /*[i]*/
-//#define GAMEDLL_S7 /*[i]*/
-
 //-----------------------------------------------------------------------------
 // Set up platform defines.
 //-----------------------------------------------------------------------------
@@ -140,12 +131,8 @@
 #define MAX_PLAYERS 128 // Absolute max R5 players.
 #define MAX_TEAMS   126 // Absolute max R5 teams.
 
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
-#define MAX_MAP_NAME_HOST 64
-#else
-#define MAX_MAP_NAME_HOST 32
-#endif // Max BSP file name len.
-#define MAX_MAP_NAME 64
+#define MAX_MAP_NAME_HOST 64 // Max host BSP file name len.
+#define MAX_MAP_NAME      64 // Max BSP file name len.
 
 #define SDK_VERSION "VGameSDK009" // Increment this with every /breaking/ SDK change (i.e. security/backend changes breaking compatibility).
 #define SDK_ARRAYSIZE(arr) ((sizeof(arr) / sizeof(*arr))) // Name due to IMGUI implementation and NT implementation that we shouldn't share across everywhere.

--- a/src/public/tier0/jobthread.h
+++ b/src/public/tier0/jobthread.h
@@ -7,16 +7,9 @@ struct JobFifoLock_s
 
 typedef uint32_t JobID_t;
 
-inline CMemory p_JT_ParallelCall;
 inline void(*JT_ParallelCall)(void);
-
-inline CMemory p_JT_HelpWithAnything;
 inline void*(*JT_HelpWithAnything)(bool bShouldLoadPak);
-
-inline CMemory p_JT_AcquireFifoLock;
 inline bool(*JT_AcquireFifoLock)(struct JobFifoLock_s* pFifo);
-
-inline CMemory p_JT_ReleaseFifoLock;
 inline void(*JT_ReleaseFifoLock)(struct JobFifoLock_s* pFifo);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -24,27 +17,17 @@ class VJobThread : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("JT_ParallelCall", p_JT_ParallelCall.GetPtr());
-		LogFunAdr("JT_HelpWithAnything", p_JT_HelpWithAnything.GetPtr());
-		LogFunAdr("JT_AcquireFifoLock", p_JT_AcquireFifoLock.GetPtr());
-		LogFunAdr("JT_ReleaseFifoLock", p_JT_ReleaseFifoLock.GetPtr());
+		LogFunAdr("JT_ParallelCall", JT_ParallelCall);
+		LogFunAdr("JT_HelpWithAnything", JT_HelpWithAnything);
+		LogFunAdr("JT_AcquireFifoLock", JT_AcquireFifoLock);
+		LogFunAdr("JT_ReleaseFifoLock", JT_ReleaseFifoLock);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_JT_ParallelCall     = g_GameDll.FindPatternSIMD("48 8B C4 48 89 58 10 48 89 70 18 55 57 41 57");
-		p_JT_HelpWithAnything = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 83 EC 30 80 3D ?? ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_JT_ParallelCall     = g_GameDll.FindPatternSIMD("48 8B C4 48 89 58 08 48 89 78 10 55 48 8D 68 A1 48 81 EC ?? ?? ?? ?? 0F 29 70 E8 48 8D 1D ?? ?? ?? ??");
-		p_JT_HelpWithAnything = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 80 3D ?? ?? ?? ?? ??");
-#endif
-		p_JT_AcquireFifoLock = g_GameDll.FindPatternSIMD("48 83 EC 08 65 48 8B 04 25 ?? ?? ?? ?? 4C 8B C1");
-		p_JT_ReleaseFifoLock = g_GameDll.FindPatternSIMD("48 83 EC 28 44 8B 11");
-
-		JT_ParallelCall = p_JT_ParallelCall.RCast<void (*)(void)>();                         /*48 8B C4 48 89 58 08 48 89 78 10 55 48 8D 68 A1 48 81 EC ?? ?? ?? ?? 0F 29 70 E8 48 8D 1D ?? ?? ?? ??*/
-		JT_HelpWithAnything = p_JT_HelpWithAnything.RCast<void* (*)(bool bShouldLoadPak)>(); /*48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 80 3D ?? ?? ?? ?? ??*/
-		JT_AcquireFifoLock = p_JT_AcquireFifoLock.RCast<bool (*)(struct JobFifoLock_s*)>();  /*48 83 EC 08 65 48 8B 04 25 ?? ?? ?? ?? 4C 8B C1*/
-		JT_ReleaseFifoLock = p_JT_ReleaseFifoLock.RCast<void (*)(struct JobFifoLock_s*)>();  /*48 83 EC 28 44 8B 11*/
+		g_GameDll.FindPatternSIMD("48 8B C4 48 89 58 08 48 89 78 10 55 48 8D 68 A1 48 81 EC ?? ?? ?? ?? 0F 29 70 E8 48 8D 1D ?? ?? ?? ??").GetPtr(JT_ParallelCall);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 80 3D ?? ?? ?? ?? ??").GetPtr(JT_HelpWithAnything);
+		g_GameDll.FindPatternSIMD("48 83 EC 08 65 48 8B 04 25 ?? ?? ?? ?? 4C 8B C1").GetPtr(JT_AcquireFifoLock);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 44 8B 11").GetPtr(JT_ReleaseFifoLock);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/public/tier0/memaddr.h
+++ b/src/public/tier0/memaddr.h
@@ -48,6 +48,12 @@ public:
 		return ptr;
 	}
 
+	template<typename T>
+	inline void GetPtr(T*& outPtr) const
+	{
+		outPtr = reinterpret_cast<T*>(ptr);
+	}
+
 	template<class T> inline T GetValue(void) const
 	{
 		return *reinterpret_cast<T*>(ptr);

--- a/src/public/tier0/module.h
+++ b/src/public/tier0/module.h
@@ -28,15 +28,6 @@ public:
 	void LoadSections();
 
 	CMemory FindPatternSIMD(const char* szPattern, const ModuleSections_t* moduleSection = nullptr) const;
-
-	template<typename T>
-	inline void FindPatternSIMD(const char* szPattern,
-		T*& pMemPtrOut, const ModuleSections_t* moduleSection = nullptr) const
-	{
-		CMemory mem = FindPatternSIMD(szPattern, moduleSection);
-		pMemPtrOut = mem.RCast<T*>();
-	}
-
 	CMemory FindString(const char* szString, const ptrdiff_t occurrence = 1, bool nullTerminator = false) const;
 	CMemory FindStringReadOnly(const char* szString, bool nullTerminator) const;
 	CMemory FindFreeDataPage(const size_t nSize) const;

--- a/src/public/tier0/platform_internal.h
+++ b/src/public/tier0/platform_internal.h
@@ -1,13 +1,8 @@
 #ifndef PLATFORM_INTERNAL_H
 #define PLATFORM_INTERNAL_H
 
-inline CMemory p_InitTime;
 inline void(*v_InitTime)(void);
-
-inline CMemory p_Plat_FloatTime;
 inline double(*v_Plat_FloatTime)(void);
-
-inline CMemory p_Plat_MSTime;
 inline uint64_t(*v_Plat_MSTime)(void);
 
 inline bool* s_pbTimeInitted = nullptr;
@@ -21,31 +16,27 @@ class VPlatform : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("InitTime", p_InitTime.GetPtr());
-		LogFunAdr("Plat_FloatTime", p_Plat_FloatTime.GetPtr());
-		LogFunAdr("Plat_MSTime", p_Plat_MSTime.GetPtr());
-		LogVarAdr("s_bTimeInitted", reinterpret_cast<uintptr_t>(s_pbTimeInitted));
-		LogVarAdr("g_PerformanceCounterToMS", reinterpret_cast<uintptr_t>(g_pPerformanceCounterToMS));
-		LogVarAdr("g_PerformanceFrequency", reinterpret_cast<uintptr_t>(g_pPerformanceFrequency));
-		LogVarAdr("g_ClockStart", reinterpret_cast<uintptr_t>(g_pClockStart));
-		LogVarAdr("g_flErrorTimeStamp", reinterpret_cast<uintptr_t>(g_flErrorTimeStamp));
+		LogFunAdr("InitTime", v_InitTime);
+		LogFunAdr("Plat_FloatTime", v_Plat_FloatTime);
+		LogFunAdr("Plat_MSTime", v_Plat_MSTime);
+		LogVarAdr("s_bTimeInitted", s_pbTimeInitted);
+		LogVarAdr("g_PerformanceCounterToMS", g_pPerformanceCounterToMS);
+		LogVarAdr("g_PerformanceFrequency", g_pPerformanceFrequency);
+		LogVarAdr("g_ClockStart", g_pClockStart);
+		LogVarAdr("g_flErrorTimeStamp", g_flErrorTimeStamp);
 	}
 	virtual void GetFun(void) const
 	{
-		p_InitTime       = g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 75 4C");
-		p_Plat_FloatTime = g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 75 05 E8 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 74 1D");
-		p_Plat_MSTime    = g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 75 05 E8 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 74 2A");
-
-		v_InitTime       = p_InitTime.RCast<void(*)(void)>();
-		v_Plat_FloatTime = p_Plat_FloatTime.RCast<double(*)(void)>(); /*48 83 EC 28 80 3D ? ? ? ? ? 75 05 E8 ? ? ? ? 80 3D ? ? ? ? ? 74 1D*/
-		v_Plat_MSTime    = p_Plat_MSTime.RCast<uint64_t(*)(void)>();  /*48 83 EC 28 80 3D ? ? ? ? ? 75 05 E8 ? ? ? ? 80 3D ? ? ? ? ? 74 2A*/
+		g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 75 4C").GetPtr(v_InitTime);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 75 05 E8 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 74 1D").GetPtr(v_Plat_FloatTime);
+		g_GameDll.FindPatternSIMD("48 83 EC 28 80 3D ?? ?? ?? ?? ?? 75 05 E8 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 74 2A").GetPtr(v_Plat_MSTime);
 	}
 	virtual void GetVar(void) const
 	{
-		s_pbTimeInitted = p_InitTime.FindPattern("80 3D").ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
-		g_pPerformanceCounterToMS = p_InitTime.FindPattern("48 89").ResolveRelativeAddressSelf(0x3, 0x7).RCast<double*>();
-		g_pPerformanceFrequency = p_InitTime.FindPattern("48 F7").ResolveRelativeAddressSelf(0x3, 0x7).RCast<LARGE_INTEGER*>();
-		g_pClockStart = p_InitTime.FindPattern("48 8D", CMemory::Direction::DOWN, 512, 2).ResolveRelativeAddressSelf(0x3, 0x7).RCast<LARGE_INTEGER*>();
+		s_pbTimeInitted = CMemory(v_InitTime).FindPattern("80 3D").ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
+		g_pPerformanceCounterToMS = CMemory(v_InitTime).FindPattern("48 89").ResolveRelativeAddressSelf(0x3, 0x7).RCast<double*>();
+		g_pPerformanceFrequency = CMemory(v_InitTime).FindPattern("48 F7").ResolveRelativeAddressSelf(0x3, 0x7).RCast<LARGE_INTEGER*>();
+		g_pClockStart = CMemory(v_InitTime).FindPattern("48 8D", CMemory::Direction::DOWN, 512, 2).ResolveRelativeAddressSelf(0x3, 0x7).RCast<LARGE_INTEGER*>();
 
 		g_flErrorTimeStamp = g_GameDll.FindPatternSIMD("0F 57 C0 F2 0F 11 05 ?? ?? ?? ?? C3").FindPatternSelf("F2 0F").ResolveRelativeAddressSelf(0x4, 0x8).RCast<double*>();
 	}

--- a/src/public/tier0/threadtools.h
+++ b/src/public/tier0/threadtools.h
@@ -260,7 +260,6 @@ typedef CInterlockedIntT<unsigned> CInterlockedUInt;
 
 #ifndef BUILDING_MATHLIB
 //=============================================================================
-inline CMemory p_DeclareCurrentThreadIsMainThread;
 inline ThreadId_t(*v_DeclareCurrentThreadIsMainThread)(void);
 
 #endif // !BUILDING_MATHLIB
@@ -336,18 +335,17 @@ class VThreadTools : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("DeclareCurrentThreadIsMainThread", p_DeclareCurrentThreadIsMainThread.GetPtr());
-		LogVarAdr("g_ThreadMainThreadID", reinterpret_cast<uintptr_t>(g_ThreadMainThreadID));
-		LogVarAdr("g_ThreadServerFrameThreadID", reinterpret_cast<uintptr_t>(g_ThreadServerFrameThreadID));
+		LogFunAdr("DeclareCurrentThreadIsMainThread", v_DeclareCurrentThreadIsMainThread);
+		LogVarAdr("g_ThreadMainThreadID", g_ThreadMainThreadID);
+		LogVarAdr("g_ThreadServerFrameThreadID", g_ThreadServerFrameThreadID);
 	}
 	virtual void GetFun(void) const
 	{
-		p_DeclareCurrentThreadIsMainThread = g_GameDll.FindPatternSIMD("48 83 EC 28 FF 15 ?? ?? ?? ?? 89 05 ?? ?? ?? ?? 48 83 C4 28");
-		v_DeclareCurrentThreadIsMainThread = p_DeclareCurrentThreadIsMainThread.RCast<ThreadId_t(*)(void)>(); /*48 83 EC 28 FF 15 ?? ?? ?? ?? 89 05 ?? ?? ?? ?? 48 83 C4 28 */
+		g_GameDll.FindPatternSIMD("48 83 EC 28 FF 15 ?? ?? ?? ?? 89 05 ?? ?? ?? ?? 48 83 C4 28").GetPtr(v_DeclareCurrentThreadIsMainThread);
 	}
 	virtual void GetVar(void) const
 	{
-		g_ThreadMainThreadID = p_DeclareCurrentThreadIsMainThread.FindPattern("89 05").ResolveRelativeAddressSelf(0x2, 0x6).RCast<ThreadId_t*>();
+		g_ThreadMainThreadID = CMemory(v_DeclareCurrentThreadIsMainThread).FindPattern("89 05").ResolveRelativeAddressSelf(0x2, 0x6).RCast<ThreadId_t*>();
 		g_ThreadServerFrameThreadID = g_GameDll.FindPatternSIMD("83 79 ?? ?? 75 28 8B").FindPatternSelf("8B 05").ResolveRelativeAddressSelf(0x2, 0x6).RCast<ThreadId_t*>();
 	}
 	virtual void GetCon(void) const { }

--- a/src/public/tier0/tier0_iface.h
+++ b/src/public/tier0/tier0_iface.h
@@ -32,8 +32,8 @@ ReturnType CallVFunc(int index, void* thisPtr, Args... args)
 	return (*reinterpret_cast<ReturnType(__fastcall***)(void*, Args...)>(thisPtr))[index](thisPtr, args...);
 }
 
-void LogFunAdr(const char* szFun, uintptr_t nAdr); // Logging function addresses.
-void LogVarAdr(const char* szVar, uintptr_t nAdr); // Logging variable addresses.
-void LogConAdr(const char* szCon, uintptr_t nAdr); // Logging constant addresses.
+void LogFunAdr(const char* szFun, const void* const pAdr); // Logging function addresses.
+void LogVarAdr(const char* szVar, const void* const pAdr); // Logging variable addresses.
+void LogConAdr(const char* szCon, const void* const pAdr); // Logging constant addresses.
 
 #endif // TIER0_IFACE_H

--- a/src/public/tier0/tslist.h
+++ b/src/public/tier0/tslist.h
@@ -43,18 +43,13 @@ class VTSListBase : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogVarAdr("g_AlignedMemAlloc", reinterpret_cast<uintptr_t>(g_pAlignedMemAlloc));
+		LogVarAdr("g_AlignedMemAlloc", g_pAlignedMemAlloc);
 	}
 	virtual void GetFun(void) const { }
 	virtual void GetVar(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		g_pAlignedMemAlloc = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? 48 8B D9 FF 15 ?? ?? ?? ??")
-			.Offset(0x600).FindPatternSelf("48 8D 15 ?? ?? ?? 01", CMemory::Direction::DOWN, 100).ResolveRelativeAddressSelf(0x3, 0x7).RCast<CAlignedMemAlloc*>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 		g_pAlignedMemAlloc = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B D9")
 			.Offset(0x130).FindPatternSelf("48 8D 15 ?? ?? ?? 01", CMemory::Direction::DOWN, 100).ResolveRelativeAddressSelf(0x3, 0x7).RCast<CAlignedMemAlloc*>();
-#endif
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const { }

--- a/src/public/tier1/convar.h
+++ b/src/public/tier1/convar.h
@@ -234,14 +234,9 @@ FORCEINLINE const char* ConVar::GetString(void) const
 }
 
 /* ==== CONVAR ========================================================================================================================================================== */
-inline CMemory p_ConVar_Register;
-inline void*(*v_ConVar_Register)(ConVar* thisptr, const char* szName, const char* szDefaultValue, int nFlags, const char* szHelpString, bool bMin, float fMin, bool bMax, float fMax, FnChangeCallback_t pCallback, const char* pszUsageString);
-
-inline CMemory p_ConVar_Unregister;
-inline void(*v_ConVar_Unregister)(ConVar* thisptr);
-
-inline CMemory p_ConVar_IsFlagSet;
-inline bool(*v_ConVar_IsFlagSet)(ConVar* pConVar, int nFlag);
+inline void*(*ConVar__Register)(ConVar* thisptr, const char* szName, const char* szDefaultValue, int nFlags, const char* szHelpString, bool bMin, float fMin, bool bMax, float fMax, FnChangeCallback_t pCallback, const char* pszUsageString);
+inline void(*ConVar__Unregister)(ConVar* thisptr);
+inline bool(*ConVar__IsFlagSet)(ConVar* pConVar, int nFlag);
 
 inline ConCommandBase* g_pConCommandBaseVFTable;
 inline ConCommand* g_pConCommandVFTable;
@@ -253,28 +248,19 @@ class VConVar : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogConAdr("ConCommandBase::`vftable'", reinterpret_cast<uintptr_t>(g_pConCommandBaseVFTable));
-		LogConAdr("ConCommand::`vftable'", reinterpret_cast<uintptr_t>(g_pConCommandVFTable));
-		LogConAdr("ConVar::`vbtable'", reinterpret_cast<uintptr_t>(g_pConVarVBTable));
-		LogConAdr("ConVar::`vftable'", reinterpret_cast<uintptr_t>(g_pConVarVFTable));
-		LogFunAdr("ConVar::Register", p_ConVar_Register.GetPtr());
-		LogFunAdr("ConVar::Unregister", p_ConVar_Unregister.GetPtr());
-		LogFunAdr("ConVar::IsFlagSet", p_ConVar_IsFlagSet.GetPtr());
+		LogConAdr("ConCommandBase::`vftable'", g_pConCommandBaseVFTable);
+		LogConAdr("ConCommand::`vftable'", g_pConCommandVFTable);
+		LogConAdr("ConVar::`vbtable'", g_pConVarVBTable);
+		LogConAdr("ConVar::`vftable'", g_pConVarVFTable);
+		LogFunAdr("ConVar::Register", ConVar__Register);
+		LogFunAdr("ConVar::Unregister", ConVar__Unregister);
+		LogFunAdr("ConVar::IsFlagSet", ConVar__IsFlagSet);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_ConVar_Register                   = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 83 EC 30 F3 0F 10 44 24 ??");
-		p_ConVar_Unregister                 = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 57 48 83 EC 20 48 8B 59 58 48 8D 05 ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_ConVar_Register                   = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 40 F3 0F 10 84 24 ?? ?? ?? ??");
-		p_ConVar_Unregister                 = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 79 58");
-#endif
-		p_ConVar_IsFlagSet                  = g_GameDll.FindPatternSIMD("48 8B 41 48 85 50 38");
-
-		v_ConVar_IsFlagSet                  = p_ConVar_IsFlagSet.RCast<bool (*)(ConVar*, int)>();
-		v_ConVar_Register                   = p_ConVar_Register.RCast<void* (*)(ConVar*, const char*, const char*, int, const char*, bool, float, bool, float, FnChangeCallback_t, const char*)>();
-		v_ConVar_Unregister                 = p_ConVar_Unregister.RCast<void (*)(ConVar*)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 40 F3 0F 10 84 24 ?? ?? ?? ??").GetPtr(ConVar__Register);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 79 58").GetPtr(ConVar__Unregister);
+		g_GameDll.FindPatternSIMD("48 8B 41 48 85 50 38").GetPtr(ConVar__IsFlagSet);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const

--- a/src/public/tier1/cvar.h
+++ b/src/public/tier1/cvar.h
@@ -161,7 +161,6 @@ extern ConVarFlags g_ConVarFlags;
 bool ConVar_ParseFlagString(const char* pszFlags, int& nFlags, const char* pszConVarName = "<<unspecified>>");
 void ConVar_PrintDescription(ConCommandBase* pVar);
 
-inline CMemory p_ConVar_PrintDescription;
 inline void (*v_ConVar_PrintDescription)(ConCommandBase* pVar);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -169,13 +168,12 @@ class VCVar : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("ConVar_PrintDescription", p_ConVar_PrintDescription.GetPtr());
-		LogVarAdr("g_pCVar", reinterpret_cast<uintptr_t>(g_pCVar));
+		LogFunAdr("ConVar_PrintDescription", v_ConVar_PrintDescription);
+		LogVarAdr("g_pCVar", g_pCVar);
 	}
 	virtual void GetFun(void) const 
 	{
-		p_ConVar_PrintDescription = g_GameDll.FindPatternSIMD("B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B 01 48 89 9C 24 ?? ?? ?? ??");
-		v_ConVar_PrintDescription = p_ConVar_PrintDescription.RCast<void (*)(ConCommandBase*)>();
+		g_GameDll.FindPatternSIMD("B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B 01 48 89 9C 24 ?? ?? ?? ??").GetPtr(v_ConVar_PrintDescription);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/rtech/rtech_game.cpp
+++ b/src/rtech/rtech_game.cpp
@@ -16,7 +16,6 @@
 // each pak listed in this vector gets unloaded.
 CUtlVector<PakHandle_t> g_vLoadedPakHandle;
 
-#ifdef GAMEDLL_S3
 //-----------------------------------------------------------------------------
 // Purpose: process guid relations for asset
 // Input  : *pak   - 
@@ -24,11 +23,7 @@ CUtlVector<PakHandle_t> g_vLoadedPakHandle;
 //-----------------------------------------------------------------------------
 void Pak_ProcessGuidRelationsForAsset(PakFile_t* pak, PakAsset_t* asset)
 {
-#if defined (GAMEDLL_S0) && defined (GAMEDLL_S1) && defined (GAMEDLL_S2)
-    static const int GLOBAL_MUL = 0x1D;
-#else
     static const int GLOBAL_MUL = 0x17;
-#endif
 
     PakPage_t* pGuidDescriptors = &pak->m_memoryData.m_guidDescriptors[asset->m_usesStartIdx];
     volatile uint32_t* v5 = reinterpret_cast<volatile uint32_t*>(*(reinterpret_cast<uint64_t*>(g_pPakGlobals) + GLOBAL_MUL * (pak->m_memoryData.qword2D8 & 0x1FF) + 0x160212));
@@ -107,8 +102,6 @@ void Pak_ProcessGuidRelationsForAsset(PakFile_t* pak, PakAsset_t* asset)
         *pCurrentGuid = g_pPakGlobals->m_assets[assetIdx].m_head;
     }
 }
-#endif // GAMEDLL_S3
-
 
 //-----------------------------------------------------------------------------
 // Purpose: load user-requested pak files on-demand
@@ -593,9 +586,7 @@ void V_RTechGame::Detour(const bool bAttach) const
 	DetourSetup(&v_Pak_LoadAsync, &Pak_LoadAsync, bAttach);
 	DetourSetup(&v_Pak_UnloadPak, &Pak_UnloadPak, bAttach);
 
-#ifdef GAMEDLL_S3
     //DetourSetup(&RTech_Pak_ProcessGuidRelationsForAsset, &RTech::PakProcessGuidRelationsForAsset, bAttach);
-#endif
 }
 
 // Symbols taken from R2 dll's.

--- a/src/rtech/rtech_game.h
+++ b/src/rtech/rtech_game.h
@@ -4,27 +4,15 @@
 #include "public/rtech/ipakfile.h"
 
 /* ==== RTECH_GAME ====================================================================================================================================================== */
-inline CMemory p_Pak_LoadAsync;
 inline PakHandle_t(*v_Pak_LoadAsync)(const char* fileName, CAlignedMemAlloc* allocator, int nIdx, bool bUnk);
-
-inline CMemory p_Pak_WaitAsync;
 inline EPakStatus(*v_Pak_WaitAsync)(PakHandle_t handle, void* finishCallback);
-
-inline CMemory p_Pak_LoadPak;
 inline unsigned int (*v_Pak_LoadPak)(void* thisptr, void* a2, uint64_t a3);
-
-inline CMemory p_Pak_UnloadPak;
 inline void(*v_Pak_UnloadPak)(PakHandle_t handle);
-
-inline CMemory p_Pak_OpenFile;
 inline int(*v_Pak_OpenFile)(const CHAR* fileName, int64_t unused, LONGLONG* outFileSize);
-
-inline CMemory p_Pak_CloseFile;
 inline void(*v_Pak_CloseFile)(short fileHandle);
 
 inline CMemory p_Pak_OpenFileOffset; // Offset to inlined 'Pak_OpenFile'.
 
-inline CMemory p_Pak_ProcessGuidRelationsForAsset;
 inline void(*v_Pak_ProcessGuidRelationsForAsset)(PakFile_t* pak, PakAsset_t* asset);
 
 typedef struct PakLoadFuncs_s
@@ -76,43 +64,28 @@ class V_RTechGame : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Pak_LoadAsync", p_Pak_LoadAsync.GetPtr());
-		LogFunAdr("Pak_WaitAsync", p_Pak_WaitAsync.GetPtr());
-		LogFunAdr("Pak_LoadPak", p_Pak_LoadPak.GetPtr());
-		LogFunAdr("Pak_UnloadPak", p_Pak_UnloadPak.GetPtr());
-		LogFunAdr("Pak_OpenFile", p_Pak_OpenFile.GetPtr());
-		LogFunAdr("Pak_CloseFile", p_Pak_CloseFile.GetPtr());
-		LogFunAdr("Pak_ProcessGuidRelationsForAsset", p_Pak_ProcessGuidRelationsForAsset.GetPtr());
-		LogVarAdr("g_pakLoadApi", reinterpret_cast<uintptr_t>(g_pakLoadApi));
+		LogFunAdr("Pak_LoadAsync", v_Pak_LoadAsync);
+		LogFunAdr("Pak_WaitAsync", v_Pak_WaitAsync);
+		LogFunAdr("Pak_LoadPak", v_Pak_LoadPak);
+		LogFunAdr("Pak_UnloadPak", v_Pak_UnloadPak);
+		LogFunAdr("Pak_OpenFile", v_Pak_OpenFile);
+		LogFunAdr("Pak_CloseFile", v_Pak_CloseFile);
+		LogFunAdr("Pak_ProcessGuidRelationsForAsset", v_Pak_ProcessGuidRelationsForAsset);
+		LogVarAdr("g_pakLoadApi", g_pakLoadApi);
 	}
 	virtual void GetFun(void) const
 	{
-		p_Pak_LoadAsync = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 89 03 8B 0B").FollowNearCallSelf();
-		v_Pak_LoadAsync = p_Pak_LoadAsync.RCast<PakHandle_t(*)(const char*, CAlignedMemAlloc*, int, bool)>();
-
-		p_Pak_WaitAsync = g_GameDll.FindPatternSIMD("40 53 55 48 83 EC 38 48 89 74 24 ??");
-		v_Pak_WaitAsync = p_Pak_WaitAsync.RCast<EPakStatus(*)(PakHandle_t, void*)>();
-
-		p_Pak_LoadPak = g_GameDll.FindPatternSIMD("48 89 4C 24 ?? 56 41 55 48 81 EC ?? ?? ?? ?? 4C");
-		v_Pak_LoadPak = p_Pak_LoadPak.RCast<unsigned int (*)(void*, void*, uint64_t)>();
-
-		p_Pak_UnloadPak = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 85 FF 74 0C").FollowNearCallSelf();
-		v_Pak_UnloadPak = p_Pak_UnloadPak.RCast<void (*)(PakHandle_t)>();
-
-		p_Pak_OpenFile = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 89 85 08 01 ?? ??").FollowNearCallSelf();
-		v_Pak_OpenFile = p_Pak_OpenFile.RCast<int (*)(const char*, int64_t, ssize_t*)>();
-
-		p_Pak_CloseFile = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 8B D9 48 8D 35 ?? ?? ?? ??");
-		v_Pak_CloseFile = p_Pak_CloseFile.RCast<void (*)(short)>();
-
-#ifdef GAMEDLL_S3
-		p_Pak_ProcessGuidRelationsForAsset = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 8B 86 ?? ?? ?? ?? 42 8B 0C B0").FollowNearCallSelf();
-		v_Pak_ProcessGuidRelationsForAsset = p_Pak_ProcessGuidRelationsForAsset.RCast<void(*)(PakFile_t*, PakAsset_t*)>();
-#endif
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 89 03 8B 0B").FollowNearCallSelf().GetPtr(v_Pak_LoadAsync);
+		g_GameDll.FindPatternSIMD("40 53 55 48 83 EC 38 48 89 74 24 ??").GetPtr(v_Pak_WaitAsync);
+		g_GameDll.FindPatternSIMD("48 89 4C 24 ?? 56 41 55 48 81 EC ?? ?? ?? ?? 4C").GetPtr(v_Pak_LoadPak);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 85 FF 74 0C").FollowNearCallSelf().GetPtr(v_Pak_UnloadPak);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 89 85 08 01 ?? ??").FollowNearCallSelf().GetPtr(v_Pak_OpenFile);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 8B D9 48 8D 35 ?? ?? ?? ??").GetPtr(v_Pak_CloseFile);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 8B 86 ?? ?? ?? ?? 42 8B 0C B0").FollowNearCallSelf().GetPtr(v_Pak_ProcessGuidRelationsForAsset);
 	}
 	virtual void GetVar(void) const
 	{
-		g_pakLoadApi = p_LauncherMain.Offset(0x820).FindPatternSelf("48 89").ResolveRelativeAddressSelf(0x3, 0x7).RCast<PakLoadFuncs_t*>();
+		g_pakLoadApi = CMemory(v_LauncherMain).Offset(0x820).FindPatternSelf("48 89").ResolveRelativeAddressSelf(0x3, 0x7).RCast<PakLoadFuncs_t*>();
 	}
 	virtual void GetCon(void) const
 	{

--- a/src/rtech/rtech_utils.h
+++ b/src/rtech/rtech_utils.h
@@ -7,13 +7,8 @@
 
 /* ==== RTECH =========================================================================================================================================================== */
 // [ PIXIE ]: I'm very unsure about this, but it really seems like it
-inline CMemory p_RTech_FindFreeSlotInFiles;
 inline int32_t(*RTech_FindFreeSlotInFiles)(int32_t*);
-
-inline CMemory p_RTech_RegisterAsset;
 inline void(*RTech_RegisterAsset)(int, int, const char*, void*, void*, void*, void*, int, int, uint32_t, int, int);
-
-inline CMemory p_StreamDB_Init;
 inline void(*v_StreamDB_Init)(const char* pszLevelName);
 
 inline PakLoadedInfo_t* g_pLoadedPakInfo;
@@ -51,51 +46,46 @@ class V_RTechUtils : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("RTech::FindFreeSlotInFiles", p_RTech_FindFreeSlotInFiles.GetPtr());
+		LogFunAdr("RTech::FindFreeSlotInFiles", RTech_FindFreeSlotInFiles);
 
-		LogFunAdr("StreamDB_Init", p_StreamDB_Init.GetPtr());
-		LogVarAdr("s_FileArray", reinterpret_cast<uintptr_t>(s_pFileArray));
-		LogVarAdr("s_FileArrayMutex", reinterpret_cast<uintptr_t>(s_pFileArrayMutex));
-		LogVarAdr("s_FileHandles", reinterpret_cast<uintptr_t>(s_pFileHandles));
+		LogFunAdr("StreamDB_Init", v_StreamDB_Init);
+		LogVarAdr("s_FileArray", s_pFileArray);
+		LogVarAdr("s_FileArrayMutex", s_pFileArrayMutex);
+		LogVarAdr("s_FileHandles", s_pFileHandles);
 
-		LogVarAdr("g_loadedPakInfo", reinterpret_cast<uintptr_t>(g_pLoadedPakInfo));
-		LogVarAdr("g_loadedPakCount", reinterpret_cast<uintptr_t>(g_pLoadedPakCount));
-		LogVarAdr("g_requestedPakCount", reinterpret_cast<uintptr_t>(g_pRequestedPakCount));
+		LogVarAdr("g_loadedPakInfo", g_pLoadedPakInfo);
+		LogVarAdr("g_loadedPakCount", g_pLoadedPakCount);
+		LogVarAdr("g_requestedPakCount", g_pRequestedPakCount);
 
-		LogVarAdr("g_pakGlobals", reinterpret_cast<uintptr_t>(g_pPakGlobals));
-		LogVarAdr("g_pakLoadJobID", reinterpret_cast<uintptr_t>(g_pPakLoadJobID));
+		LogVarAdr("g_pakGlobals", g_pPakGlobals);
+		LogVarAdr("g_pakLoadJobID", g_pPakLoadJobID);
 
-		LogVarAdr("g_pakFifoLock", reinterpret_cast<uintptr_t>(g_pPakFifoLock));
-		LogVarAdr("g_pakFifoLockWrapper", reinterpret_cast<uintptr_t>(g_pPakFifoLockWrapper));
-		LogVarAdr("g_pakFifoLockAcquired", reinterpret_cast<uintptr_t>(g_bPakFifoLockAcquired));
+		LogVarAdr("g_pakFifoLock", g_pPakFifoLock);
+		LogVarAdr("g_pakFifoLockWrapper", g_pPakFifoLockWrapper);
+		LogVarAdr("g_pakFifoLockAcquired", g_bPakFifoLockAcquired);
 	}
 	virtual void GetFun(void) const 
 	{
-		p_StreamDB_Init = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 54 41 56 41 57 48 83 EC 40 48 8B E9");
-		v_StreamDB_Init = p_StreamDB_Init.RCast<void (*)(const char*)>(); /*48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 54 41 56 41 57 48 83 EC 40 48 8B E9*/
-
-		p_RTech_FindFreeSlotInFiles = g_GameDll.FindPatternSIMD("44 8B 51 0C 4C 8B C1");
-		RTech_FindFreeSlotInFiles   = p_RTech_FindFreeSlotInFiles.RCast<int32_t(*)(int32_t*)>(); /*44 8B 51 0C 4C 8B C1*/
-
-		p_RTech_RegisterAsset = g_GameDll.FindPatternSIMD("4D 89 42 08").FindPatternSelf("48 89 6C", CMemory::Direction::UP);
-		RTech_RegisterAsset   = p_RTech_RegisterAsset.RCast<void(*)(int, int, const char*, void*, void*, void*, void*, int, int, uint32_t, int, int)>(); /*4D 89 42 08*/
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 54 41 56 41 57 48 83 EC 40 48 8B E9").GetPtr(v_StreamDB_Init);
+		g_GameDll.FindPatternSIMD("44 8B 51 0C 4C 8B C1").GetPtr(RTech_FindFreeSlotInFiles);
+		g_GameDll.FindPatternSIMD("4D 89 42 08").FindPatternSelf("48 89 6C", CMemory::Direction::UP).GetPtr(RTech_RegisterAsset);
 	}
 	virtual void GetVar(void) const
 	{
-		s_pFileArray      = p_StreamDB_Init.Offset(0x70).FindPatternSelf("48 8D 0D", CMemory::Direction::DOWN, 512, 2).ResolveRelativeAddress(0x3, 0x7).RCast<int32_t*>();
-		s_pFileHandles    = p_StreamDB_Init.Offset(0x70).FindPatternSelf("4C 8D", CMemory::Direction::DOWN, 512, 1).ResolveRelativeAddress(0x3, 0x7).RCast<pFileHandleTracker_t*>();
-		s_pFileArrayMutex = p_StreamDB_Init.Offset(0x70).FindPatternSelf("48 8D 0D", CMemory::Direction::DOWN, 512, 1).ResolveRelativeAddress(0x3, 0x7).RCast<PSRWLOCK*>();
+		s_pFileArray      = CMemory(v_StreamDB_Init).Offset(0x70).FindPatternSelf("48 8D 0D", CMemory::Direction::DOWN, 512, 2).ResolveRelativeAddress(0x3, 0x7).RCast<int32_t*>();
+		s_pFileHandles    = CMemory(v_StreamDB_Init).Offset(0x70).FindPatternSelf("4C 8D", CMemory::Direction::DOWN, 512, 1).ResolveRelativeAddress(0x3, 0x7).RCast<pFileHandleTracker_t*>();
+		s_pFileArrayMutex = CMemory(v_StreamDB_Init).Offset(0x70).FindPatternSelf("48 8D 0D", CMemory::Direction::DOWN, 512, 1).ResolveRelativeAddress(0x3, 0x7).RCast<PSRWLOCK*>();
 
-		g_pLoadedPakInfo     = p_Pak_UnloadPak.FindPattern("48 8D 05", CMemory::Direction::DOWN).ResolveRelativeAddressSelf(0x3, 0x7).RCast<PakLoadedInfo_t*>();
-		g_pRequestedPakCount = p_Pak_UnloadPak.FindPattern("66 89", CMemory::Direction::DOWN, 450).ResolveRelativeAddressSelf(0x3, 0x7).RCast<int16_t*>();
+		g_pLoadedPakInfo     = CMemory(v_Pak_UnloadPak).FindPattern("48 8D 05", CMemory::Direction::DOWN).ResolveRelativeAddressSelf(0x3, 0x7).RCast<PakLoadedInfo_t*>();
+		g_pRequestedPakCount = CMemory(v_Pak_UnloadPak).FindPattern("66 89", CMemory::Direction::DOWN, 450).ResolveRelativeAddressSelf(0x3, 0x7).RCast<int16_t*>();
 		g_pLoadedPakCount    = &*g_pRequestedPakCount - 1; // '-1' shifts it back with sizeof(int16_t).
 
 		g_pPakGlobals   = g_GameDll.FindPatternSIMD("48 8D 1D ?? ?? ?? ?? 45 8D 5A 0E").ResolveRelativeAddressSelf(0x3, 0x7).RCast<PakGlobals_t*>(); /*48 8D 1D ? ? ? ? 45 8D 5A 0E*/
 		g_pPakLoadJobID = reinterpret_cast<JobID_t*>(&*g_pLoadedPakCount - 2);
 
-		g_pPakFifoLock         = p_JT_HelpWithAnything.Offset(0x155).FindPatternSelf("48 8D 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<JobFifoLock_s*>();
-		g_pPakFifoLockWrapper  = p_JT_HelpWithAnything.Offset(0x1BC).FindPatternSelf("48 8D 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<void*>();
-		g_bPakFifoLockAcquired = p_JT_HelpWithAnything.Offset(0x50).FindPatternSelf("C6 05").ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
+		g_pPakFifoLock         = CMemory(JT_HelpWithAnything).Offset(0x155).FindPatternSelf("48 8D 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<JobFifoLock_s*>();
+		g_pPakFifoLockWrapper  = CMemory(JT_HelpWithAnything).Offset(0x1BC).FindPatternSelf("48 8D 0D").ResolveRelativeAddressSelf(0x3, 0x7).RCast<void*>();
+		g_bPakFifoLockAcquired = CMemory(JT_HelpWithAnything).Offset(0x50).FindPatternSelf("C6 05").ResolveRelativeAddressSelf(0x2, 0x7).RCast<bool*>();
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/rtech/rui/rui.h
+++ b/src/rtech/rui/rui.h
@@ -1,13 +1,8 @@
 #pragma once
 
 /* ==== RUI ====================================================================================================================================================== */
-inline CMemory p_Rui_Draw;
 inline bool(*v_Rui_Draw)(__int64* a1, __m128* a2, const __m128i* a3, __int64 a4, __m128* a5);
-
-inline CMemory p_Rui_LoadAsset;
 inline void*(*v_Rui_LoadAsset)(const char* szRuiAssetName);
-
-inline CMemory p_Rui_GetFontFace;
 inline int16_t(*v_Rui_GetFontFace)(void);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -15,20 +10,15 @@ class V_Rui : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Rui_Draw", p_Rui_Draw.GetPtr());
-		LogFunAdr("Rui_LoadAsset", p_Rui_LoadAsset.GetPtr());
-		LogFunAdr("Rui_GetFontFace", p_Rui_GetFontFace.GetPtr());
+		LogFunAdr("Rui_Draw", v_Rui_Draw);
+		LogFunAdr("Rui_LoadAsset", v_Rui_LoadAsset);
+		LogFunAdr("Rui_GetFontFace", v_Rui_GetFontFace);
 	}
 	virtual void GetFun(void) const
 	{
-		p_Rui_Draw = g_GameDll.FindPatternSIMD("40 53 48 83 EC 40 4C 8B 5A 18");
-		v_Rui_Draw = p_Rui_Draw.RCast<bool(*)(__int64*, __m128*, const __m128i*, __int64, __m128*)>(); /* 40 53 48 83 EC 40 4C 8B 5A 18 */
-
-		p_Rui_LoadAsset = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? EB 03 49 8B C6 48 89 86 ?? ?? ?? ?? 8B 86 ?? ?? ?? ??").FollowNearCallSelf();
-		v_Rui_LoadAsset = p_Rui_LoadAsset.RCast<void* (*)(const char*)>(); /*E8 ?? ?? ?? ?? EB 03 49 8B C6 48 89 86 ?? ?? ?? ?? 8B 86 ?? ?? ?? ??*/
-
-		p_Rui_GetFontFace = g_GameDll.FindPatternSIMD("F7 05 ?? ?? ?? ?? ?? ?? ?? ?? 4C 8D 0D ?? ?? ?? ?? 74 05 49 8B D1 EB 19 48 8B 05 ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ?? 48 8B 48 58 48 85 C9 48 0F 45 D1 F7 05 ?? ?? ?? ?? ?? ?? ?? ?? 75 19 48 8B 05 ?? ?? ?? ?? 4C 8D 0D ?? ?? ?? ?? 4C 8B 40 58 4D 85 C0 4D 0F 45 C8 49 8B C9 48 FF 25 ?? ?? ?? ??");
-		v_Rui_GetFontFace = p_Rui_GetFontFace.RCast<int16_t(*)(void)>();/*F7 05 ? ? ? ? ? ? ? ? 4C 8D 0D ? ? ? ? 74 05 49 8B D1 EB 19 48 8B 05 ? ? ? ? 48 8D 15 ? ? ? ? 48 8B 48 58 48 85 C9 48 0F 45 D1 F7 05 ? ? ? ? ? ? ? ? 75 19 48 8B 05 ? ? ? ? 4C 8D 0D ? ? ? ? 4C 8B 40 58 4D 85 C0 4D 0F 45 C8 49 8B C9 48 FF 25 ? ? ? ?*/
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 40 4C 8B 5A 18").GetPtr(v_Rui_Draw);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? EB 03 49 8B C6 48 89 86 ?? ?? ?? ?? 8B 86 ?? ?? ?? ??").FollowNearCallSelf().GetPtr(v_Rui_LoadAsset);
+		g_GameDll.FindPatternSIMD("F7 05 ?? ?? ?? ?? ?? ?? ?? ?? 4C 8D 0D ?? ?? ?? ?? 74 05 49 8B D1 EB 19 48 8B 05 ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ?? 48 8B 48 58 48 85 C9 48 0F 45 D1 F7 05 ?? ?? ?? ?? ?? ?? ?? ?? 75 19 48 8B 05 ?? ?? ?? ?? 4C 8D 0D ?? ?? ?? ?? 4C 8B 40 58 4D 85 C0 4D 0F 45 C8 49 8B C9 48 FF 25 ?? ?? ?? ??").GetPtr(v_Rui_GetFontFace);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/rtech/stryder/stryder.h
+++ b/src/rtech/stryder/stryder.h
@@ -1,31 +1,21 @@
 #pragma once
 
 /* ==== STRYDER ================================================================================================================================================ */
-inline CMemory p_Stryder_StitchRequest;
-inline void*(*Stryder_StitchRequest)(void* a1);
-
-inline CMemory p_Stryder_SendOfflineRequest;
-inline bool(*Stryder_SendOfflineRequest)(void);
+inline void*(*v_Stryder_StitchRequest)(void* a1);
+inline bool(*v_Stryder_SendOfflineRequest)(void);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VStryder : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Stryder_StitchRequest", p_Stryder_StitchRequest.GetPtr());
-		LogFunAdr("Stryder_SendOfflineRequest", p_Stryder_SendOfflineRequest.GetPtr());
+		LogFunAdr("Stryder_StitchRequest", v_Stryder_StitchRequest);
+		LogFunAdr("Stryder_SendOfflineRequest", v_Stryder_SendOfflineRequest);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_Stryder_StitchRequest      = g_GameDll.FindPatternSIMD("48 8B C4 53 57 41 56 48 81 EC 20");
-		p_Stryder_SendOfflineRequest = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 35 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 83 65 D0 FC 48 8D 4D 80");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_Stryder_StitchRequest      = g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B F9 E8 B4");
-		p_Stryder_SendOfflineRequest = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 55 57 41 56 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 35 ?? ?? ?? ??");
-#endif
-		Stryder_StitchRequest      = p_Stryder_StitchRequest.RCast<void* (*)(void*)>();   /*48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B F9 E8 B4*/
-		Stryder_SendOfflineRequest = p_Stryder_SendOfflineRequest.RCast<bool(*)(void)>(); /*48 89 5C 24 ?? 48 89 74 24 ?? 55 57 41 56 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 35 ?? ?? ?? ??*/
+		g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B F9 E8 B4").GetPtr(v_Stryder_StitchRequest);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 55 57 41 56 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 35 ?? ?? ?? ??").GetPtr(v_Stryder_SendOfflineRequest);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/studiorender/studiorendercontext.h
+++ b/src/studiorender/studiorendercontext.h
@@ -3,32 +3,21 @@
 //-------------------------------------------------------------------------
 // CSTUDIORENDERCONTEXT
 //-------------------------------------------------------------------------
-inline CMemory CStudioRenderContext__LoadModel;
-inline CMemory CStudioRenderContext__LoadMaterials;
+inline void (*CStudioRenderContext__LoadModel)(__int64 thisptr, studiohdr_t* pStudioHdr, void* pVtxBuffer, studiohwdata_t* pStudioHWData);
+inline __int64 (*CStudioRenderContext__LoadMaterials)(__int64 thisptr, studiohdr_t* pStudioHdr, void* a3, uint32_t* pFlags);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VStudioRenderContext : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CStudioRenderContext::LoadModel", CStudioRenderContext__LoadModel.GetPtr());
-		LogFunAdr("CStudioRenderContext::LoadMaterials", CStudioRenderContext__LoadMaterials.GetPtr());
+		LogFunAdr("CStudioRenderContext::LoadModel", CStudioRenderContext__LoadModel);
+		LogFunAdr("CStudioRenderContext::LoadMaterials", CStudioRenderContext__LoadMaterials);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S1)
-		CStudioRenderContext__LoadModel = g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 53 55 56 41 54 41 57");
-#elif defined (GAMEDLL_S2)
-		CStudioRenderContext__LoadModel = g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 48 89 54 24 ?? 53 57 41 55 48 81 EC ?? ?? ?? ??");
-#elif defined (GAMEDLL_S3)
-		CStudioRenderContext__LoadModel = g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 48 89 54 24 ?? 48 89 4C 24 ?? 53 55 56 57 48 83 EC 78");
-#endif// 0x1404554C0 // 4C 89 44 24 ? 48 89 54 24 ? 48 89 4C 24 ? 53 55 56 57 48 83 EC 78 //
-
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		CStudioRenderContext__LoadMaterials = g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 55 56 41 57");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		CStudioRenderContext__LoadMaterials = g_GameDll.FindPatternSIMD("48 8B C4 4C 89 40 18 55 56 41 55");
-#endif// 0x140456B50 // 48 8B C4 4C 89 40 18 55 56 41 55 //
+		g_GameDll.FindPatternSIMD("4C 89 44 24 ?? 48 89 54 24 ?? 48 89 4C 24 ?? 53 55 56 57 48 83 EC 78").GetPtr(CStudioRenderContext__LoadModel);
+		g_GameDll.FindPatternSIMD("48 8B C4 4C 89 40 18 55 56 41 55").GetPtr(CStudioRenderContext__LoadMaterials);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/tier0/commandline.cpp
+++ b/src/tier0/commandline.cpp
@@ -20,7 +20,7 @@ void CCommandLine::StaticCreateCmdLine(CCommandLine* thisptr, const char* pszCom
 	// get lost when the game recreates it in 'LauncherMain'.
 	if (!g_bCommandLineCreated)
 	{
-		v_CCommandLine__CreateCmdLine(thisptr, pszCommandLine);
+		CCommandLine__CreateCmdLine(thisptr, pszCommandLine);
 	}
 }
 
@@ -91,5 +91,5 @@ CCommandLine* g_pCmdLine = nullptr;
 
 void VCommandLine::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_CCommandLine__CreateCmdLine, &CCommandLine::StaticCreateCmdLine, bAttach);
+	DetourSetup(&CCommandLine__CreateCmdLine, &CCommandLine::StaticCreateCmdLine, bAttach);
 }

--- a/src/tier0/commandline.h
+++ b/src/tier0/commandline.h
@@ -30,20 +30,18 @@ inline CCommandLine* CommandLine(void)
 	return g_pCmdLine;
 }
 
-inline CMemory p_CCommandLine__CreateCmdLine;
-inline void(*v_CCommandLine__CreateCmdLine)(CCommandLine* thisptr, const char* pszCommandLine);
+inline void(*CCommandLine__CreateCmdLine)(CCommandLine* thisptr, const char* pszCommandLine);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VCommandLine : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CCommandLine::CreateCmdLine", p_CCommandLine__CreateCmdLine.GetPtr());
+		LogFunAdr("CCommandLine::CreateCmdLine", CCommandLine__CreateCmdLine);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CCommandLine__CreateCmdLine = g_GameDll.FindPatternSIMD("48 89 54 24 ?? 48 89 4C 24 ?? 53 41 55 B8 ?? ?? ?? ??");
-		v_CCommandLine__CreateCmdLine = p_CCommandLine__CreateCmdLine.RCast<void(*)(CCommandLine*, const char*)>();
+		g_GameDll.FindPatternSIMD("48 89 54 24 ?? 48 89 4C 24 ?? 53 41 55 B8 ?? ?? ?? ??").GetPtr(CCommandLine__CreateCmdLine);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/tier0/jobthread.cpp
+++ b/src/tier0/jobthread.cpp
@@ -7,19 +7,17 @@
 //-----------------------------------------------------------------------------
 void* HJT_HelpWithAnything(bool bShouldLoadPak)
 {
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-	static void* retaddr = g_GameDll.FindPatternSIMD("48 8B C4 56 41 54 41 57 48 81 EC ?? ?? ?? ?? F2 0F 10 05 ?? ?? ?? ??")
-		.Offset(0x400).FindPatternSelf("48 8B ?? ?? ?? ?? 01", CMemory::Direction::DOWN).RCast<void*>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-	static void* retaddr = g_GameDll.FindPatternSIMD("48 8B C4 ?? 41 54 41 55 48 81 EC 70 04 ?? ?? F2 0F 10 05 ?? ?? ?? 0B")
-		.Offset(0x4A0).FindPatternSelf("48 8B ?? ?? ?? ?? 01", CMemory::Direction::DOWN).RCast<void*>();
-#endif
-	void* results = JT_HelpWithAnything(bShouldLoadPak);
+	// !! Uncomment if needed !!
+	// !! Consider initializing this in idetour iface if enabled !!
+	//static void* const retaddr = g_GameDll.FindPatternSIMD("48 8B C4 ?? 41 54 41 55 48 81 EC 70 04 ?? ?? F2 0F 10 05 ?? ?? ?? 0B")
+	//	.Offset(0x4A0).FindPatternSelf("48 8B ?? ?? ?? ?? 01", CMemory::Direction::DOWN).RCast<void*>();
 
-	if (retaddr != _ReturnAddress()) // Check if this is called after 'PakFile_Init()'.
-	{
-		return results;
-	}
+	void* const results = JT_HelpWithAnything(bShouldLoadPak);
+
+	//if (retaddr != _ReturnAddress()) // Check if this is called after 'PakFile_Init()'.
+	//{
+	//	return results;
+	//}
 	// Do stuff here after 'PakFile_Init()'.
 	return results;
 }

--- a/src/tier0/tier0_iface.cpp
+++ b/src/tier0/tier0_iface.cpp
@@ -20,33 +20,33 @@ string g_LogSessionDirectory;
 
 static const char* const s_AdrFmt = "| {:s}: {:42s}: {:#18x} |\n";
 
-void LogFunAdr(const char* const szFun, const uintptr_t nAdr) // Logging function addresses.
+void LogFunAdr(const char* const szFun, const void* const pAdr) // Logging function addresses.
 {
 	if (!IsCert() && !IsRetail())
-		spdlog::debug(s_AdrFmt, "FUN", szFun, nAdr);
+		spdlog::debug(s_AdrFmt, "FUN", szFun, uintptr_t(pAdr));
 	else
 	{
 		NOTE_UNUSED(szFun);
-		NOTE_UNUSED(nAdr);
+		NOTE_UNUSED(pAdr);
 	}
 }
-void LogVarAdr(const char* const szVar, const uintptr_t nAdr) // Logging variable addresses.
+void LogVarAdr(const char* const szVar, const void* const pAdr) // Logging variable addresses.
 {
 	if (!IsCert() && !IsRetail())
-		spdlog::debug(s_AdrFmt, "VAR", szVar, nAdr);
+		spdlog::debug(s_AdrFmt, "VAR", szVar, uintptr_t(pAdr));
 	else
 	{
 		NOTE_UNUSED(szVar);
-		NOTE_UNUSED(nAdr);
+		NOTE_UNUSED(pAdr);
 	}
 }
-void LogConAdr(const char* const szCon, const uintptr_t nAdr) // Logging constant addresses.
+void LogConAdr(const char* const szCon, const void* const pAdr) // Logging constant addresses.
 {
 	if (!IsCert() && !IsRetail())
-		spdlog::debug(s_AdrFmt, "CON", szCon, nAdr);
+		spdlog::debug(s_AdrFmt, "CON", szCon, uintptr_t(pAdr));
 	else
 	{
 		NOTE_UNUSED(szCon);
-		NOTE_UNUSED(nAdr);
+		NOTE_UNUSED(pAdr);
 	}
 }

--- a/src/tier1/convar.cpp
+++ b/src/tier1/convar.cpp
@@ -132,7 +132,7 @@ ConVar* ConVar::StaticCreate(const char* pszName, const char* pszDefaultValue,
 
 	pNewConVar->m_fnChangeCallbacks.Init();
 
-	v_ConVar_Register(pNewConVar, pszName, pszDefaultValue, nFlags,
+	ConVar__Register(pNewConVar, pszName, pszDefaultValue, nFlags,
 		pszHelpString, bMin, fMin, bMax, fMax, pCallback, pszUsageString);
 	return pNewConVar;
 }
@@ -142,7 +142,7 @@ ConVar* ConVar::StaticCreate(const char* pszName, const char* pszDefaultValue,
 //-----------------------------------------------------------------------------
 void ConVar::Destroy(void)
 {
-	v_ConVar_Unregister(this);
+	ConVar__Unregister(this);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/vgui/vgui_baseui_interface.cpp
+++ b/src/vgui/vgui_baseui_interface.cpp
@@ -17,7 +17,7 @@
 //-----------------------------------------------------------------------------
 int CEngineVGui::Paint(CEngineVGui* thisptr, PaintMode_t mode)
 {
-	int result = CEngineVGui_Paint(thisptr, mode);
+	int result = CEngineVGui__Paint(thisptr, mode);
 
 	if (/*mode == PaintMode_t::PAINT_UIPANELS ||*/ mode == PaintMode_t::PAINT_INGAMEPANELS) // Render in-main menu and in-game.
 	{
@@ -30,7 +30,7 @@ int CEngineVGui::Paint(CEngineVGui* thisptr, PaintMode_t mode)
 ///////////////////////////////////////////////////////////////////////////////
 void VEngineVGui::Detour(const bool bAttach) const
 {
-	DetourSetup(&CEngineVGui_Paint, &CEngineVGui::Paint, bAttach);
+	DetourSetup(&CEngineVGui__Paint, &CEngineVGui::Paint, bAttach);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/vgui/vgui_baseui_interface.h
+++ b/src/vgui/vgui_baseui_interface.h
@@ -77,16 +77,11 @@ public:
 };
 
 /* ==== CENGINEVGUI ===================================================================================================================================================== */
-inline CMemory p_CEngineVGui_Paint;
-inline int(*CEngineVGui_Paint)(CEngineVGui* thisptr, PaintMode_t mode);
+inline int(*CEngineVGui__Paint)(CEngineVGui* thisptr, PaintMode_t mode);
+inline void*(*CEngineVGui__RenderStart)(CMatSystemSurface* pMatSystemSurface);
+inline void*(*CEngineVGui__RenderEnd)(void);
 
-inline CMemory p_CEngineVGui_RenderStart;
-inline void*(*CEngineVGui_RenderStart)(CMatSystemSurface* pMatSystemSurface);
-
-inline CMemory p_CEngineVGui_RenderEnd;
-inline void*(*CEngineVGui_RenderEnd)(void);
-
-inline InputEventCallback_t UIEventDispatcher = nullptr; // Points to 'CGame::DispatchInputEvent()'
+inline InputEventCallback_t v_UIEventDispatcher = nullptr; // Points to 'CGame::DispatchInputEvent()'
 inline CEngineVGui* g_pEngineVGui = nullptr;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -94,31 +89,18 @@ class VEngineVGui : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CEngineVGui::Paint", p_CEngineVGui_Paint.GetPtr());
-		LogFunAdr("CEngineVGui::RenderStart", p_CEngineVGui_RenderStart.GetPtr());
-		LogFunAdr("CEngineVGui::RenderEnd", p_CEngineVGui_RenderEnd.GetPtr());
-		LogFunAdr("UIEventDispatcher", reinterpret_cast<uintptr_t>(UIEventDispatcher));
-		LogVarAdr("g_pEngineVGui", reinterpret_cast<uintptr_t>(g_pEngineVGui));
+		LogFunAdr("CEngineVGui::Paint", CEngineVGui__Paint);
+		LogFunAdr("CEngineVGui::RenderStart", CEngineVGui__RenderStart);
+		LogFunAdr("CEngineVGui::RenderEnd", CEngineVGui__RenderEnd);
+		LogFunAdr("UIEventDispatcher", v_UIEventDispatcher);
+		LogVarAdr("g_pEngineVGui", g_pEngineVGui);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_CEngineVGui_Paint = g_GameDll.FindPatternSIMD("89 54 24 10 55 56 41 55 48 81 EC ?? ?? ?? ??");
-		CEngineVGui_Paint = p_CEngineVGui_Paint.RCast<int (*)(CEngineVGui* thisptr, PaintMode_t mode)>(); /*41 55 41 56 48 83 EC 78 44 8B EA*/
-
-		p_CEngineVGui_RenderStart = g_GameDll.FindPatternSIMD("48 8B C4 53 56 57 48 81 EC ?? ?? ?? ?? 0F 29 70 D8");
-		CEngineVGui_RenderStart = p_CEngineVGui_RenderStart.RCast<void* (*)(CMatSystemSurface*)>(); /*48 8B C4 53 56 57 48 81 EC ?? ?? ?? ?? 0F 29 70 D8*/
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_CEngineVGui_Paint = g_GameDll.FindPatternSIMD("41 55 41 56 48 83 EC 78 44 8B EA");
-		CEngineVGui_Paint = p_CEngineVGui_Paint.RCast<int (*)(CEngineVGui* thisptr, PaintMode_t mode)>(); /*41 55 41 56 48 83 EC 78 44 8B EA*/
-
-		p_CEngineVGui_RenderStart = g_GameDll.FindPatternSIMD("40 53 57 48 81 EC ?? ?? ?? ?? 48 8B F9");
-		CEngineVGui_RenderStart = p_CEngineVGui_RenderStart.RCast<void* (*)(CMatSystemSurface*)>(); /*40 53 57 48 81 EC ?? ?? ?? ?? 48 8B F9*/
-#endif
-		p_CEngineVGui_RenderEnd = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B 0D ?? ?? ?? ?? C6 05 ?? ?? ?? ?? ?? 48 8B 01");
-		CEngineVGui_RenderEnd = p_CEngineVGui_RenderEnd.RCast<void* (*)(void)>(); /*40 53 48 83 EC 20 48 8B 0D ?? ?? ?? ?? C6 05 ?? ?? ?? ?? ?? 48 8B 01*/
-
-		g_GameDll.FindPatternSIMD("40 53 48 83 EC 40 48 63 01", UIEventDispatcher);
+		g_GameDll.FindPatternSIMD("41 55 41 56 48 83 EC 78 44 8B EA").GetPtr(CEngineVGui__Paint);
+		g_GameDll.FindPatternSIMD("40 53 57 48 81 EC ?? ?? ?? ?? 48 8B F9").GetPtr(CEngineVGui__RenderStart);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 48 8B 0D ?? ?? ?? ?? C6 05 ?? ?? ?? ?? ?? 48 8B 01").GetPtr(CEngineVGui__RenderEnd);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 40 48 63 01").GetPtr(v_UIEventDispatcher);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/vgui/vgui_controls/RichText.cpp
+++ b/src/vgui/vgui_controls/RichText.cpp
@@ -45,7 +45,7 @@ void vgui::RichText::SetText(const char* text)
 ///////////////////////////////////////////////////////////////////////////////
 void VVGUIRichText::Detour(const bool bAttach) const
 {
-	DetourSetup(&vgui_RichText_SetText, &RichText_SetText, bAttach);
+	DetourSetup(&vgui__RichText__SetText, &RichText_SetText, bAttach);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/vgui/vgui_controls/RichText.h
+++ b/src/vgui/vgui_controls/RichText.h
@@ -27,20 +27,18 @@ namespace vgui
 };
 
 /* ==== RICHTEXT ===================================================================================================================================================== */
-inline CMemory p_vgui_RichText_SetText;
-inline void(*vgui_RichText_SetText)(vgui::RichText* thisptr, const char* text);
+inline void(*vgui__RichText__SetText)(vgui::RichText* thisptr, const char* text);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VVGUIRichText : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("vgui::RichText::SetText", p_vgui_RichText_SetText.GetPtr());
+		LogFunAdr("vgui::RichText::SetText", vgui__RichText__SetText);
 	}
 	virtual void GetFun(void) const
 	{
-		p_vgui_RichText_SetText = g_GameDll.FindPatternSIMD("40 53 B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B D9");
-		vgui_RichText_SetText = p_vgui_RichText_SetText.RCast<void(*)(vgui::RichText*, const char*)>();
+		g_GameDll.FindPatternSIMD("40 53 B8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 2B E0 48 8B D9").GetPtr(vgui__RichText__SetText);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/vgui/vgui_debugpanel.cpp
+++ b/src/vgui/vgui_debugpanel.cpp
@@ -106,7 +106,7 @@ void CTextOverlay::DrawNotify(void)
 		{
 			c[3] = 255;
 		}
-		CMatSystemSurface_DrawColoredText(g_pMatSystemSurface, v_Rui_GetFontFace(),
+		CMatSystemSurface__DrawColoredText(g_pMatSystemSurface, v_Rui_GetFontFace(),
 			m_nFontHeight, x, y, c.r(), c.g(), c.b(), c.a(), "%s", notify.m_Text.String());
 
 		if (IsX360())
@@ -141,7 +141,7 @@ void CTextOverlay::DrawFormat(const int x, const int y, const Color c, const cha
 		va_end(args);
 	}/////////////////////////////
 
-	CMatSystemSurface_DrawColoredText(g_pMatSystemSurface, v_Rui_GetFontFace(), m_nFontHeight, x, y, c.r(), c.g(), c.b(), c.a(), "%s", szLogbuf);
+	CMatSystemSurface__DrawColoredText(g_pMatSystemSurface, v_Rui_GetFontFace(), m_nFontHeight, x, y, c.r(), c.g(), c.b(), c.a(), "%s", szLogbuf);
 }
 
 //-----------------------------------------------------------------------------
@@ -187,7 +187,7 @@ void CTextOverlay::Con_NPrintf(void)
 	const int nWidth = cl_notify_invert_x->GetBool() ? g_nWindowRect[0] - cl_notify_offset_x->GetInt() : cl_notify_offset_x->GetInt() + m_nCon_NPrintf_Idx * m_nFontHeight;
 	const int nHeight = cl_notify_invert_y->GetBool() ? g_nWindowRect[1] - cl_notify_offset_y->GetInt() : cl_notify_offset_y->GetInt();
 
-	CMatSystemSurface_DrawColoredText(g_pMatSystemSurface, v_Rui_GetFontFace(), m_nFontHeight, nWidth, nHeight, c.r(), c.g(), c.b(), c.a(), "%s", m_szCon_NPrintf_Buf);
+	CMatSystemSurface__DrawColoredText(g_pMatSystemSurface, v_Rui_GetFontFace(), m_nFontHeight, nWidth, nHeight, c.r(), c.g(), c.b(), c.a(), "%s", m_szCon_NPrintf_Buf);
 
 	m_nCon_NPrintf_Idx = 0;
 	m_szCon_NPrintf_Buf[0] = '\0';
@@ -224,7 +224,7 @@ void CTextOverlay::DrawGPUStats(void) const
 //-----------------------------------------------------------------------------
 void CTextOverlay::DrawCrosshairMaterial(void) const
 {
-	CMaterialGlue* pMaterialGlue = GetMaterialAtCrossHair();
+	CMaterialGlue* pMaterialGlue = v_GetMaterialAtCrossHair();
 	if (!pMaterialGlue)
 		return;
 
@@ -246,8 +246,8 @@ void CTextOverlay::DrawStreamOverlay(void) const
 	static char szLogbuf[4096];
 	static const Color c = { 255, 255, 255, 255 };
 	
-	v_GetStreamOverlay(stream_overlay_mode->GetString(), szLogbuf, sizeof(szLogbuf));
-	CMatSystemSurface_DrawColoredText(g_pMatSystemSurface, v_Rui_GetFontFace(), m_nFontHeight, 20, 300, c.r(), c.g(), c.b(), c.a(), "%s", szLogbuf);
+	CMaterialSystem__GetStreamOverlay(stream_overlay_mode->GetString(), szLogbuf, sizeof(szLogbuf));
+	CMatSystemSurface__DrawColoredText(g_pMatSystemSurface, v_Rui_GetFontFace(), m_nFontHeight, 20, 300, c.r(), c.g(), c.b(), c.a(), "%s", szLogbuf);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/vgui/vgui_fpspanel.cpp
+++ b/src/vgui/vgui_fpspanel.cpp
@@ -16,11 +16,11 @@
 ConVar* HCFPSPanel_Paint(void* thisptr)
 {
 	g_pOverlay->Update();
-	return CFPSPanel_Paint(thisptr);
+	return CFPSPanel__Paint(thisptr);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 void VFPSPanel::Detour(const bool bAttach) const
 {
-	DetourSetup(&CFPSPanel_Paint, &HCFPSPanel_Paint, bAttach);
+	DetourSetup(&CFPSPanel__Paint, &HCFPSPanel_Paint, bAttach);
 }

--- a/src/vgui/vgui_fpspanel.h
+++ b/src/vgui/vgui_fpspanel.h
@@ -1,20 +1,18 @@
 #pragma once
 
 /* ==== CFPSPANEL ======================================================================================================================================================= */
-inline CMemory p_CFPSPanel_Paint;
-inline ConVar*(*CFPSPanel_Paint)(void* thisptr);
+inline ConVar*(*CFPSPanel__Paint)(void* thisptr);
 
 ///////////////////////////////////////////////////////////////////////////////
 class VFPSPanel : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CFPSPanel::Paint", p_CFPSPanel_Paint.GetPtr());
+		LogFunAdr("CFPSPanel::Paint", CFPSPanel__Paint);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CFPSPanel_Paint = g_GameDll.FindPatternSIMD("48 8B C4 55 56 41 ?? 48 8D A8 ?? FD FF FF 48 81 EC 80");
-		CFPSPanel_Paint = p_CFPSPanel_Paint.RCast<ConVar* (*)(void*)>(); /*48 8B C4 55 56 41 ?? 48 8D A8 ?? FD FF FF 48 81 EC 80*/
+		g_GameDll.FindPatternSIMD("48 8B C4 55 56 41 ?? 48 8D A8 ?? FD FF FF 48 81 EC 80").GetPtr(CFPSPanel__Paint);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/vguimatsurface/MatSystemSurface.h
+++ b/src/vguimatsurface/MatSystemSurface.h
@@ -1,8 +1,7 @@
 #pragma once
 
 /* ==== CMATSYSTEMSURFACE =============================================================================================================================================== */
-inline CMemory p_CMatSystemSurface_DrawColoredText;
-inline void*(*CMatSystemSurface_DrawColoredText)(void* thisptr, short font, int fontHeight, int offsetX, int offsetY, int red, int green, int blue, int alpha, const char* text, ...);
+inline void*(*CMatSystemSurface__DrawColoredText)(void* thisptr, short font, int fontHeight, int offsetX, int offsetY, int red, int green, int blue, int alpha, const char* text, ...);
 
 class CMatSystemSurface
 {
@@ -16,24 +15,19 @@ class VMatSystemSurface : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CMatSystemSurface::DrawColoredText", p_CMatSystemSurface_DrawColoredText.GetPtr());
-		LogVarAdr("g_pMatSystemSurface", reinterpret_cast<uintptr_t>(g_pMatSystemSurface));
-		LogVarAdr("g_pVGuiSurface", reinterpret_cast<uintptr_t>(g_pVGuiSurface));
+		LogFunAdr("CMatSystemSurface::DrawColoredText", CMatSystemSurface__DrawColoredText);
+		LogVarAdr("g_pMatSystemSurface", g_pMatSystemSurface);
+		LogVarAdr("g_pVGuiSurface", g_pVGuiSurface);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CMatSystemSurface_DrawColoredText = g_GameDll.FindPatternSIMD("4C 8B DC 48 83 EC 68 49 8D 43 58 0F 57 C0");
-		CMatSystemSurface_DrawColoredText = p_CMatSystemSurface_DrawColoredText.RCast<void* (*)(void*, short, int, int, int, int, int, int, int, const char*, ...)>(); /*4C 8B DC 48 83 EC 68 49 8D 43 58 0F 57 C0*/
+		g_GameDll.FindPatternSIMD("4C 8B DC 48 83 EC 68 49 8D 43 58 0F 57 C0").GetPtr(CMatSystemSurface__DrawColoredText);
 	}
 	virtual void GetVar(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		g_pMatSystemSurface = g_GameDll.FindPatternSIMD("48 83 3D ?? ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??")
-			.ResolveRelativeAddressSelf(0x3, 0x8).RCast<CMatSystemSurface*>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 		g_pMatSystemSurface = g_GameDll.FindPatternSIMD("48 83 EC 28 48 83 3D ?? ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??")
 			.FindPatternSelf("48 83 3D", CMemory::Direction::DOWN, 40).ResolveRelativeAddressSelf(0x3, 0x8).RCast<CMatSystemSurface*>();
-#endif
+
 		g_pVGuiSurface = g_GameDll.FindPatternSIMD("48 8B 05 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 48 8B 05 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 8B 81 ?? ?? ?? ??")
 			.ResolveRelativeAddressSelf(0x3, 0x7).RCast<CMatSystemSurface*>();
 	}

--- a/src/vpc/IAppSystem.h
+++ b/src/vpc/IAppSystem.h
@@ -1,21 +1,11 @@
 #pragma once
 
 /* ==== IAPPSYSTEM ============================================================================================================================================== */
-//inline CMemory p_IAppSystem_LoadLibrary; // C initializers/terminators
-//inline void*(*IAppSystem_LoadLibrary)(void);
-
 ///////////////////////////////////////////////////////////////////////////////
 class VAppSystem : public IDetour
 {
-	virtual void GetAdr(void) const
-	{
-		//LogFunAdr("CAppSystem::LoadLibrary", p_IAppSystem_LoadLibrary.GetPtr());
-	}
-	virtual void GetFun(void) const
-	{
-		//p_IAppSystem_LoadLibrary = g_GameDll.FindPatternSIMD("48 83 EC 28 48 8B 0D ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 85 C9 74 11");
-		//IAppSystem_LoadLibrary = p_IAppSystem_LoadLibrary.RCast<void* (*)(void)>(); /*48 83 EC 28 48 8B 0D ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 85 C9 74 11*/
-	}
+	virtual void GetAdr(void) const { }
+	virtual void GetFun(void) const { }
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const { }

--- a/src/vpc/interfaces.cpp
+++ b/src/vpc/interfaces.cpp
@@ -49,7 +49,7 @@ const char* CFactorySystem::GetVersion(void) const
 //---------------------------------------------------------------------------------
 void* CreateInterface(const char* pName, int* pReturnCode)
 {
-	return CreateInterfaceInternal(pName, pReturnCode);
+	return v_CreateInterfaceInternal(pName, pReturnCode);
 }
 
 //---------------------------------------------------------------------------------

--- a/src/vpc/interfaces.h
+++ b/src/vpc/interfaces.h
@@ -59,21 +59,18 @@ extern CFactorySystem* g_pFactorySystem;
 PLATFORM_INTERFACE IFactorySystem* GetFactorySystem();
 
 ///////////////////////////////////////////////////////////////////////////////
-
-inline CMemory p_CreateInterfaceInternal;
-inline void*(*CreateInterfaceInternal)(const char* pName, int* pReturnCode);
+inline void*(*v_CreateInterfaceInternal)(const char* pName, int* pReturnCode);
 
 class VFactory : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CreateInterfaceInternal", p_CreateInterfaceInternal.GetPtr());
-		LogVarAdr("s_pInterfaceRegs", reinterpret_cast<uintptr_t>(s_ppInterfaceRegs));
+		LogFunAdr("CreateInterfaceInternal", v_CreateInterfaceInternal);
+		LogVarAdr("s_pInterfaceRegs", s_ppInterfaceRegs);
 	}
 	virtual void GetFun(void) const
 	{
-		p_CreateInterfaceInternal = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 1D ?? ?? ?? ?? 48 8B FA");
-		CreateInterfaceInternal = p_CreateInterfaceInternal.RCast<void*(*)(const char*, int*)>();
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 1D ?? ?? ?? ?? 48 8B FA").GetPtr(v_CreateInterfaceInternal);
 	}
 	virtual void GetVar(void) const
 	{

--- a/src/vpc/keyvalues.cpp
+++ b/src/vpc/keyvalues.cpp
@@ -1224,7 +1224,7 @@ void KeyValues::RecursiveSaveToFile(CUtlBuffer& buf, int nIndentLevel)
 //-----------------------------------------------------------------------------
 void KeyValues::RecursiveSaveToFile(IBaseFileSystem* pFileSystem, FileHandle_t pHandle, CUtlBuffer* pBuf, int nIndentLevel)
 {
-	KeyValues_RecursiveSaveToFile(this, pFileSystem, pHandle, pBuf, nIndentLevel);
+	KeyValues__RecursiveSaveToFile(this, pFileSystem, pHandle, pBuf, nIndentLevel);
 }
 
 //-----------------------------------------------------------------------------
@@ -1233,7 +1233,7 @@ void KeyValues::RecursiveSaveToFile(IBaseFileSystem* pFileSystem, FileHandle_t p
 //-----------------------------------------------------------------------------
 KeyValues* KeyValues::LoadFromFile(IBaseFileSystem* pFileSystem, const char* pszResourceName, const char* pszPathID, void* pfnEvaluateSymbolProc)
 {
-	return KeyValues_LoadFromFile(this, pFileSystem, pszResourceName, pszPathID, pfnEvaluateSymbolProc);
+	return KeyValues__LoadFromFile(this, pFileSystem, pszResourceName, pszPathID, pfnEvaluateSymbolProc);
 }
 
 //-----------------------------------------------------------------------------
@@ -1387,7 +1387,7 @@ void KeyValues::InitFileSystem(void)
 //-----------------------------------------------------------------------------
 bool KeyValues::LoadPlaylists(const char* pszPlaylist)
 {
-	bool bResults = KeyValues_LoadPlaylists(pszPlaylist);
+	bool bResults = KeyValues__LoadPlaylists(pszPlaylist);
 	KeyValues::InitPlaylists();
 
 	return bResults;
@@ -1424,7 +1424,7 @@ bool KeyValues::ParsePlaylists(const char* pszPlaylist)
 		reinterpret_cast<void(*)()>(verifyPlaylistIntegrityFn)();
 	}
 
-	return KeyValues_ParsePlaylists(pszPlaylist); // Parse playlist.
+	return KeyValues__ParsePlaylists(pszPlaylist); // Parse playlist.
 }
 
 //-----------------------------------------------------------------------------
@@ -1441,15 +1441,15 @@ KeyValues* KeyValues::ReadKeyValuesFile(CFileSystem_Stdio* pFileSystem, const ch
 		bInitFileSystem = true;
 		KeyValues::InitFileSystem();
 	}
-	return KeyValues_ReadKeyValuesFile(pFileSystem, pFileName);
+	return KeyValues__ReadKeyValuesFile(pFileSystem, pFileName);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 void VKeyValues::Detour(const bool bAttach) const
 {
-	DetourSetup(&KeyValues_LoadPlaylists, &KeyValues::LoadPlaylists, bAttach);
-	DetourSetup(&KeyValues_ParsePlaylists, &KeyValues::ParsePlaylists, bAttach);
-	DetourSetup(&KeyValues_ReadKeyValuesFile, &KeyValues::ReadKeyValuesFile, bAttach);
+	DetourSetup(&KeyValues__LoadPlaylists, &KeyValues::LoadPlaylists, bAttach);
+	DetourSetup(&KeyValues__ParsePlaylists, &KeyValues::ParsePlaylists, bAttach);
+	DetourSetup(&KeyValues__ReadKeyValuesFile, &KeyValues::ReadKeyValuesFile, bAttach);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/vpc/keyvalues.h
+++ b/src/vpc/keyvalues.h
@@ -20,26 +20,13 @@ class CFileSystem_Stdio;
 class IBaseFileSystem;
 
 /* ==== KEYVALUES ======================================================================================================================================================= */
-inline CMemory p_KeyValues_FindKey;
-inline void*(*KeyValues_FindKey)(KeyValues* thisptr, const char* pkeyName, bool bCreate);
-
-inline CMemory p_KeyValues_LoadPlaylists;
-inline bool(*KeyValues_LoadPlaylists)(const char* pszPlaylist);
-
-inline CMemory p_KeyValues_ParsePlaylists;
-inline bool(*KeyValues_ParsePlaylists)(const char* pszPlaylist);
-
-inline CMemory p_KeyValues_GetCurrentPlaylist;
-inline const char* (*KeyValues_GetCurrentPlaylist)(void);
-
-inline CMemory p_KeyValues_ReadKeyValuesFile;
-inline KeyValues*(*KeyValues_ReadKeyValuesFile)(CFileSystem_Stdio* pFileSystem, const char* pFileName);
-
-inline CMemory p_KeyValues_RecursiveSaveToFile;
-inline void(*KeyValues_RecursiveSaveToFile)(KeyValues* thisptr, IBaseFileSystem* pFileSystem, FileHandle_t pHandle, CUtlBuffer* pBuf, int nIndentLevel);
-
-inline CMemory p_KeyValues_LoadFromFile;
-inline KeyValues*(*KeyValues_LoadFromFile)(KeyValues* thisptr, IBaseFileSystem* pFileSystem, const char* pszResourceName, const char* pszPathID, void* pfnEvaluateSymbolProc);
+inline void*(*KeyValues__FindKey)(KeyValues* thisptr, const char* pkeyName, bool bCreate);
+inline bool(*KeyValues__LoadPlaylists)(const char* pszPlaylist);
+inline bool(*KeyValues__ParsePlaylists)(const char* pszPlaylist);
+inline const char* (*KeyValues__GetCurrentPlaylist)(void);
+inline KeyValues*(*KeyValues__ReadKeyValuesFile)(CFileSystem_Stdio* pFileSystem, const char* pFileName);
+inline void(*KeyValues__RecursiveSaveToFile)(KeyValues* thisptr, IBaseFileSystem* pFileSystem, FileHandle_t pHandle, CUtlBuffer* pBuf, int nIndentLevel);
+inline KeyValues*(*KeyValues__LoadFromFile)(KeyValues* thisptr, IBaseFileSystem* pFileSystem, const char* pszResourceName, const char* pszPathID, void* pfnEvaluateSymbolProc);
 
 enum KeyValuesTypes_t : char
 {
@@ -191,49 +178,29 @@ class VKeyValues : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("KeyValues::FindKey", p_KeyValues_FindKey.GetPtr());
-		LogFunAdr("KeyValues::LoadPlaylists", p_KeyValues_LoadPlaylists.GetPtr());
-		LogFunAdr("KeyValues::ParsePlaylists", p_KeyValues_ParsePlaylists.GetPtr());
-		LogFunAdr("KeyValues::GetCurrentPlaylist", p_KeyValues_GetCurrentPlaylist.GetPtr());
-		LogFunAdr("KeyValues::ReadKeyValuesFile", p_KeyValues_ReadKeyValuesFile.GetPtr());
-		LogFunAdr("KeyValues::RecursiveSaveToFile", p_KeyValues_RecursiveSaveToFile.GetPtr());
-		LogFunAdr("KeyValues::LoadFromFile", p_KeyValues_LoadFromFile.GetPtr());
-		LogVarAdr("g_pPlaylistKeyValues", reinterpret_cast<uintptr_t>(g_pPlaylistKeyValues));
+		LogFunAdr("KeyValues::FindKey", KeyValues__FindKey);
+		LogFunAdr("KeyValues::LoadPlaylists", KeyValues__LoadPlaylists);
+		LogFunAdr("KeyValues::ParsePlaylists", KeyValues__ParsePlaylists);
+		LogFunAdr("KeyValues::GetCurrentPlaylist", KeyValues__GetCurrentPlaylist);
+		LogFunAdr("KeyValues::ReadKeyValuesFile", KeyValues__ReadKeyValuesFile);
+		LogFunAdr("KeyValues::RecursiveSaveToFile", KeyValues__RecursiveSaveToFile);
+		LogFunAdr("KeyValues::LoadFromFile", KeyValues__LoadFromFile);
+		LogVarAdr("g_pPlaylistKeyValues", g_pPlaylistKeyValues);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_KeyValues_FindKey            = g_GameDll.FindPatternSIMD("48 89 5C 24 10 48 89 6C 24 18 48 89 74 24 20 57 41 54 41 55 41 56 41 57 48 81 EC 20 01 ?? ?? 45");
-		p_KeyValues_GetCurrentPlaylist = g_GameDll.FindPatternSIMD("48 8B 0D ?? ?? ?? ?? 48 85 C9 75 08 48 8D 05 ?? ?? ?? ??");
-		p_KeyValues_ReadKeyValuesFile  = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 55 56 57 41 54 41 57 48 8D 6C 24 ??");
-		p_KeyValues_LoadFromFile       = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 4C 89 4C 24 ?? 4C 89 44 24 ?? 48 89 4C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_KeyValues_FindKey            = g_GameDll.FindPatternSIMD("40 56 57 41 57 48 81 EC ?? ?? ?? ?? 45");
-		p_KeyValues_GetCurrentPlaylist = g_GameDll.FindPatternSIMD("48 8B 05 ?? ?? ?? ?? 48 85 C0 75 08 48 8D 05 ?? ?? ?? ?? C3 0F B7 50 2A");
-		p_KeyValues_ReadKeyValuesFile  = g_GameDll.FindPatternSIMD("48 8B C4 55 53 57 41 54 48 8D 68 A1");
-		p_KeyValues_LoadFromFile       = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 4C 89 4C 24 ?? 48 89 4C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ??");
-#endif
-		p_KeyValues_LoadPlaylists        = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 40 48 8B F1");
-		p_KeyValues_ParsePlaylists       = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 74 0C").FollowNearCallSelf();
-		p_KeyValues_RecursiveSaveToFile  = g_GameDll.FindPatternSIMD("48 8B C4 53 ?? 57 41 55 41 ?? 48 83");
-
-		KeyValues_FindKey            = p_KeyValues_FindKey.RCast<void* (*)(KeyValues*, const char*, bool)>();                  /*40 56 57 41 57 48 81 EC 30 01 00 00 45 0F B6 F8*/
-		KeyValues_LoadPlaylists      = p_KeyValues_ParsePlaylists.RCast<bool (*)(const char*)>();                              /*48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 40 48 8B F1*/
-		KeyValues_ParsePlaylists     = p_KeyValues_ParsePlaylists.RCast<bool (*)(const char*)>();                              /*E8 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 74 0C*/
-		KeyValues_GetCurrentPlaylist = p_KeyValues_GetCurrentPlaylist.RCast<const char* (*)(void)>();                          /*48 8B 05 ?? ?? ?? ?? 48 85 C0 75 08 48 8D 05 ?? ?? ?? ?? C3 0F B7 50 2A*/
-		KeyValues_ReadKeyValuesFile  = p_KeyValues_ReadKeyValuesFile.RCast<KeyValues* (*)(CFileSystem_Stdio*, const char*)>(); /*48 8B C4 55 53 57 41 54 48 8D 68 A1*/
-		KeyValues_RecursiveSaveToFile = p_KeyValues_RecursiveSaveToFile.RCast<void (*)(KeyValues*, IBaseFileSystem*, FileHandle_t, CUtlBuffer*, int)>();  /*48 8B C4 53 ?? 57 41 55 41 ?? 48 83*/
-		KeyValues_LoadFromFile        = p_KeyValues_LoadFromFile.RCast<KeyValues* (*)(KeyValues*, IBaseFileSystem*, const char*, const char*, void*)>();
+		g_GameDll.FindPatternSIMD("40 56 57 41 57 48 81 EC ?? ?? ?? ?? 45").GetPtr(KeyValues__FindKey);
+		g_GameDll.FindPatternSIMD("48 8B 05 ?? ?? ?? ?? 48 85 C0 75 08 48 8D 05 ?? ?? ?? ?? C3 0F B7 50 2A").GetPtr(KeyValues__GetCurrentPlaylist);
+		g_GameDll.FindPatternSIMD("48 8B C4 55 53 57 41 54 48 8D 68 A1").GetPtr(KeyValues__ReadKeyValuesFile);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 4C 89 4C 24 ?? 48 89 4C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ??").GetPtr(KeyValues__LoadFromFile);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 40 48 8B F1").GetPtr(KeyValues__LoadPlaylists);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 80 3D ?? ?? ?? ?? ?? 74 0C").FollowNearCallSelf().GetPtr(KeyValues__ParsePlaylists);
+		g_GameDll.FindPatternSIMD("48 8B C4 53 ?? 57 41 55 41 ?? 48 83").GetPtr(KeyValues__RecursiveSaveToFile);
 	}
 	virtual void GetVar(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		g_pPlaylistKeyValues = g_GameDll.FindPatternSIMD("48 8B C4 53 57 41 56 48 81 EC 20")
-			.FindPatternSelf("48 8B 2D", CMemory::Direction::DOWN, 100).ResolveRelativeAddressSelf(0x3, 0x7).RCast<KeyValues**>();
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
 		g_pPlaylistKeyValues = g_GameDll.FindPatternSIMD("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B F9 E8 B4")
 			.FindPatternSelf("48 8B 0D", CMemory::Direction::DOWN, 100).ResolveRelativeAddressSelf(0x3, 0x7).RCast<KeyValues**>();
-#endif
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/vpc/rson.h
+++ b/src/vpc/rson.h
@@ -84,10 +84,7 @@ public:
 	static Node_t* LoadFromFile(const char* pszFilePath, const char* pPathID = nullptr);
 };
 ///////////////////////////////////////////////////////////////////////////////
-inline CMemory p_RSON_LoadFromBuffer;
 inline RSON::Node_t* (*RSON_LoadFromBuffer)(const char* bufName, char* buf, RSON::eFieldType rootType, __int64 a4, void* a5);
-
-inline CMemory p_RSON_Free;
 inline void (*RSON_Free)(RSON::Node_t* rson, CAlignedMemAlloc* allocator);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -95,16 +92,13 @@ class VRSON : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("RSON_LoadFromBuffer", p_RSON_LoadFromBuffer.GetPtr());
-		LogFunAdr("RSON_Free", p_RSON_Free.GetPtr());
+		LogFunAdr("RSON_LoadFromBuffer", RSON_LoadFromBuffer);
+		LogFunAdr("RSON_Free", RSON_Free);
 	}
 	virtual void GetFun(void) const
 	{
-		p_RSON_LoadFromBuffer = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 89 45 60 48 8B D8").FollowNearCallSelf();
-		RSON_LoadFromBuffer = p_RSON_LoadFromBuffer.RCast< RSON::Node_t* (*)(const char*, char*, RSON::eFieldType, __int64, void*)>();
-
-		p_RSON_Free = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 83 EF 01 75 E7").FollowNearCallSelf();
-		RSON_Free = p_RSON_Free.RCast<void(*)(RSON::Node_t*, CAlignedMemAlloc*)>();
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 89 45 60 48 8B D8").FollowNearCallSelf().GetPtr(RSON_LoadFromBuffer);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 83 EF 01 75 E7").FollowNearCallSelf().GetPtr(RSON_Free);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/vphysics/QHull.h
+++ b/src/vphysics/QHull.h
@@ -1,10 +1,7 @@
 #pragma once
 
-inline CMemory p_QHull_PrintFunc;
 inline int(*v_QHull_PrintFunc)(const char* fmt, ...);
-
-//inline CMemory p_speex_warning_int;
-//inline int(*speex_warning_int)(FILE* stream, const char* format, ...);
+inline int(*v_speex_warning_int)(FILE* stream, const char* format, ...);
 
 ///////////////////////////////////////////////////////////////////////////////
 int QHull_PrintFunc(const char* fmt, ...);
@@ -14,16 +11,13 @@ class VQHull : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("QHull_PrintFunc", p_QHull_PrintFunc.GetPtr());
-		//LogFunAdr("speex_warning_int", p_speex_warning_int.GetPtr());
+		LogFunAdr("QHull_PrintFunc", v_QHull_PrintFunc);
+		LogFunAdr("speex_warning_int", v_speex_warning_int);
 	}
 	virtual void GetFun(void) const
 	{
-		p_QHull_PrintFunc = g_GameDll.FindPatternSIMD("48 89 4C 24 08 48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 53 B8 40 27 ?? ?? ?? ?? ?? ?? ?? 48");
-		v_QHull_PrintFunc = p_QHull_PrintFunc.RCast<int (*)(const char* fmt, ...)>(); /*48 89 4C 24 08 48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 53 B8 40 27 00 00 ?? ?? ?? ?? 00 48*/
-
-		//p_speex_warning_int = g_GameDll.FindPatternSIMD("48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 53 56 57 48 83 EC 30 48 8B FA 48 8D 74 24 60 48 8B");
-		//speex_warning_int = p_speex_warning_int.RCast<int (*)(FILE* stream, const char* format, ...)>(); /*48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 53 56 57 48 83 EC 30 48 8B FA 48 8D 74 24 60 48 8B*/
+		g_GameDll.FindPatternSIMD("48 89 4C 24 08 48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 53 B8 40 27 ?? ?? ?? ?? ?? ?? ?? 48").GetPtr(v_QHull_PrintFunc);
+		g_GameDll.FindPatternSIMD("48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 53 56 57 48 83 EC 30 48 8B FA 48 8D 74 24 60 48 8B").GetPtr(v_speex_warning_int);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/vscript/languages/squirrel_re/include/sqstate.h
+++ b/src/vscript/languages/squirrel_re/include/sqstate.h
@@ -6,9 +6,7 @@
 struct SQSharedState
 {
 	uint8_t gap0[17256];
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
 	uint8_t gap1[32];
-#endif
 	void* _printfunc;
 	uint8_t gap4390[33];
 	SQChar _contextname[8];

--- a/src/vscript/languages/squirrel_re/include/sqstdaux.h
+++ b/src/vscript/languages/squirrel_re/include/sqstdaux.h
@@ -6,10 +6,7 @@ extern bool g_bSQAuxError;
 extern bool g_bSQAuxBadLogic;
 extern HSQUIRRELVM g_pErrorVM;
 
-inline CMemory p_sqstd_aux_printerror;
 inline SQInteger(*v_sqstd_aux_printerror)(HSQUIRRELVM v);
-
-inline CMemory p_sqstd_aux_badlogic;
 inline SQInteger(*v_sqstd_aux_badlogic)(HSQUIRRELVM v, __m128i* a2, __m128i* a3);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -17,20 +14,13 @@ class VSquirrelAUX : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("sqstd_aux_printerror", p_sqstd_aux_printerror.GetPtr());
-		LogFunAdr("sqstd_aux_badlogic", p_sqstd_aux_badlogic.GetPtr());
+		LogFunAdr("sqstd_aux_printerror", v_sqstd_aux_printerror);
+		LogFunAdr("sqstd_aux_badlogic", v_sqstd_aux_badlogic);
 	}
 	virtual void GetFun(void) const
 	{
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_sqstd_aux_printerror = g_GameDll.FindPatternSIMD("40 53 55 56 57 41 54 41 55 41 57 48 81 EC ?? ?? ?? ??");
-		v_sqstd_aux_printerror = p_sqstd_aux_printerror.RCast<SQInteger(*)(HSQUIRRELVM)>(); /*40 53 55 56 57 41 54 41 55 41 57 48 81 EC ?? ?? ?? ??*/
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_sqstd_aux_printerror = g_GameDll.FindPatternSIMD("40 53 56 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? FF 05 ?? ?? ?? ??");
-		v_sqstd_aux_printerror = p_sqstd_aux_printerror.RCast<SQInteger(*)(HSQUIRRELVM)>(); /*40 53 56 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? FF 05 ?? ?? ?? ??*/
-#endif
-		p_sqstd_aux_badlogic = g_GameDll.FindPatternSIMD("48 8B C4 55 48 8B EC 48 83 EC 70 41 0F 10 ??");
-		v_sqstd_aux_badlogic = p_sqstd_aux_badlogic.RCast<SQInteger(*)(HSQUIRRELVM, __m128i*, __m128i*)>(); /*48 8B C4 55 48 8B EC 48 83 EC 70 41 0F 10 00*/
+		g_GameDll.FindPatternSIMD("40 53 56 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? FF 05 ?? ?? ?? ??").GetPtr(v_sqstd_aux_printerror);
+		g_GameDll.FindPatternSIMD("48 8B C4 55 48 8B EC 48 83 EC 70 41 0F 10 ??").GetPtr(v_sqstd_aux_badlogic);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/vscript/languages/squirrel_re/include/squirrel.h
+++ b/src/vscript/languages/squirrel_re/include/squirrel.h
@@ -45,37 +45,16 @@ SQRESULT sq_compilebuffer(HSQUIRRELVM v, SQBufState* bufferState, const SQChar* 
 SQRESULT sq_call(HSQUIRRELVM v, SQInteger params, SQBool retval, SQBool raiseerror);
 
 /* ==== SQUIRREL ======================================================================================================================================================== */
-inline CMemory p_sq_pushroottable;
 inline SQRESULT(*v_sq_pushroottable)(HSQUIRRELVM v);
-
-inline CMemory p_sq_pushbool;
 inline void(*v_sq_pushbool)(HSQUIRRELVM v, SQBool b);
-
-inline CMemory p_sq_pushstring;
 inline void(*v_sq_pushstring)(HSQUIRRELVM v, const SQChar* string, SQInteger len);
-
-inline CMemory p_sq_pushinteger;
 inline void(*v_sq_pushinteger)(HSQUIRRELVM v, SQInteger val);
-
-inline CMemory p_sq_newarray;
 inline void(*v_sq_newarray)(HSQUIRRELVM v, SQInteger size);
-
-inline CMemory p_sq_newtable;
 inline void(*v_sq_newtable)(HSQUIRRELVM v);
-
-inline CMemory p_sq_newslot;
 inline SQRESULT(*v_sq_newslot)(HSQUIRRELVM v, SQInteger idx);
-
-inline CMemory p_sq_arrayappend;
 inline SQRESULT(*v_sq_arrayappend)(HSQUIRRELVM v, SQInteger idx);
-
-inline CMemory p_sq_pushstructure;
 inline SQRESULT(*v_sq_pushstructure)(HSQUIRRELVM v, const SQChar* name, const SQChar* member, const SQChar* codeclass1, const SQChar* codeclass2);
-
-inline CMemory p_sq_compilebuffer;
 inline SQRESULT(*v_sq_compilebuffer)(HSQUIRRELVM v, SQBufState* bufferstate, const SQChar* buffer, SQInteger level);
-
-inline CMemory p_sq_call;
 inline SQRESULT(*v_sq_call)(HSQUIRRELVM v, SQInteger params, SQBool retval, SQBool raiseerror);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -83,52 +62,31 @@ class VSquirrelAPI : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("sq_pushroottable", p_sq_pushroottable.GetPtr());
-		LogFunAdr("sq_pushbool", p_sq_pushbool.GetPtr());
-		LogFunAdr("sq_pushstring", p_sq_pushstring.GetPtr());
-		LogFunAdr("sq_pushinteger", p_sq_pushinteger.GetPtr());
-		LogFunAdr("sq_newarray", p_sq_newarray.GetPtr());
-		LogFunAdr("sq_arrayappend", p_sq_arrayappend.GetPtr());
-		LogFunAdr("sq_newtable", p_sq_newtable.GetPtr());
-		LogFunAdr("sq_newslot", p_sq_newslot.GetPtr());
-		LogFunAdr("sq_pushstructure", p_sq_pushstructure.GetPtr());
-		LogFunAdr("sq_compilebuffer", p_sq_compilebuffer.GetPtr());
-		LogFunAdr("sq_call", p_sq_call.GetPtr());
+		LogFunAdr("sq_pushroottable", v_sq_pushroottable);
+		LogFunAdr("sq_pushbool", v_sq_pushbool);
+		LogFunAdr("sq_pushstring", v_sq_pushstring);
+		LogFunAdr("sq_pushinteger", v_sq_pushinteger);
+		LogFunAdr("sq_newarray", v_sq_newarray);
+		LogFunAdr("sq_arrayappend", v_sq_arrayappend);
+		LogFunAdr("sq_newtable", v_sq_newtable);
+		LogFunAdr("sq_newslot", v_sq_newslot);
+		LogFunAdr("sq_pushstructure", v_sq_pushstructure);
+		LogFunAdr("sq_compilebuffer", v_sq_compilebuffer);
+		LogFunAdr("sq_call", v_sq_call);
 	}
 	virtual void GetFun(void) const
 	{
-		p_sq_pushroottable = g_GameDll.FindPatternSIMD("48 83 EC 28 8B 51 ?? 44 8B C2");
-		p_sq_pushbool      = g_GameDll.FindPatternSIMD("48 83 EC 38 33 C0 48 C7 44 24 20 08 ?? ?? 01 48");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1) || defined (GAMEDLL_S2)
-		p_sq_pushstring = g_GameDll.FindPatternSIMD("40 56 48 83 EC 30 48 8B F1 48 85 D2 0F 84 8C ??");
-#elif defined (GAMEDLL_S3)
-		p_sq_pushstring = g_GameDll.FindPatternSIMD("40 56 48 83 EC 30 48 8B F1 48 85 D2 0F 84 8F ??");
-#endif
-		p_sq_pushinteger  = g_GameDll.FindPatternSIMD("48 83 EC 38 33 C0 48 C7 44 24 20 02 ?? ?? 05 48");
-		p_sq_newarray     = g_GameDll.FindPatternSIMD("48 89 5C 24 08 57 48 83 EC 30 48 8B D9 48 C7 44 24 20 40");
-		p_sq_newtable     = g_GameDll.FindPatternSIMD("48 89 5C 24 08 57 48 83 EC 30 48 8B D9 48 C7 44 24 20 20");
-		p_sq_newslot      = g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 44 8B 49 ?? 48 8B D9 41 8B C1");
-		p_sq_arrayappend  = g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 8B 41 ?? 48 8B D9 2B 41 ?? 83 F8 02 7D");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1) || defined (GAMEDLL_S2)
-		p_sq_pushstructure = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 4C 89 4C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC");
-#elif defined (GAMEDLL_S3)
-		p_sq_pushstructure = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 60 48 8B 59 60");
-#endif
-		p_sq_compilebuffer = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 56 41 57 48 83 EC 50 41 8B E9 49 8B F8");
-		p_sq_call          = g_GameDll.FindPatternSIMD("4C 8B DC 49 89 5B 08 49 89 6B 10 49 89 73 18 57 48 83 EC 50 8B F2");
-
-		v_sq_pushroottable = p_sq_pushroottable.RCast<SQRESULT(*)(HSQUIRRELVM)>();                                                             /*48 83 EC 28 8B 51 ?? 44 8B C2*/
-		v_sq_pushbool      = p_sq_pushbool.RCast<void (*)(HSQUIRRELVM, SQBool)>();                                                             /*48 83 EC 38 33 C0 48 C7 44 24 20 08 00 00 01 48*/
-		v_sq_pushstring    = p_sq_pushstring.RCast<void (*)(HSQUIRRELVM, const SQChar*, SQInteger)>();                                         /*40 56 48 83 EC 30 48 8B F1 48 85 D2 0F 84 8F 00*/
-		v_sq_pushinteger   = p_sq_pushinteger.RCast<void (*)(HSQUIRRELVM, SQInteger)>();                                                       /*48 83 EC 38 33 C0 48 C7 44 24 20 02 00 00 05 48*/
-		v_sq_newarray      = p_sq_newarray.RCast<void (*)(HSQUIRRELVM, SQInteger)>();                                                          /*48 89 5C 24 08 57 48 83 EC 30 48 8B D9 48 C7 44 24 20 40*/
-		v_sq_newtable      = p_sq_newtable.RCast<void (*)(HSQUIRRELVM)>();                                                                     /*48 89 5C 24 08 57 48 83 EC 30 48 8B D9 48 C7 44 24 20 20*/
-		v_sq_newslot       = p_sq_newslot.RCast<SQRESULT(*)(HSQUIRRELVM, SQInteger)>();                                                        /*40 53 48 83 EC 20 8B 41 ?? 48 8B D9 2B 41 ?? 83 F8 02 7D*/
-		v_sq_arrayappend   = p_sq_arrayappend.RCast<SQRESULT(*)(HSQUIRRELVM, SQInteger)>();                                                    /*40 53 48 83 EC 20 8B 41 ?? 48 8B D9 2B 41 ?? 83 F8 02 7D*/
-		v_sq_pushstructure = p_sq_pushstructure.RCast<SQRESULT(*)(HSQUIRRELVM, const SQChar*, const SQChar*, const SQChar*, const SQChar*)>(); /*48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 60 48 8B 59 60*/
-		v_sq_compilebuffer = p_sq_compilebuffer.RCast<SQRESULT(*)(HSQUIRRELVM, SQBufState*, const SQChar*, SQInteger)>();                      /*48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 56 41 57 48 83 EC 50 41 8B E9 49 8B F8*/
-		v_sq_call          = p_sq_call.RCast<SQRESULT(*)(HSQUIRRELVM, SQInteger, SQBool, SQBool)>();                                           /*4C 8B DC 49 89 5B 08 49 89 6B 10 49 89 73 18 57 48 83 EC 50 8B F2*/
-
+		g_GameDll.FindPatternSIMD("48 83 EC 28 8B 51 ?? 44 8B C2").GetPtr(v_sq_pushroottable);
+		g_GameDll.FindPatternSIMD("48 83 EC 38 33 C0 48 C7 44 24 20 08 ?? ?? 01 48").GetPtr(v_sq_pushbool);
+		g_GameDll.FindPatternSIMD("40 56 48 83 EC 30 48 8B F1 48 85 D2 0F 84 8F ??").GetPtr(v_sq_pushstring);
+		g_GameDll.FindPatternSIMD("48 83 EC 38 33 C0 48 C7 44 24 20 02 ?? ?? 05 48").GetPtr(v_sq_pushinteger);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 08 57 48 83 EC 30 48 8B D9 48 C7 44 24 20 40").GetPtr(v_sq_newarray);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 08 57 48 83 EC 30 48 8B D9 48 C7 44 24 20 20").GetPtr(v_sq_newtable);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 44 8B 49 ?? 48 8B D9 41 8B C1").GetPtr(v_sq_newslot);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 20 8B 41 ?? 48 8B D9 2B 41 ?? 83 F8 02 7D").GetPtr(v_sq_arrayappend);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8B EC 48 83 EC 60 48 8B 59 60").GetPtr(v_sq_pushstructure);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 56 41 57 48 83 EC 50 41 8B E9 49 8B F8").GetPtr(v_sq_compilebuffer);
+		g_GameDll.FindPatternSIMD("4C 8B DC 49 89 5B 08 49 89 6B 10 49 89 73 18 57 48 83 EC 50 8B F2").GetPtr(v_sq_call);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/vscript/languages/squirrel_re/include/sqvm.h
+++ b/src/vscript/languages/squirrel_re/include/sqvm.h
@@ -21,18 +21,7 @@ struct SQVM
 	}
 	SQCONTEXT GetContext() const
 	{
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
 		return _contextidx;
-#else // This is the only way to obtain the context directly in anything <S3 without involving global script pointers.
-		if (strcmp(_sharedstate->_contextname, "SERVER") == 0)
-			return SQCONTEXT::SERVER;
-		if (strcmp(_sharedstate->_contextname, "CLIENT") == 0)
-			return SQCONTEXT::CLIENT;
-		if (strcmp(_sharedstate->_contextname, "UI") == 0)
-			return SQCONTEXT::UI;
-
-		return SQCONTEXT::NONE;
-#endif // !GAMEDLL_S0 && !GAMEDLL_S1 && !GAMEDLL_S2
 	}
 
 	eDLL_T GetNativeContext() const
@@ -42,11 +31,9 @@ struct SQVM
 
 	SQVM* _vftable;
 	_BYTE gap000[16];
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
 	SQCONTEXT _contextidx;
 	_BYTE gap001[8];
 	_BYTE gap002[4];
-#endif
 	void* _ncvftable;
 	void* _table;
 	_BYTE gap003[14];
@@ -59,38 +46,19 @@ struct SQVM
 	char gap004[16];
 	int _top;
 	char gap005[148];
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1) && !defined (GAMEDLL_S2)
 	char gap006[30];
-#endif
 	SQInteger _nnativecalls;
 };
 
 /* ==== SQUIRREL ======================================================================================================================================================== */
-inline CMemory p_SQVM_PrintFunc;
 inline SQRESULT(*v_SQVM_PrintFunc)(HSQUIRRELVM v, SQChar* fmt, ...);
-
-inline CMemory p_SQVM_sprintf;
 inline SQRESULT(*v_SQVM_sprintf)(HSQUIRRELVM v, SQInteger a2, SQInteger a3, SQInteger* nStringSize, SQChar** ppString);
-
-inline CMemory p_SQVM_GetErrorLine;
 inline size_t(*v_SQVM_GetErrorLine)(const SQChar* pszFile, SQInteger nLine, SQChar* pszContextBuf, SQInteger nBufLen);
-
-inline CMemory p_SQVM_WarningCmd;
 inline SQRESULT(*v_SQVM_WarningCmd)(HSQUIRRELVM v, SQInteger a2);
-
-inline CMemory p_SQVM_CompileError;
 inline void(*v_SQVM_CompileError)(HSQUIRRELVM v, const SQChar* pszError, const SQChar* pszFile, SQUnsignedInteger nLine, SQInteger nColumn);
-
-inline CMemory p_SQVM_LogicError;
 inline void(*v_SQVM_LogicError)(SQBool bPrompt);
-
-inline CMemory p_SQVM_ScriptError;
 inline SQInteger(*v_SQVM_ScriptError)(const SQChar* pszFormat, ...);
-
-inline CMemory p_SQVM_RaiseError;
 inline SQInteger(*v_SQVM_RaiseError)(HSQUIRRELVM v, const SQChar* pszFormat, ...);
-
-inline CMemory p_SQVM_ThrowError;
 inline SQBool(*v_SQVM_ThrowError)(__int64 a1, HSQUIRRELVM v);
 
 SQRESULT SQVM_PrintFunc(HSQUIRRELVM v, SQChar* fmt, ...);
@@ -105,42 +73,27 @@ class VSquirrelVM : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("SQVM_PrintFunc", p_SQVM_PrintFunc.GetPtr());
-		LogFunAdr("SQVM_sprintf", p_SQVM_sprintf.GetPtr());
-		LogFunAdr("SQVM_GetErrorLine", p_SQVM_GetErrorLine.GetPtr());
-		LogFunAdr("SQVM_WarningCmd", p_SQVM_WarningCmd.GetPtr());
-		LogFunAdr("SQVM_CompileError", p_SQVM_CompileError.GetPtr());
-		LogFunAdr("SQVM_LogicError", p_SQVM_LogicError.GetPtr());
-		LogFunAdr("SQVM_ScriptError", p_SQVM_ScriptError.GetPtr());
-		LogFunAdr("SQVM_RaiseError", p_SQVM_RaiseError.GetPtr());
-		LogFunAdr("SQVM_ThrowError", p_SQVM_ThrowError.GetPtr());
+		LogFunAdr("SQVM_PrintFunc", v_SQVM_PrintFunc);
+		LogFunAdr("SQVM_sprintf", v_SQVM_sprintf);
+		LogFunAdr("SQVM_GetErrorLine", v_SQVM_GetErrorLine);
+		LogFunAdr("SQVM_WarningCmd", v_SQVM_WarningCmd);
+		LogFunAdr("SQVM_CompileError", v_SQVM_CompileError);
+		LogFunAdr("SQVM_LogicError", v_SQVM_LogicError);
+		LogFunAdr("SQVM_ScriptError", v_SQVM_ScriptError);
+		LogFunAdr("SQVM_RaiseError", v_SQVM_RaiseError);
+		LogFunAdr("SQVM_ThrowError", v_SQVM_ThrowError);
 	}
 	virtual void GetFun(void) const
 	{
-		p_SQVM_PrintFunc    = g_GameDll.FindPatternSIMD("48 8B C4 48 89 50 10 4C 89 40 18 4C 89 48 20 53 56 57 48 81 EC 30 08 ?? ?? 48 8B DA 48 8D 70 18 48 8B F9 E8 ?? ?? ?? FF 48 89 74 24 28 48 8D 54 24 30 33");
-		p_SQVM_sprintf  = g_GameDll.FindPatternSIMD("4C 89 4C 24 20 44 89 44 24 18 89 54 24 10 53 55 56 57 41 54 41 55 41 56 41 57 48 83 EC ?? 48 8B");
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_SQVM_GetErrorLine = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 83 65 90 FC");
-		p_SQVM_LogicError   = g_GameDll.FindPatternSIMD("48 83 EC 48 F2 0F 10 05 ?? ?? ?? ??");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_SQVM_GetErrorLine = g_GameDll.FindPatternSIMD("48 8B C4 55 56 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 83 65 90 FC");
-		p_SQVM_LogicError   = g_GameDll.FindPatternSIMD("48 83 EC 38 F2 0F 10 05 ?? ?? ?? ??");
-#endif
-		p_SQVM_WarningCmd   = g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 33 DB 48 8D 44 24 ?? 4C 8D 4C 24 ??");
-		p_SQVM_CompileError = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 81 EC ?? ?? ?? ?? 48 8B D9 4C 8B F2");
-		p_SQVM_ScriptError  = g_GameDll.FindPatternSIMD("E9 ?? ?? ?? ?? F7 D2").FollowNearCallSelf();
-		p_SQVM_RaiseError   = g_GameDll.FindPatternSIMD("48 89 54 24 ?? 4C 89 44 24 ?? 4C 89 4C 24 ?? 53 56 57 48 83 EC 40");
-		p_SQVM_ThrowError   = g_GameDll.FindPatternSIMD("E8 ? ? ? ? BB ? ? ? ? 8B C3").FollowNearCallSelf();
-
-		v_SQVM_PrintFunc    = p_SQVM_PrintFunc.RCast<SQRESULT(*)(HSQUIRRELVM, SQChar*, ...)>();                                               /*48 8B C4 48 89 50 10 4C 89 40 18 4C 89 48 20 53 56 57 48 81 EC 30 08 00 00 48 8B DA 48 8D 70 18 48 8B F9 E8 ?? ?? ?? FF 48 89 74 24 28 48 8D 54 24 30 33*/
-		v_SQVM_sprintf      = p_SQVM_sprintf.RCast<SQRESULT(*)(HSQUIRRELVM, SQInteger, SQInteger, SQInteger*, SQChar**)>();               /*4C 89 4C 24 20 44 89 44 24 18 89 54 24 10 53 55 56 57 41 54 41 55 41 56 41 57 48 83 EC ?? 48 8B*/
-		v_SQVM_GetErrorLine = p_SQVM_GetErrorLine.RCast<size_t(*)(const SQChar*, SQInteger, SQChar*, SQInteger)>();                           /*48 8B C4 55 56 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 83 65 90 FC*/
-		v_SQVM_WarningCmd   = p_SQVM_WarningCmd.RCast<SQRESULT(*)(HSQUIRRELVM, SQInteger)>();                                                 /*40 53 48 83 EC 30 33 DB 48 8D 44 24 ?? 4C 8D 4C 24 ??*/
-		v_SQVM_CompileError = p_SQVM_CompileError.RCast<void (*)(HSQUIRRELVM, const SQChar*, const SQChar*, SQUnsignedInteger, SQInteger)>(); /*48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 81 EC ?? ?? ?? ?? 48 8B D9 4C 8B F2*/
-		v_SQVM_LogicError   = p_SQVM_LogicError.RCast<void (*)(SQBool)>();                                                                    /*48 83 EC 38 F2 0F 10 05 ?? ?? ?? ??*/
-		v_SQVM_ScriptError  = p_SQVM_ScriptError.RCast<SQInteger(*)(const SQChar*, ...)>();                                                   /*E9 ?? ?? ?? ?? F7 D2*/
-		v_SQVM_RaiseError   = p_SQVM_RaiseError.RCast<SQInteger(*)(HSQUIRRELVM, const SQChar*, ...)>();                                       /*E8 ?? ?? ?? ?? 32 C0 EB 3C*/
-		v_SQVM_ThrowError   = p_SQVM_ThrowError.RCast<SQBool(*)(__int64, HSQUIRRELVM)>();                                                     /*E8 ? ? ? ? BB ? ? ? ? 8B C3*/
+		g_GameDll.FindPatternSIMD("48 8B C4 48 89 50 10 4C 89 40 18 4C 89 48 20 53 56 57 48 81 EC 30 08 ?? ?? 48 8B DA 48 8D 70 18 48 8B F9 E8 ?? ?? ?? FF 48 89 74 24 28 48 8D 54 24 30 33").GetPtr(v_SQVM_PrintFunc);
+		g_GameDll.FindPatternSIMD("4C 89 4C 24 20 44 89 44 24 18 89 54 24 10 53 55 56 57 41 54 41 55 41 56 41 57 48 83 EC ?? 48 8B").GetPtr(v_SQVM_sprintf);
+		g_GameDll.FindPatternSIMD("48 8B C4 55 56 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 83 65 90 FC").GetPtr(v_SQVM_GetErrorLine);
+		g_GameDll.FindPatternSIMD("48 83 EC 38 F2 0F 10 05 ?? ?? ?? ??").GetPtr(v_SQVM_LogicError);
+		g_GameDll.FindPatternSIMD("40 53 48 83 EC 30 33 DB 48 8D 44 24 ?? 4C 8D 4C 24 ??").GetPtr(v_SQVM_WarningCmd);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 81 EC ?? ?? ?? ?? 48 8B D9 4C 8B F2").GetPtr(v_SQVM_CompileError);
+		g_GameDll.FindPatternSIMD("E9 ?? ?? ?? ?? F7 D2").FollowNearCallSelf().GetPtr(v_SQVM_ScriptError);
+		g_GameDll.FindPatternSIMD("48 89 54 24 ?? 4C 89 44 24 ?? 4C 89 4C 24 ?? 53 56 57 48 83 EC 40").GetPtr(v_SQVM_RaiseError);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? BB ?? ?? ?? ?? 8B C3").FollowNearCallSelf().GetPtr(v_SQVM_ThrowError);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/vscript/languages/squirrel_re/squirrel/sqvm.cpp
+++ b/src/vscript/languages/squirrel_re/squirrel/sqvm.cpp
@@ -99,12 +99,12 @@ SQRESULT SQVM_PrintFunc(HSQUIRRELVM v, SQChar* fmt, ...)
 //---------------------------------------------------------------------------------
 SQRESULT SQVM_sprintf(HSQUIRRELVM v, SQInteger a2, SQInteger a3, SQInteger* nStringSize, SQChar** ppString)
 {
-	static void* retaddr = reinterpret_cast<void*>(p_SQVM_WarningCmd.Offset(0x10).FindPatternSelf("85 ?? ?? 99", CMemory::Direction::DOWN).GetPtr());
-	SQRESULT result = v_SQVM_sprintf(v, a2, a3, nStringSize, ppString);
+	static void* const retaddr = reinterpret_cast<void*>(CMemory(v_SQVM_WarningCmd).Offset(0x10).FindPatternSelf("85 ?? ?? 99", CMemory::Direction::DOWN).GetPtr());
+	const SQRESULT result = v_SQVM_sprintf(v, a2, a3, nStringSize, ppString);
 
 	if (retaddr == _ReturnAddress()) // Check if its SQVM_Warning calling.
 	{
-		SQCONTEXT scriptContext = v->GetContext();
+		const SQCONTEXT scriptContext = v->GetContext();
 		eDLL_T remoteContext;
 
 		switch (scriptContext)
@@ -123,7 +123,7 @@ SQRESULT SQVM_sprintf(HSQUIRRELVM v, SQInteger a2, SQInteger a3, SQInteger* nStr
 			break;
 		}
 
-		std::string svConstructor(*ppString, *nStringSize); // Get string from memory via std::string constructor.
+		const std::string svConstructor(*ppString, *nStringSize); // Get string from memory via std::string constructor.
 		CoreMsg(LogType_t::SQ_WARNING, static_cast<LogLevel_t>(script_show_warning->GetInt()),
 			remoteContext, NO_ERROR, "squirrel_re(warning)", "%s", svConstructor.c_str());
 	}

--- a/src/vscript/languages/squirrel_re/vsquirrel.cpp
+++ b/src/vscript/languages/squirrel_re/vsquirrel.cpp
@@ -27,7 +27,7 @@ void(*ScriptConstantRegister_Callback)(CSquirrelVM* s) = nullptr;
 bool CSquirrelVM::Init(CSquirrelVM* s, SQCONTEXT context, SQFloat curTime)
 {
 	// original func always returns true, added check just in case.
-	if (!v_CSquirrelVM_Init(s, context, curTime))
+	if (!CSquirrelVM__Init(s, context, curTime))
 	{
 		return false;
 	}
@@ -76,7 +76,7 @@ bool CSquirrelVM::Init(CSquirrelVM* s, SQCONTEXT context, SQFloat curTime)
 //---------------------------------------------------------------------------------
 bool CSquirrelVM::DestroySignalEntryListHead(CSquirrelVM* s, HSQUIRRELVM v, SQFloat f)
 {
-	SQBool result = v_CSquirrelVM_DestroySignalEntryListHead(s, v, f);
+	SQBool result = CSquirrelVM__DestroySignalEntryListHead(s, v, f);
 	s->RegisterConstant("DEVELOPER", developer->GetInt());
 
 	// Must have one.
@@ -93,7 +93,7 @@ bool CSquirrelVM::DestroySignalEntryListHead(CSquirrelVM* s, HSQUIRRELVM v, SQFl
 //---------------------------------------------------------------------------------
 SQRESULT CSquirrelVM::RegisterConstant(const SQChar* name, SQInteger value)
 {
-	return v_CSquirrelVM_RegisterConstant(this, name, value);
+	return CSquirrelVM__RegisterConstant(this, name, value);
 }
 
 //---------------------------------------------------------------------------------
@@ -112,7 +112,7 @@ SQRESULT CSquirrelVM::RegisterFunction(const SQChar* scriptName, const SQChar* n
 	ScriptFunctionBinding_t binding;
 	binding.Init(scriptName, nativeName, helpString, returnString, parameters, 5, function);
 
-	SQRESULT results = v_CSquirrelVM_RegisterFunction(this, &binding, 1);
+	SQRESULT results = CSquirrelVM__RegisterFunction(this, &binding, 1);
 	return results;
 }
 
@@ -201,13 +201,13 @@ void CSquirrelVM::CompileModScripts()
 			{
 			case SQCONTEXT::SERVER:
 			{
-				v_CSquirrelVM_PrecompileServerScripts(this, GetContext(), (char**)scriptPathArray, scriptCount);
+				CSquirrelVM__PrecompileServerScripts(this, GetContext(), (char**)scriptPathArray, scriptCount);
 				break;
 			}
 			case SQCONTEXT::CLIENT:
 			case SQCONTEXT::UI:
 			{
-				v_CSquirrelVM_PrecompileClientScripts(this, GetContext(), (char**)scriptPathArray, scriptCount);
+				CSquirrelVM__PrecompileClientScripts(this, GetContext(), (char**)scriptPathArray, scriptCount);
 				break;
 			}
 			}
@@ -227,6 +227,6 @@ void CSquirrelVM::CompileModScripts()
 //---------------------------------------------------------------------------------
 void VSquirrel::Detour(const bool bAttach) const
 {
-	DetourSetup(&v_CSquirrelVM_Init, &CSquirrelVM::Init, bAttach);
-	DetourSetup(&v_CSquirrelVM_DestroySignalEntryListHead, &CSquirrelVM::DestroySignalEntryListHead, bAttach);
+	DetourSetup(&CSquirrelVM__Init, &CSquirrelVM::Init, bAttach);
+	DetourSetup(&CSquirrelVM__DestroySignalEntryListHead, &CSquirrelVM::DestroySignalEntryListHead, bAttach);
 }

--- a/src/vscript/languages/squirrel_re/vsquirrel.h
+++ b/src/vscript/languages/squirrel_re/vsquirrel.h
@@ -31,14 +31,9 @@ private:
 	SQInteger m_nFlags;
 	SQChar pad2[4];
 	SQChar pad3[16];
-#if !defined (GAMEDLL_S0) && !defined (GAMEDLL_S1)
 	SQChar pad4[4];
-#endif
 	SQInteger m_nTick;
 	SQCONTEXT m_iContext; // 0x38
-#if !defined (GAMEDLL_S2) && !defined (GAMEDLL_S3)
-	SQChar pad6[4];
-#endif
 	void* m_pCompareFunc;
 };
 #pragma pack(pop)
@@ -52,26 +47,17 @@ extern void(*AdminPanelScriptRegister_Callback)(CSquirrelVM* s);
 
 extern void(*ScriptConstantRegister_Callback)(CSquirrelVM* s);
 
-inline CMemory p_CSquirrelVM_Init;
-inline bool(*v_CSquirrelVM_Init)(CSquirrelVM* s, SQCONTEXT context, SQFloat curtime);
-
-inline CMemory p_CSquirrelVM_DestroySignalEntryListHead;
-inline bool(*v_CSquirrelVM_DestroySignalEntryListHead)(CSquirrelVM* s, HSQUIRRELVM v, SQFloat f);
-
-inline CMemory p_CSquirrelVM_RegisterFunction;
-inline SQRESULT(*v_CSquirrelVM_RegisterFunction)(CSquirrelVM* s, ScriptFunctionBinding_t* binding, SQInteger a1);
-
-inline CMemory p_CSquirrelVM_RegisterConstant;
-inline SQRESULT(*v_CSquirrelVM_RegisterConstant)(CSquirrelVM* s, const SQChar* name, SQInteger value);
+inline bool(*CSquirrelVM__Init)(CSquirrelVM* s, SQCONTEXT context, SQFloat curtime);
+inline bool(*CSquirrelVM__DestroySignalEntryListHead)(CSquirrelVM* s, HSQUIRRELVM v, SQFloat f);
+inline SQRESULT(*CSquirrelVM__RegisterFunction)(CSquirrelVM* s, ScriptFunctionBinding_t* binding, SQInteger a1);
+inline SQRESULT(*CSquirrelVM__RegisterConstant)(CSquirrelVM* s, const SQChar* name, SQInteger value);
 
 #ifndef DEDICATED
-inline CMemory p_CSquirrelVM_PrecompileClientScripts;
-inline bool(*v_CSquirrelVM_PrecompileClientScripts)(CSquirrelVM* vm, SQCONTEXT context, char** scriptArray, int scriptCount);
+inline bool(*CSquirrelVM__PrecompileClientScripts)(CSquirrelVM* vm, SQCONTEXT context, char** scriptArray, int scriptCount);
 #endif
 
 #ifndef CLIENT_DLL
-inline CMemory p_CSquirrelVM_PrecompileServerScripts;
-inline bool(*v_CSquirrelVM_PrecompileServerScripts)(CSquirrelVM* vm, SQCONTEXT context, char** scriptArray, int scriptCount);
+inline bool(*CSquirrelVM__PrecompileServerScripts)(CSquirrelVM* vm, SQCONTEXT context, char** scriptArray, int scriptCount);
 #endif
 
 #ifndef CLIENT_DLL
@@ -89,42 +75,33 @@ class VSquirrel : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("CSquirrelVM::Init", p_CSquirrelVM_Init.GetPtr());
-		LogFunAdr("CSquirrelVM::DestroySignalEntryListHead", p_CSquirrelVM_DestroySignalEntryListHead.GetPtr());
+		LogFunAdr("CSquirrelVM::Init", CSquirrelVM__Init);
+		LogFunAdr("CSquirrelVM::DestroySignalEntryListHead", CSquirrelVM__DestroySignalEntryListHead);
 
-		LogFunAdr("CSquirrelVM::RegisterConstant", p_CSquirrelVM_RegisterConstant.GetPtr());
-		LogFunAdr("CSquirrelVM::RegisterFunction", p_CSquirrelVM_RegisterFunction.GetPtr());
+		LogFunAdr("CSquirrelVM::RegisterConstant", CSquirrelVM__RegisterConstant);
+		LogFunAdr("CSquirrelVM::RegisterFunction", CSquirrelVM__RegisterFunction);
 #ifndef CLIENT_DLL
-		LogFunAdr("CSquirrelVM::PrecompileServerScripts", p_CSquirrelVM_PrecompileServerScripts.GetPtr());
+		LogFunAdr("CSquirrelVM::PrecompileServerScripts", CSquirrelVM__PrecompileServerScripts);
 #endif // !CLIENT_DLL
 #ifndef DEDICATED
-		LogFunAdr("CSquirrelVM::PrecompileClientScripts", p_CSquirrelVM_PrecompileClientScripts.GetPtr());
+		LogFunAdr("CSquirrelVM::PrecompileClientScripts", CSquirrelVM__PrecompileClientScripts);
 #endif // !DEDICATED
 	}
 	virtual void GetFun(void) const
 	{
-		p_CSquirrelVM_Init = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 0F 28 74 24 ?? 48 89 1D ?? ?? ?? ??").FollowNearCallSelf();
-		v_CSquirrelVM_Init = p_CSquirrelVM_Init.RCast<bool(*)(CSquirrelVM*, SQCONTEXT, SQFloat)>();
-
-		p_CSquirrelVM_DestroySignalEntryListHead = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 50 44 8B 42");
-		v_CSquirrelVM_DestroySignalEntryListHead = p_CSquirrelVM_DestroySignalEntryListHead.RCast<bool(*)(CSquirrelVM*, HSQUIRRELVM, SQFloat)>();
-
-		p_CSquirrelVM_RegisterConstant = g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 4C 8B");
-		v_CSquirrelVM_RegisterConstant = p_CSquirrelVM_RegisterConstant.RCast<SQRESULT(*)(CSquirrelVM*, const SQChar*, SQInteger)>();
-
-		p_CSquirrelVM_RegisterFunction = g_GameDll.FindPatternSIMD("48 83 EC 38 45 0F B6 C8");
-		v_CSquirrelVM_RegisterFunction = p_CSquirrelVM_RegisterFunction.RCast<SQRESULT(*)(CSquirrelVM*, ScriptFunctionBinding_t*, SQInteger)>();
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 0F 28 74 24 ?? 48 89 1D ?? ?? ?? ??").FollowNearCallSelf().GetPtr(CSquirrelVM__Init);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 50 44 8B 42").GetPtr(CSquirrelVM__DestroySignalEntryListHead);
+		g_GameDll.FindPatternSIMD("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 4C 8B").GetPtr(CSquirrelVM__RegisterConstant);
+		g_GameDll.FindPatternSIMD("48 83 EC 38 45 0F B6 C8").GetPtr(CSquirrelVM__RegisterFunction);
 
 #ifndef CLIENT_DLL
 		// sv scripts.rson compiling
-		p_CSquirrelVM_PrecompileServerScripts = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 0F B6 F0 48 85 DB").FollowNearCallSelf();
-		v_CSquirrelVM_PrecompileServerScripts = p_CSquirrelVM_PrecompileServerScripts.RCast<bool(*)(CSquirrelVM*, SQCONTEXT, char**, int)>();
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 0F B6 F0 48 85 DB").FollowNearCallSelf().GetPtr(CSquirrelVM__PrecompileServerScripts);
 #endif
 
 #ifndef DEDICATED
 		// cl/ui scripts.rson compiling
-		p_CSquirrelVM_PrecompileClientScripts = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 44 0F B6 F0 48 85 DB").FollowNearCallSelf();
-		v_CSquirrelVM_PrecompileClientScripts = p_CSquirrelVM_PrecompileClientScripts.RCast<bool(*)(CSquirrelVM*, SQCONTEXT, char**, int)>();
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 44 0F B6 F0 48 85 DB").FollowNearCallSelf().GetPtr(CSquirrelVM__PrecompileClientScripts);
 #endif
 	}
 	virtual void GetVar(void) const { }

--- a/src/vscript/vscript.h
+++ b/src/vscript/vscript.h
@@ -13,25 +13,12 @@
 //-----------------------------------------------------------------------------
 class CSquirrelVM;
 
-inline CMemory p_Script_LoadScriptList;
 inline RSON::Node_t*(*v_Script_LoadScriptList)(const SQChar* rsonfile);
-
-inline CMemory p_Script_LoadScriptFile;
 inline SQBool(*v_Script_LoadScriptFile)(HSQUIRRELVM v, const SQChar* path, const SQChar* name, SQInteger flags);
-
-inline CMemory p_Script_ParseScriptList;
 inline SQBool(*v_Script_ParseScriptList)(SQCONTEXT ctx, const char* scriptListPath, RSON::Node_t* rson, char** scriptArray, int* pScriptCount, char** precompiledScriptArray, int precompiledScriptCount);
-
-inline CMemory p_Script_PrecompileServerScripts;
 inline SQBool(*v_Script_PrecompileServerScripts)(CSquirrelVM* vm /*This parameter is not used internally (the client variant does use it)!*/);
-
-inline CMemory p_Script_SetServerCompiler;
 inline void(*v_Script_SetServerPrecompiler)(SQCONTEXT ctx, RSON::Node_t* rson);
-
-inline CMemory p_Script_PrecompileClientScripts;
 inline SQBool(*v_Script_PrecompileClientScripts)(CSquirrelVM* vm);
-
-inline CMemory p_Script_SetClientCompiler;
 inline void(*v_Script_SetClientPrecompiler)(SQCONTEXT ctx, RSON::Node_t* rson);
 
 CSquirrelVM* Script_GetScriptHandle(const SQCONTEXT context);
@@ -46,39 +33,24 @@ class VScript : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogFunAdr("Script_LoadScriptList", p_Script_LoadScriptList.GetPtr());
-		LogFunAdr("Script_LoadScriptFile", p_Script_LoadScriptFile.GetPtr());
-		LogFunAdr("Script_ParseScriptList", p_Script_ParseScriptList.GetPtr());
-		LogFunAdr("Script_PrecompileServerInit", p_Script_PrecompileServerScripts.GetPtr());
-		LogFunAdr("Script_SetServerCompiler", p_Script_SetServerCompiler.GetPtr());
-		LogFunAdr("Script_PrecompileClientInit", p_Script_PrecompileClientScripts.GetPtr());
-		LogFunAdr("Script_SetClientCompiler", p_Script_SetClientCompiler.GetPtr());
+		LogFunAdr("Script_LoadScriptList", v_Script_LoadScriptList);
+		LogFunAdr("Script_LoadScriptFile", v_Script_LoadScriptFile);
+		LogFunAdr("Script_ParseScriptList", v_Script_ParseScriptList);
+		LogFunAdr("Script_PrecompileServerInit", v_Script_PrecompileServerScripts);
+		LogFunAdr("Script_SetServerCompiler", v_Script_SetServerPrecompiler);
+		LogFunAdr("Script_PrecompileClientInit", v_Script_PrecompileClientScripts);
+		LogFunAdr("Script_SetClientCompiler", v_Script_SetClientPrecompiler);
 	}
 	virtual void GetFun(void) const
 	{
-		p_Script_LoadScriptList = g_GameDll.FindPatternSIMD("4C 8B DC 49 89 5B 08 57 48 81 EC A0 ?? ?? ?? 33");
-		v_Script_LoadScriptList = p_Script_LoadScriptList.RCast<RSON::Node_t* (*)(const SQChar*)>();
-#if defined (GAMEDLL_S0) || defined (GAMEDLL_S1)
-		p_Script_LoadScriptFile = g_GameDll.FindPatternSIMD("48 89 5C 24 10 48 89 74 24 18 48 89 7C 24 20 48 89 4C 24 08 55 41 54 41 55 41 56 41 57 48 8D 6C");
-#elif defined (GAMEDLL_S2) || defined (GAMEDLL_S3)
-		p_Script_LoadScriptFile = g_GameDll.FindPatternSIMD("48 8B C4 48 89 48 08 55 41 56 48 8D 68");
-#endif
-		v_Script_LoadScriptFile = p_Script_LoadScriptFile.RCast<SQBool(*)(HSQUIRRELVM, const SQChar*, const SQChar*, SQInteger)>();
+		g_GameDll.FindPatternSIMD("4C 8B DC 49 89 5B 08 57 48 81 EC A0 ?? ?? ?? 33").GetPtr(v_Script_LoadScriptList);
+		g_GameDll.FindPatternSIMD("48 8B C4 48 89 48 08 55 41 56 48 8D 68").GetPtr(v_Script_LoadScriptFile);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 33 DB 88 05 ?? ?? ?? ??").FollowNearCallSelf().GetPtr(v_Script_PrecompileServerScripts);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 8D 84 24 ?? ?? ?? ?? 44 89 64 24 ?? 4C 89 64 24 ?? 4C 8D 8C 24 ?? ?? ?? ?? 4C 8B C5").FollowNearCallSelf().GetPtr(v_Script_SetServerPrecompiler);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 88 05 ?? ?? ?? ?? 33 C0").FollowNearCallSelf().GetPtr(v_Script_PrecompileClientScripts);
+		g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 8D 84 24 ?? ?? ?? ?? 44 89 64 24 ?? 4C 89 64 24 ?? 4C 8D 8C 24 ?? ?? ?? ?? 4C 8B C6").FollowNearCallSelf().GetPtr(v_Script_SetClientPrecompiler);
 
-		p_Script_PrecompileServerScripts = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 33 DB 88 05 ?? ?? ?? ??").FollowNearCallSelf();
-		v_Script_PrecompileServerScripts = p_Script_PrecompileServerScripts.RCast<SQBool(__fastcall*)(CSquirrelVM*)>();
-
-		p_Script_SetServerCompiler = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 8D 84 24 ?? ?? ?? ?? 44 89 64 24 ?? 4C 89 64 24 ?? 4C 8D 8C 24 ?? ?? ?? ?? 4C 8B C5").FollowNearCallSelf();
-		v_Script_SetServerPrecompiler = p_Script_SetServerCompiler.RCast<void(__fastcall*)(SQCONTEXT ctx, RSON::Node_t* rson)>();
-
-		p_Script_PrecompileClientScripts = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 88 05 ?? ?? ?? ?? 33 C0").FollowNearCallSelf();
-		v_Script_PrecompileClientScripts = p_Script_PrecompileClientScripts.RCast<SQBool(__fastcall*)(CSquirrelVM*)>();
-
-		p_Script_SetClientCompiler = g_GameDll.FindPatternSIMD("E8 ?? ?? ?? ?? 48 8D 84 24 ?? ?? ?? ?? 44 89 64 24 ?? 4C 89 64 24 ?? 4C 8D 8C 24 ?? ?? ?? ?? 4C 8B C6").FollowNearCallSelf();
-		v_Script_SetClientPrecompiler = p_Script_SetClientCompiler.RCast<void(__fastcall*)(SQCONTEXT ctx, RSON::Node_t* rson)>();
-
-		p_Script_ParseScriptList = g_GameDll.FindPatternSIMD("4C 89 4C 24 ?? 55 41 56");
-		v_Script_ParseScriptList = p_Script_ParseScriptList.RCast<SQBool(__fastcall*)(SQCONTEXT, const SQChar*, RSON::Node_t*, char**, int*, char**, int)>();
+		g_GameDll.FindPatternSIMD("4C 89 4C 24 ?? 55 41 56").GetPtr(v_Script_ParseScriptList);
 	}
 	virtual void GetVar(void) const { }
 	virtual void GetCon(void) const { }

--- a/src/vstdlib/autocompletefilelist.cpp
+++ b/src/vstdlib/autocompletefilelist.cpp
@@ -16,5 +16,5 @@
 //-----------------------------------------------------------------------------
 int CBaseAutoCompleteFileList::AutoCompletionFunc(const char* partial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH])
 {
-	return v_CBaseAutoCompleteFileList_AutoCompletionFunc(this, partial, commands);
+	return CBaseAutoCompleteFileList__AutoCompletionFunc(this, partial, commands);
 }

--- a/src/vstdlib/keyvaluessystem.h
+++ b/src/vstdlib/keyvaluessystem.h
@@ -65,8 +65,8 @@ class HKeyValuesSystem : public IDetour
 {
 	virtual void GetAdr(void) const
 	{
-		LogVarAdr("g_pKeyValuesMemPool", reinterpret_cast<uintptr_t>(g_pKeyValuesMemPool));
-		LogVarAdr("g_pKeyValuesSystem", reinterpret_cast<uintptr_t>(g_pKeyValuesSystem));
+		LogVarAdr("g_pKeyValuesMemPool", g_pKeyValuesMemPool);
+		LogVarAdr("g_pKeyValuesSystem", g_pKeyValuesSystem);
 	}
 	virtual void GetFun(void) const { }
 	virtual void GetVar(void) const

--- a/src/windows/input.cpp
+++ b/src/windows/input.cpp
@@ -103,6 +103,7 @@ void Input_Init()
 	if (hr != NO_ERROR)
 	{
 		// Failed to hook into the process, terminate
+		Assert(0);
 		Error(eDLL_T::COMMON, 0xBAD0C0DE, "Failed to detour process: error code = %08x\n", hr);
 	}
 }

--- a/src/windows/system.cpp
+++ b/src/windows/system.cpp
@@ -96,6 +96,7 @@ void WinSys_Init()
 	if (hr != NO_ERROR)
 	{
 		// Failed to hook into the process, terminate
+		Assert(0);
 		Error(eDLL_T::COMMON, 0xBAD0C0DE, "Failed to detour process: error code = %08x\n", hr);
 	}
 #endif // DEDICATED


### PR DESCRIPTION
* Removes all extraneous static pointers and cast operations.
* Removes support for < GAMEDLL_S3 (currently broken, and too hard to fix and maintain due to the current scale of the project).