### PR TITLE
Implement crash reporting system (Backtrace)

### DIFF
--- a/src/common/sdkint.h
+++ b/src/common/sdkint.h
@@ -53,7 +53,7 @@ typedef          float     float32;
 typedef         double     float64;
 
 typedef        float32     f32;
-typedef        float32     f64;
+typedef        float64     f64;
 //-----------------------------------------------------------------------------
 // 8-bit <--> 64-bit wide boolean type
 typedef           int8     b8;

--- a/src/core/dllmain.cpp
+++ b/src/core/dllmain.cpp
@@ -38,7 +38,7 @@ static HMODULE s_hModuleHandle = NULL;
 // UTILITY
 //#############################################################################
 
-void Crash_Callback()
+void Crash_Callback(const CCrashHandler* handler)
 {
     // Shutdown SpdLog to flush all buffers.
     SpdLog_Shutdown();

--- a/src/core/dllmain.cpp
+++ b/src/core/dllmain.cpp
@@ -7,6 +7,7 @@
 #include "tier0/basetypes.h"
 #include "tier0/crashhandler.h"
 #include "tier0/commandline.h"
+#include "tier2/crashreporter.h"
 /*****************************************************************************/
 #ifndef DEDICATED
 #include "windows/id3dx.h"
@@ -40,10 +41,8 @@ static HMODULE s_hModuleHandle = NULL;
 
 void Crash_Callback(const CCrashHandler* handler)
 {
-    // Shutdown SpdLog to flush all buffers.
-    SpdLog_Shutdown();
-
-    // TODO[ AMOS ]: This is where we want to call backtrace from.
+    CrashReporter_SubmitToCollector(handler);
+    SpdLog_Shutdown(); // Shutdown SpdLog to flush all buffers.
 }
 
 void Show_Emblem()

--- a/src/core/init.cpp
+++ b/src/core/init.cpp
@@ -401,7 +401,7 @@ void QuerySystemInfo()
 	Msg(eDLL_T::NONE, "%-25s: '%s'\n","CPU model identifier", pi.m_szProcessorBrand);
 	Msg(eDLL_T::NONE, "%-25s: '%s'\n","CPU vendor tag", pi.m_szProcessorID);
 	Msg(eDLL_T::NONE, "%-25s: '%12hhu' ('%2hhu' %s)\n", "CPU core count", pi.m_nPhysicalProcessors, pi.m_nLogicalProcessors, "logical");
-	Msg(eDLL_T::NONE, "%-25s: '%12lld' ('%6.1f' %s)\n", "CPU core speed", pi.m_Speed, float(pi.m_Speed / 1000000), "MHz");
+	Msg(eDLL_T::NONE, "%-25s: '%12lld' ('%.1lf' %s)\n", "CPU core speed", pi.m_Speed, f64(pi.m_Speed / 1000000.0), "MHz");
 	Msg(eDLL_T::NONE, "%-20s%s: '%12lu' ('0x%-8X')\n", "L1 cache", "(KiB)", pi.m_nL1CacheSizeKb, pi.m_nL1CacheDesc);
 	Msg(eDLL_T::NONE, "%-20s%s: '%12lu' ('0x%-8X')\n", "L2 cache", "(KiB)", pi.m_nL2CacheSizeKb, pi.m_nL2CacheDesc);
 	Msg(eDLL_T::NONE, "%-20s%s: '%12lu' ('0x%-8X')\n", "L3 cache", "(KiB)", pi.m_nL3CacheSizeKb, pi.m_nL3CacheDesc);

--- a/src/public/tier0/crashhandler.h
+++ b/src/public/tier0/crashhandler.h
@@ -4,6 +4,26 @@
 
 #define CRASHMESSAGE_MSG_EXECUTABLE "bin\\crashmsg.exe"
 
+class CCrashHandler;
+typedef void (*CrashCallback_t)(const CCrashHandler* handler);
+
+struct CrashHardWareInfo_s
+{
+	CrashHardWareInfo_s()
+	{
+		displayDevice = { sizeof(displayDevice), {0} };
+		memoryStatus = { sizeof(memoryStatus) , {0} };
+		availDiskSpace = 0;
+		totalDiskSpace = 0;
+	}
+
+	DISPLAY_DEVICE displayDevice;
+	MEMORYSTATUSEX memoryStatus;
+
+	size_t totalDiskSpace;
+	size_t availDiskSpace;
+};
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -29,6 +49,12 @@ public:
 
 	inline bool IsValid() const { return m_hExceptionHandler != nullptr; };
 
+	inline bool CrashingModuleNameKnown() const { return m_CrashingModule.Length() > 0; }
+	inline const char* GetCrashingModuleName() const { return m_CrashingModule.String(); }
+
+	inline const EXCEPTION_POINTERS* GetExceptionPointers() const { return m_pExceptionPointers; }
+	inline const CrashHardWareInfo_s& GetHardwareInfo() const { return m_HardWareInfo; }
+
 	//-------------------------------------------------------------------------
 	// Formatters: 
 	//-------------------------------------------------------------------------
@@ -46,13 +72,13 @@ public:
 	const char* ExceptionToString(const DWORD nExceptionCode) const;
 
 	void SetExceptionPointers(EXCEPTION_POINTERS* const pExceptionPointers) { m_pExceptionPointers = pExceptionPointers; }
-	void SetCrashCallback(PVOID pCrashCallback) { m_pCrashCallback = pCrashCallback; }
+	void SetCrashCallback(CrashCallback_t pCrashCallback) { m_pCrashCallback = pCrashCallback; }
 
 	void CaptureCallStack();
 	void WriteFile();
 
 	void CreateMessageProcess();
-	void CrashCallback();
+	void CrashCallback() const;
 
 private:
 
@@ -83,7 +109,7 @@ private:
 	HMODULE m_ppModuleHandles[MAX_MODULE_HANDLES];
 
 	// Custom crash callback that's called after the logs have been written.
-	PVOID m_pCrashCallback;
+	CrashCallback_t m_pCrashCallback;
 
 	// Current exception handler, only kept here for tracking as we need the
 	// handle if we want to remove this handler.
@@ -109,6 +135,9 @@ private:
 
 	// Set when crashmsg.exe is created to prevent recursive messages.
 	bool m_bMessageCreated;
+	
+	// Cached hardware info this application crashed on.
+	CrashHardWareInfo_s m_HardWareInfo;
 
 	mutable RTL_SRWLOCK m_Lock;
 };

