### PR TITLE
Bot player timebase fix

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -60,37 +60,29 @@ QAngle* CPlayer::EyeAngles(QAngle* pAngles)
 //------------------------------------------------------------------------------
 inline void CPlayer::SetTimeBase(float flTimeBase)
 {
-	float flTime = float(TIME_TO_TICKS(flTimeBase));
+	const int nRemainderTime = Max(TIME_TO_TICKS(flTimeBase), 0);
+	SetLastUCmdSimulationRemainderTime(nRemainderTime);
 
-	if (flTime < 0.0f)
-		flTime = 0.0f;
-
-	SetLastUCmdSimulationRemainderTime(flTime);
-
-	float flSimulationTime = flTimeBase - m_lastUCmdSimulationRemainderTime * TICK_INTERVAL;
-	if (flSimulationTime >= 0.0f)
-	{
-		flTime = flSimulationTime;
-	}
-
-	SetTotalExtraClientCmdTimeAttempted(flTime);
+	const float flAttemptedTime = Max(flTimeBase - (m_lastUCmdSimulationRemainderTime * TICK_INTERVAL), 0.0f);
+	SetTotalExtraClientCmdTimeAttempted(flAttemptedTime);
 }
 
 //------------------------------------------------------------------------------
 // Purpose: sets the last user cmd simulation remainder time
-// Input  : flRemainderTime - 
+// Input  : nRemainderTime - 
 //------------------------------------------------------------------------------
-void CPlayer::SetLastUCmdSimulationRemainderTime(float flRemainderTime)
+void CPlayer::SetLastUCmdSimulationRemainderTime(int nRemainderTime)
 {
-	if (m_lastUCmdSimulationRemainderTime != flRemainderTime)
+	if (m_lastUCmdSimulationRemainderTime != nRemainderTime)
 	{
-		edict_t nEdict = NetworkProp()->GetEdict();
+		const edict_t nEdict = NetworkProp()->GetEdict();
+
 		if (nEdict != FL_EDICT_INVALID)
 		{
 			_InterlockedOr16((SHORT*)(*g_pGlobals)->m_pEdicts + nEdict + 32, 0x200u);
 		}
 
-		m_lastUCmdSimulationRemainderTime = flRemainderTime;
+		m_lastUCmdSimulationRemainderTime = nRemainderTime;
 	}
 }
 
@@ -102,7 +94,8 @@ void CPlayer::SetTotalExtraClientCmdTimeAttempted(float flAttemptedTime)
 {
 	if (m_totalExtraClientCmdTimeAttempted != flAttemptedTime)
 	{
-		edict_t nEdict = NetworkProp()->GetEdict();
+		const edict_t nEdict = NetworkProp()->GetEdict();
+
 		if (nEdict != FL_EDICT_INVALID)
 		{
 			_InterlockedOr16((SHORT*)(*g_pGlobals)->m_pEdicts + nEdict + 32, 0x200u);

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -247,13 +247,11 @@ public:
 	QAngle* EyeAngles(QAngle* pAngles);
 
 	void SetTimeBase(float flTimeBase);
-	void SetLastUCmdSimulationRemainderTime(float flRemainderTime);
+	void SetLastUCmdSimulationRemainderTime(int nRemainderTime);
 	void SetTotalExtraClientCmdTimeAttempted(float flAttemptedTime);
 
 	void ProcessUserCmds(CUserCmd* cmds, int numCmds, int totalCmds,
 		int droppedPackets, bool paused);
-
-	void ClampUnlag(CUserCmd* cmd);
 
 	void PlayerRunCommand(CUserCmd* pUserCmd, IMoveHelper* pMover);
 	void SetLastUserCommand(CUserCmd* pUserCmd);
@@ -576,7 +574,7 @@ private:
 	float m_totalFrameTime;
 	float m_joinFrameTime;
 	int m_lastUCmdSimulationTicks;
-	float m_lastUCmdSimulationRemainderTime;
+	int m_lastUCmdSimulationRemainderTime; // Originally float???
 	float m_totalExtraClientCmdTimeAttempted;
 	int m_hPlayerViewEntity;
 	bool m_atLeastOneCommandRunThisServerFrame;


### PR DESCRIPTION
- Member CPlayer::m_lastUCmdSimulationRemainderTime is set and checked as an int in compiled code, change type from float to int.
- Simulation time was calculated incorrectly; brought expression 'CPlayer::m_lastUCmdSimulationRemainderTime * TICK_INTERVAL' into parentheses.
- Call to CPlayer::SetTotalExtraClientCmdTimeAttempted() took incorrect parameter value if flSimulationTime < 0.0f, it was supposed to be clamped to 0.0f, but instead, took the value of 'TIME_TO_TICKS( flTimeBase )'.