### PR TITLE
Fix GetFactorySystem not being exported

### DIFF
--- a/src/vpc/interfaces.h
+++ b/src/vpc/interfaces.h
@@ -49,7 +49,7 @@ public:
 };
 
 extern CFactorySystem g_FactorySystem;
-PLATFORM_INTERFACE IFactorySystem* GetFactorySystem();
+DLL_EXPORT IFactorySystem* GetFactorySystem();
 
 ///////////////////////////////////////////////////////////////////////////////
 inline void*(*v_CreateInterfaceInternal)(const char* pName, int* pReturnCode);


### PR DESCRIPTION
This resolves plugins failing to import GetFactorySystem as it was not being exported.