--- a/src/public/tier0/utility.h
+++ b/src/public/tier0/utility.h
@@ -94,9 +94,17 @@ string Format(const char* szFormat, ...);
 template <typename Iter, typename Compare>
 Iter ExtremeElementABS(Iter first, Iter last, Compare compare)
 {
-    auto abs_compare = [compare](LONG a, LONG b)
+    using ValueType = typename std::iterator_traits<Iter>::value_type;
+    auto abs_compare = [compare](ValueType a, ValueType b)
     {
-        return compare(abs(a), abs(b));
+        if constexpr (std::is_signed_v<ValueType>)
+        {
+            return compare(abs(a), abs(b));
+        }
+        else
+        {
+            return compare(a, b);
+        }
     };
 
     return std::min_element(first, last, abs_compare);

--- a/src/public/tier2/crashreporter.h
+++ b/src/public/tier2/crashreporter.h
@@ -1,0 +1,11 @@
+//=============================================================================//
+//
+// Purpose: Post-mortem crash reporter
+//
+//=============================================================================//
+#ifndef TIER2_CRASHREPORTER_H
+#define TIER2_CRASHREPORTER_H
+
+extern void CrashReporter_SubmitToCollector(const CCrashHandler* const handler);
+
+#endif // TIER2_CRASHREPORTER_H

--- a/src/public/tier2/curlutils.h
+++ b/src/public/tier2/curlutils.h
@@ -26,6 +26,7 @@ struct CURLParams
 		, verifyPeer(false)
 		, followRedirect(false)
 		, verbose(false)
+		, failOnError(true)
 	{}
 
 	void* readFunction;
@@ -36,6 +37,7 @@ struct CURLParams
 	bool verifyPeer;
 	bool followRedirect;
 	bool verbose;
+	bool failOnError;
 };
 
 size_t CURLReadFileCallback(void* data, const size_t size, const size_t nmemb, FILE* stream);

