### PR TITLE
Pylon: Fix incorrect return value in GetBannedList

### DIFF
--- a/src/networksystem/pylon.cpp
+++ b/src/networksystem/pylon.cpp
@@ -287,9 +287,13 @@ bool CPylon::GetBannedList(const CBanSystem::BannedList_t& inBannedVec, CBanSyst
             CBanSystem::Banned_t banned(reason ? reason : "#DISCONNECT_BANNED", nuc);
             (*outBannedVec)->AddToTail(banned);
         }
-    }
 
-    return true;
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
GetBannedList was returning true even when no players were pushed to the banlist causing excessive thread creation in the bulk check system.

Credit: ugnius1337
Assisted with validating the fix as well as assisting with debugging on a live server.