--- a/src/public/tier2/curlutils.h
+++ b/src/public/tier2/curlutils.h
@@ -12,14 +12,15 @@ struct CURLProgress
 
 	CURL* curl;
 	const char* name;
-	void* cust; // custom pointer to anything.
+	void* cust; // custom pointer to anything, todo(amos): rename to 'user'.
 	size_t size;
 };
 
 struct CURLParams
 {
 	CURLParams()
-		: writeFunction(nullptr)
+		: readFunction(nullptr)
+		, writeFunction(nullptr)
 		, statusFunction(nullptr)
 		, timeout(0)
 		, verifyPeer(false)
@@ -27,6 +28,7 @@ struct CURLParams
 		, verbose(false)
 	{}
 
+	void* readFunction;
 	void* writeFunction;
 	void* statusFunction;
 
@@ -36,9 +38,14 @@ struct CURLParams
 	bool verbose;
 };
 
+size_t CURLReadFileCallback(void* data, const size_t size, const size_t nmemb, FILE* stream);
+size_t CURLWriteFileCallback(void* data, const size_t size, const size_t nmemb, FILE* stream);
 size_t CURLWriteStringCallback(char* contents, const size_t size, const size_t nmemb, string* userp);
-size_t CURLWriteFileCallback(void* data, const size_t size, const size_t nmemb, FILE* userp);
 
+curl_slist* CURLSlistAppend(curl_slist* slist, const char* string);
+
+bool CURLUploadFile(const char* remote, const char* filePath, const char* options,
+	void* customPointer, const bool usePost, const curl_slist* slist, const CURLParams& params);
 bool CURLDownloadFile(const char* remote, const char* savePath, const char* fileName,
 	const char* options, curl_off_t dataSize, void* customPointer, const CURLParams& params);
 

--- a/src/tier2/CMakeLists.txt
+++ b/src/tier2/CMakeLists.txt
@@ -4,6 +4,7 @@ add_module( "lib" "tier2" "vpc" ${FOLDER_CONTEXT} TRUE TRUE )
 start_sources()
 
 add_sources( SOURCE_GROUP "Utility"
+    "crashreporter.cpp"
     "cryptutils.cpp"
     "curlutils.cpp"
     "fileutils.cpp"

--- a/src/tier2/crashreporter.cpp
+++ b/src/tier2/crashreporter.cpp
@@ -1,0 +1,61 @@
+//=============================================================================//
+//
+// Purpose: Post-mortem crash reporter
+//
+//=============================================================================//
+#include "tier0/crashhandler.h"
+#include "tier0/cpu.h"
+#include "tier2/curlutils.h"
+#include "tier2/crashreporter.h"
+
+static ConVar backtrace_enabled("backtrace_enabled", "1", FCVAR_RELEASE, "Whether to report fatal errors to the collection server");
+static ConVar backtrace_hostname("backtrace_hostname", "submit.backtrace.io", FCVAR_RELEASE, "Holds the error collection server hostname");
+static ConVar backtrace_universe("backtrace_universe", "r5reloaded", FCVAR_RELEASE, "Holds the error collection server hosted instance");
+static ConVar backtrace_token("backtrace_token", "f178fd48d89c8fec7f8b6404ae6dae591c330fd3e2599cab888788033944ec98", FCVAR_RELEASE, "Holds the error collection server submission token");
+
+static inline string CrashReporter_FormatAttributes(const CCrashHandler* const handler)
+{
+	const CPUInformation& pi = GetCPUInformation();
+	const CrashHardWareInfo_s& hi = handler->GetHardwareInfo();
+
+	const char* const format = "uuid=%s&"  "build_id=%lld&"
+		"cpu_model=%s&" "cpu_speed=%lf GHz&" "gpu_model=%s&" "gpu_flags=%lu&"
+		"ram_phys_total=%.2lf MiB&" "ram_phys_avail=%.2lf MiB&"
+		"ram_virt_total=%.2lf MiB&" "ram_virt_avail=%.2lf MiB&"
+		"disk_total=%.2lf MiB&" "disk_avail=%.2lf MiB";
+
+	const DISPLAY_DEVICE& dd = hi.displayDevice;
+	const MEMORYSTATUSEX& ms = hi.memoryStatus;
+
+	return Format(format, g_LogSessionUUID.c_str(), g_SDKDll.GetNTHeaders()->FileHeader.TimeDateStamp,
+		pi.m_szProcessorBrand, (f64)(pi.m_Speed / 1000000000.0), dd.DeviceString, dd.StateFlags,
+		(f64)(ms.ullTotalPhys    / (1024.0*1024.0)), (f64)(ms.ullAvailPhys    / (1024.0*1024.0)),
+		(f64)(ms.ullTotalVirtual / (1024.0*1024.0)), (f64)(ms.ullAvailVirtual / (1024.0*1024.0)),
+		(f64)(hi.totalDiskSpace  / (1024.0*1024.0)), (f64)(hi.availDiskSpace  / (1024.0*1024.0)));
+}
+
+void CrashReporter_SubmitToCollector(const CCrashHandler* const handler)
+{
+	if (!backtrace_enabled.GetBool())
+		return;
+
+	curl_slist* slist = nullptr;
+	slist = CURLSlistAppend(slist, "Expect:");
+
+	if (!slist)
+		return; // failure.
+
+	const string attributes = CrashReporter_FormatAttributes(handler);
+	const string hostName = Format("%s%s/%s/%s/%s&%s", 
+		"https://", backtrace_hostname.GetString(), backtrace_universe.GetString(), backtrace_token.GetString(), "minidump", attributes.c_str());
+	const string miniDumpPath = Format("%s/%s.dmp", g_LogSessionDirectory.c_str(), "minidump");
+
+	CURLParams params;
+	params.readFunction = &CURLReadFileCallback;
+	params.writeFunction = &CURLWriteStringCallback;
+	params.timeout = curl_timeout.GetInt();
+	params.verifyPeer = ssl_verify_peer.GetBool();
+	params.verbose = curl_debug.GetBool();
+
+	CURLUploadFile(hostName.c_str(), miniDumpPath.c_str(), "rb", nullptr, true, slist, params);
+}

--- a/src/tier2/curlutils.cpp
+++ b/src/tier2/curlutils.cpp
@@ -30,6 +30,7 @@ void CURLInitCommonOptions(CURL* curl, const char* remote,
 {
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, params.timeout);
     curl_easy_setopt(curl, CURLOPT_VERBOSE, params.verbose);
+    curl_easy_setopt(curl, CURLOPT_FAILONERROR, params.failOnError);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, params.followRedirect);
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, params.verifyPeer);
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);


### PR DESCRIPTION
Implements functionality that sends crash details to the error collection server (Backtrace) that allows investigating crashes with much more details and accuracy. It was nearly impossible to track hard and intermittent crashes in the past.

This PR also contains the following fixes to the existing crash handler system:

* Typedef 'f64' was defined as a 32-bit floating point. This has been fixed and now represents 64-bit floating points.
* The highest XMM value wasn't correctly derived from the registers, types are now unsigned to make sure the calculation runs correctly.
* Improved formatting for CPU clock speeds and available/total RAM space.
* The crash callback didn't run most of the time as it was ran after the crash outside the context. This now always runs withing the context, and now always runs during a crash.