### PR TITLE
Implement communication bans

### DIFF
--- a/src/common/global.cpp
+++ b/src/common/global.cpp
@@ -106,6 +106,8 @@ ConVar* player_userCmdsQueueWarning        = nullptr;
 ConVar* player_disallow_negative_frametime = nullptr;
 
 ConVar* script_server_fps                  = nullptr;
+
+ConVar* hudchat_dead_can_only_talk_to_other_dead = nullptr;
 #endif // !CLIENT_DLL
 ConVar* sv_cheats                          = nullptr;
 ConVar* sv_visualizetraces                 = nullptr;
@@ -262,6 +264,7 @@ void ConVar_InitShipped(void)
 	player_disallow_negative_frametime = g_pCVar->FindVar("player_disallow_negative_frametime");
 
 	script_server_fps = g_pCVar->FindVar("script_server_fps");
+	hudchat_dead_can_only_talk_to_other_dead = g_pCVar->FindVar("hudchat_dead_can_only_talk_to_other_dead");
 
 	sv_updaterate_sp->RemoveFlags(FCVAR_DEVELOPMENTONLY);
 	sv_updaterate_mp->RemoveFlags(FCVAR_DEVELOPMENTONLY);

--- a/src/common/global.h
+++ b/src/common/global.h
@@ -93,6 +93,8 @@ extern ConVar* player_userCmdsQueueWarning;
 extern ConVar* player_disallow_negative_frametime;
 
 extern ConVar* script_server_fps;
+
+extern ConVar* hudchat_dead_can_only_talk_to_other_dead;
 #endif // CLIENT_DLL
 extern ConVar* sv_cheats;
 extern ConVar* sv_visualizetraces;

--- a/src/core/init.cpp
+++ b/src/core/init.cpp
@@ -149,6 +149,7 @@
 #include "game/server/vscript_server.h"
 #include "game/server/entitylist.h"
 #include "game/server/baseentity.h"
+#include "game/server/recipientfilter.h"
 #endif // !CLIENT_DLL
 #ifndef DEDICATED
 #include "game/client/viewrender.h"
@@ -712,6 +713,7 @@ void DetourRegister() // Register detour classes to be searched and hooked.
 	REGISTER(VCBaseEntity);
 
 	REGISTER(V_UTIL_Server);
+	REGISTER(VRecipientFilter);
 
 #endif // !CLIENT_DLL
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -18,6 +18,9 @@
 #include "networksystem/hostmanager.h"
 #include "jwt/include/decode.h"
 #include "mbedtls/include/mbedtls/sha256.h"
+#include "game/server/recipientfilter.h"
+#include "game/server/util_server.h"
+#include "tier1/fmtstr.h"
 #endif
 #include "game/server/gameinterface.h"
 
@@ -560,6 +563,69 @@ bool CClient::VProcessSetConVar(CClient* pClient, NET_SetConVar* pMsg)
 	return true;
 }
 
+#ifndef CLIENT_DLL
+//---------------------------------------------------------------------------------
+// Purpose: When the client is muted and they speak send a text chat message to alert them they are banned
+// Input  : *pClient
+//---------------------------------------------------------------------------------
+static void InformClientAboutCommsBanTriggeredByVoice(CClient* const pClient)
+{
+	CClientExtended* const pClientExtended = pClient->GetClientExtended();
+
+	if (!pClientExtended->HasBeenPromptedFromVoiceAboutBan())
+	{
+		CPlayer* const pPlayer = UTIL_PlayerByIndex(pClient->GetHandle());
+
+		if (!pPlayer || !pPlayer->IsConnected())
+			return;	
+
+		CSingleUserRecipientFilter filter(pPlayer);
+		v_UserMessageBegin(&filter, "SayText", 2);
+
+		MessageWriteByte(pPlayer->GetEdict());
+		MessageWriteString(pClient->GetClientExtended()->GetCommsMuteDisplayMessage());
+		MessageWriteBool(true);
+
+		MessageEnd();
+
+		pClientExtended->SetHasBeenPromptedFromVoiceAboutBan(true);
+	}
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: This builds and stores the message we send to a client when they are comms banned
+// Input  : *pszReason -
+//				 *pszExpiryTimestamp - 
+// Output : 
+//---------------------------------------------------------------------------------
+void CClientExtended::BuildCommsBanDisplayMessage(const char* pszReasonStr, const char* pszExpiryTimestamp)
+{
+	CFmtStr fmt;
+
+	//The default bansystem reason for when there is no reason from the MS is this
+	//TODO: Localize this string into what it should be, for now we just give a descriptive default
+	if (pszReasonStr)
+	{
+		if (V_strcmp("#DISCONNECT_BANNED", pszReasonStr) == 0)
+		{
+			pszReasonStr = "Communication Banned";
+		}
+	}
+
+	fmt.Format("You have an active %s  communications ban.\nReason: %s\n", 
+		pszExpiryTimestamp ? "temporary" : "permanent",
+		pszReasonStr ? pszReasonStr : "None"
+	);
+
+	if (pszExpiryTimestamp)
+	{
+		fmt.AppendFormat("Expiry: %s", pszExpiryTimestamp);
+	}
+
+	m_MuteDisplayPrompt = fmt;
+}
+#endif
+
 //---------------------------------------------------------------------------------
 // Purpose: process voice data
 // Input  : *pClient - (ADJ)
@@ -576,6 +642,18 @@ bool CClient::VProcessVoiceData(CClient* pClient, CLC_VoiceData* pMsg)
 		return false;
 
 	CClient* const pAdj = AdjustShiftedThisPointer(pClient);
+	
+	//Is our client communication banned
+	if (pAdj->GetClientExtended()->IsClientCommsBanned())
+	{
+		//Should we apply the communication ban based on what the host has decided
+		if (SV_ShouldApplyVoiceChatGlobalMutes())
+		{
+			InformClientAboutCommsBanTriggeredByVoice(pAdj);
+			return true;
+		}
+	}
+
 	SV_BroadcastVoiceData(pAdj, Bits2Bytes(bitsRead), voiceDataBuffer);
 #endif // !CLIENT_DLL
 
@@ -598,6 +676,15 @@ bool CClient::VProcessDurangoVoiceData(CClient* pClient, CLC_DurangoVoiceData* p
 		return false;
 
 	CClient* const pAdj = AdjustShiftedThisPointer(pClient);
+
+	//Is our client communication banned
+	if (pAdj->GetClientExtended()->IsClientCommsBanned())
+	{
+		//Should we apply the communication ban based on what the host has decided
+		if (SV_ShouldApplyVoiceChatGlobalMutes())
+			return true;
+	}
+
 	SV_BroadcastDurangoVoiceData(pAdj, Bits2Bytes(bitsRead), voiceDataBuffer,
 		pMsg->m_xid, pMsg->m_unknown, pMsg->m_useVoiceStream, pMsg->m_skipXidCheck);
 #endif // !CLIENT_DLL

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -682,7 +682,10 @@ bool CClient::VProcessDurangoVoiceData(CClient* pClient, CLC_DurangoVoiceData* p
 	{
 		//Should we apply the communication ban based on what the host has decided
 		if (SV_ShouldApplyVoiceChatGlobalMutes())
+		{
+			InformClientAboutCommsBanTriggeredByVoice(pAdj);
 			return true;
+		}
 	}
 
 	SV_BroadcastDurangoVoiceData(pAdj, Bits2Bytes(bitsRead), voiceDataBuffer,

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -254,6 +254,10 @@ public:
 		m_nStringCommandQuotaCount = NULL;
 		m_flMovementTimeForUserCmdProcessingRemaining = 0.0f;
 		m_bInitialConVarsSet = false;
+
+		m_bIsCommsBanned = false;
+		m_bHasBeenPromptedAboutBanFromSpeaking = false;
+		m_MuteDisplayPrompt.Purge();
 	}
 
 public: // Inlines:
@@ -276,7 +280,18 @@ public: // Inlines:
 	void InitializeMovementTimeForUserCmdProcessing(const int numUserCmdProcessTicksMax, const float tickInterval);
 	float ConsumeMovementTimeForUserCmdProcessing(const float flTimeNeeded);
 
+	void SetClientIsCommsBanned(bool bBanned) { m_bIsCommsBanned = bBanned; }
+	bool IsClientCommsBanned() const { return m_bIsCommsBanned; }
+
+	void SetCommsBanInfo(const char* const pszReason, const char* const pszExpiryTime) { BuildCommsBanDisplayMessage(pszReason, pszExpiryTime); }
+
+	void SetHasBeenPromptedFromVoiceAboutBan(bool bPrompted) { m_bHasBeenPromptedAboutBanFromSpeaking = bPrompted; }
+	bool HasBeenPromptedFromVoiceAboutBan() const { return m_bHasBeenPromptedAboutBanFromSpeaking; }
+
+	const char* const GetCommsMuteDisplayMessage() const { return m_MuteDisplayPrompt.Get(); }
 private:
+	void BuildCommsBanDisplayMessage(const char* pszReasonStr, const char* const pszExpiryDateTime);
+
 	// Measure how long this client's packets took to process.
 	double m_flNetProcessingTimeMsecs;
 	double m_flNetProcessTimeBase;
@@ -289,6 +304,10 @@ private:
 	float m_flMovementTimeForUserCmdProcessingRemaining;
 
 	bool m_bInitialConVarsSet; // Whether or not the initial ConVar KV's are set
+
+	bool m_bIsCommsBanned;
+	bool m_bHasBeenPromptedAboutBanFromSpeaking;
+	CUtlString m_MuteDisplayPrompt;
 };
 
 /* ==== CBASECLIENT ===================================================================================================================================================== */

--- a/src/engine/server/sv_main.cpp
+++ b/src/engine/server/sv_main.cpp
@@ -15,6 +15,60 @@
 #include "server.h"
 #include "game/server/gameinterface.h"
 
+static ConVar sv_applyGlobalCommsBans("sv_applyGlobalCommsBans", "3", FCVAR_RELEASE, "Determines whether or not to use the global chat ban list, 0 = None, 1 = Text, 2 = Voice, 3 = Both.", false, 0.f, true, 3.f);
+static ConVar sv_commsBansAreGameBans("sv_commsBansAreGameBans", "0", FCVAR_RELEASE, "If set chat bans will be applied as game bans", false, 0.f, true, 1.f);
+
+bool SV_ShouldApplyTextChatGlobalMutes()
+{
+	const int globalBanSetting = sv_applyGlobalCommsBans.GetInt();
+	if (globalBanSetting == 1 || globalBanSetting == 3)
+		return true;
+	return false;
+}
+
+bool SV_ShouldApplyVoiceChatGlobalMutes()
+{
+	const int globalBanSetting = sv_applyGlobalCommsBans.GetInt();
+	if (globalBanSetting >= 2)
+		return true;
+	return false;
+}
+
+static bool SV_GlobalCommsBansEnabled()
+{
+	if (sv_applyGlobalCommsBans.GetInt() != 0)
+		return true;
+	return false;
+}
+
+static void SV_HandleConnectBan(CClient* const pClient, const char* const pszReason, const char* const pszIpStr, const int nPort, const NucleusID_t nNucleusID)
+{
+	pClient->Disconnect(Reputation_t::REP_MARK_BAD, "%s", pszReason);
+	Warning(eDLL_T::SERVER, "Removed client '[%s]:%i' from slot #%i ('%llu' is banned globally!)\n",
+		pszIpStr, nPort, pClient->GetUserID(), nNucleusID);
+}
+
+static void SV_HandleCommunicationBan(CClient* const pClient, const char* const pszReason, const char* const pszExpiry, const char* const pszIpStr, const int nPort, const NucleusID_t nNucleusID)
+{
+	const int nUserId = pClient->GetUserID();
+	CClientExtended* const pClientExtended = pClient->GetClientExtended();
+
+	if (sv_commsBansAreGameBans.GetBool())
+	{
+		pClient->Disconnect(Reputation_t::REP_MARK_BAD, "%s", pszReason);
+		Warning(eDLL_T::SERVER, "Removed client '[%s]:%i' from slot #%i ('%llu' is communication banned and communication bans are treated as game bans!)\n",
+			pszIpStr, nPort, nUserId, nNucleusID);
+	}
+	else
+	{
+		DevMsg(eDLL_T::SERVER, "Muting client '[%s]:%i' from slot #%i ('%llu' is communication banned)\n",
+			pszIpStr, nPort, nUserId, nNucleusID);
+	}
+
+	pClientExtended->SetClientIsCommsBanned(true);
+	pClientExtended->SetCommsBanInfo(pszReason, pszExpiry);
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: checks if particular client is banned on the comp server
 //-----------------------------------------------------------------------------
@@ -24,11 +78,14 @@ void SV_CheckForBanAndDisconnect(CClient* const pClient, const string& svIPAddr,
 	Assert(pClient != nullptr);
 
 	string svError;
-	const bool bCompBanned = g_MasterServer.CheckForBan(svIPAddr, nNucleusID, svPersonaName, svError);
+	string expiry;
+	CBanSystem::Banned_t::BanType_e banType = CBanSystem::Banned_t::CONNECT;
+	
+	const bool bCompBanned = g_MasterServer.CheckForBan(svIPAddr, nNucleusID, svPersonaName, svError, banType, expiry);
 
 	if (bCompBanned)
 	{
-		g_TaskQueue.Dispatch([pClient, svError, svIPAddr, nNucleusID, nPort]
+		g_TaskQueue.Dispatch([pClient, svError, svIPAddr, nNucleusID, nPort, banType, expiry]
 			{
 				// Make sure client isn't already disconnected,
 				// and that if there is a valid netchannel, that
@@ -37,11 +94,22 @@ void SV_CheckForBanAndDisconnect(CClient* const pClient, const string& svIPAddr,
 				const CNetChan* const pChan = pClient->GetNetChan();
 				if (pChan && pClient->GetNucleusID() == nNucleusID)
 				{
-					const int nUserID = pClient->GetUserID();
-
-					pClient->Disconnect(Reputation_t::REP_MARK_BAD, "%s", svError.c_str());
-					Warning(eDLL_T::SERVER, "Removed client '[%s]:%i' from slot #%i ('%llu' is banned globally!)\n",
-						svIPAddr.c_str(), nPort, nUserID, nNucleusID);
+					switch (banType)
+					{
+					case CBanSystem::Banned_t::CONNECT:
+					{
+						SV_HandleConnectBan(pClient, svError.c_str(), svIPAddr.c_str(), nPort, nNucleusID);
+						break;
+					}
+					case CBanSystem::Banned_t::COMMUNICATION:
+					{
+						if(SV_GlobalCommsBansEnabled())
+							SV_HandleCommunicationBan(pClient, svError.c_str(), expiry.c_str(), svIPAddr.c_str(), nPort, nNucleusID);
+						break;
+					default:
+						break;
+					}
+					}
 				}
 			}, 0);
 	}
@@ -106,15 +174,34 @@ void SV_CheckClientsForBan(const CBanSystem::BannedList_t* const pBannedVec /*= 
 			{
 				const CBanSystem::Banned_t& banned = (*pBannedVec)[i];
 
-				if (banned.m_NucleusID == pClient->GetNucleusID())
-				{
-					const int nUserID = pClient->GetUserID();
-					const int nPort = pNetChan->GetPort();
+				//If this ban isnt for this client then we check the next
+				if (banned.m_NucleusID != pClient->GetNucleusID())
+					continue;
 
-					pClient->Disconnect(Reputation_t::REP_MARK_BAD, "%s", banned.m_Address.String());
-					Warning(eDLL_T::SERVER, "Removed client '[%s]:%i' from slot #%i ('%llu' is banned globally!)\n",
-						szIPAddr, nPort, nUserID, nNucleusID);
+				const int nPort = pNetChan->GetPort();
+
+				//What ban type do we have for this client
+				switch (banned.m_BanType)
+				{
+				case CBanSystem::Banned_t::CONNECT:
+				{
+					SV_HandleConnectBan(pClient, banned.m_Address.String(), szIPAddr, nPort, nNucleusID);
+					break;
 				}
+				case CBanSystem::Banned_t::COMMUNICATION:
+				{
+					//Does the host have the comms ban system on and is our client already banned, no point rebanning them if they are
+					if (SV_GlobalCommsBansEnabled() && !pClient->GetClientExtended()->IsClientCommsBanned())
+						SV_HandleCommunicationBan(pClient, banned.m_Address.String(), banned.m_BanExpiry.Get(), szIPAddr, nPort, nNucleusID);
+					break;
+				}
+				//Unknown ban type
+				default:
+					break;
+				}
+
+				//Since we have handled this client we can move onto the next one
+				break;
 			}
 		}
 	}
@@ -189,6 +276,9 @@ void SV_BroadcastVoiceData(CClient* const cl, const int nBytes, char* const data
 	if (!SV_CanBroadcastVoice())
 		return;
 
+	const bool bShouldApplyGlobalMutes = SV_ShouldApplyVoiceChatGlobalMutes();
+	const bool bBannedClientsCanHearOtherClients = sv_commsBannedClientsCanRecieveComms.GetBool();
+
 	SVC_VoiceData voiceData(cl->GetUserID(), nBytes, data);
 
 	for (int i = 0; i < gpGlobals->maxClients; i++)
@@ -197,6 +287,10 @@ void SV_BroadcastVoiceData(CClient* const cl, const int nBytes, char* const data
 
 		// is this client fully connected
 		if (pClient->GetSignonState() != SIGNONSTATE::SIGNONSTATE_FULL)
+			continue;
+
+		//If the client is communication banned and the server has decidecd that players who are comms banned cant hear other players, skip broadcasting to them
+		if (!bBannedClientsCanHearOtherClients && bShouldApplyGlobalMutes &&  pClient->GetClientExtended()->IsClientCommsBanned())
 			continue;
 
 		// is this client the sender
@@ -233,6 +327,9 @@ void SV_BroadcastDurangoVoiceData(CClient* const cl, const int nBytes, char* con
 	if (!SV_CanBroadcastVoice())
 		return;
 
+	const bool bShouldApplyGlobalMutes = SV_ShouldApplyVoiceChatGlobalMutes();
+	const bool bBannedClientsCanHearOtherClients = sv_commsBannedClientsCanRecieveComms.GetBool();
+
 	SVC_DurangoVoiceData voiceData(cl->GetUserID(), nBytes, data, unknown, useVoiceStream);
 
 	for (int i = 0; i < gpGlobals->maxClients; i++)
@@ -241,6 +338,10 @@ void SV_BroadcastDurangoVoiceData(CClient* const cl, const int nBytes, char* con
 
 		// is this client fully connected
 		if (pClient->GetSignonState() != SIGNONSTATE::SIGNONSTATE_FULL)
+			continue;
+
+		//If the client is communication banned and the server has decidecd that players who are comms banned cant other players, skip broadcasting to them
+		if (!bBannedClientsCanHearOtherClients && bShouldApplyGlobalMutes && pClient->GetClientExtended()->IsClientCommsBanned())
 			continue;
 
 		// is this client the sender

--- a/src/engine/server/sv_main.cpp
+++ b/src/engine/server/sv_main.cpp
@@ -191,7 +191,7 @@ void SV_CheckClientsForBan(const CBanSystem::BannedList_t* const pBannedVec /*= 
 				case CBanSystem::Banned_t::COMMUNICATION:
 				{
 					//Does the host have the comms ban system on and is our client already banned, no point rebanning them if they are
-					if (SV_GlobalCommsBansEnabled() && !pClient->GetClientExtended()->IsClientCommsBanned())
+					if (SV_GlobalCommsBansEnabled() && (!pClient->GetClientExtended()->IsClientCommsBanned() || sv_commsBansAreGameBans.GetBool()))
 						SV_HandleCommunicationBan(pClient, banned.m_Address.String(), banned.m_BanExpiry.Get(), szIPAddr, nPort, nNucleusID);
 					break;
 				}

--- a/src/engine/server/sv_main.h
+++ b/src/engine/server/sv_main.h
@@ -67,6 +67,9 @@ void SV_BroadcastVoiceData(CClient* const cl, const int nBytes, char* const data
 void SV_BroadcastDurangoVoiceData(CClient* const cl, const int nBytes, char* const data, const int nXid, const int unknown, const bool useVoiceStream, const bool skipXidCheck);
 void SV_CheckForBanAndDisconnect(CClient* const pClient, const string& svIPAddr, const NucleusID_t nNucleusID, const string& svPersonaName, const int nPort);
 void SV_CheckClientsForBan(const CBanSystem::BannedList_t* const pBannedVec = nullptr);
+bool SV_ShouldApplyTextChatGlobalMutes();
+bool SV_ShouldApplyVoiceChatGlobalMutes();
+
 ///////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -191,6 +191,11 @@ add_sources( SOURCE_GROUP "LiveAPI"
     "server/liveapi/liveapi.h"
 )
 
+add_sources( SOURCE_GROUP "Recipient Filter"
+    "server/recipientfilter.cpp"
+    "server/recipientfilter.h"
+)
+
 file( GLOB GAME_SERVER_PUBLIC_HEADERS
     "${ENGINE_SOURCE_DIR}/public/game/server/*"
 )

--- a/src/game/server/baseentity.h
+++ b/src/game/server/baseentity.h
@@ -119,6 +119,8 @@ public:
 	model_t*		GetModel(void);
 	int				GetModelIndex(void) const; // Virtual in-engine!
 	string_t		GetModelName(void) const;  // Virtual in-engine!
+	const Vector3D& GetViewOffset(void) const { return m_vecViewOffset; }
+	const Vector3D& GetVecPrevAbsOrigin(void) const { return m_vecPrevAbsOrigin; }
 
 	inline edict_t GetEdict(void) const { return NetworkProp()->GetEdict(); }
 	inline string_t GetEntityName(void) const { return m_iName; }

--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -21,6 +21,7 @@
 #include "game/shared/usercmd.h"
 #include "game/server/util_server.h"
 #include "pluginsystem/pluginsystem.h"
+#include "game/server/recipientfilter.h"
 
 //-----------------------------------------------------------------------------
 // Purpose: retrieves the index of the client that issued the last command
@@ -125,37 +126,93 @@ static ConVar chat_debug("chat_debug", "0", FCVAR_RELEASE, "Enables chat-related
 
 void CServerGameDLL::OnReceivedSayTextMessage(CServerGameDLL* thisptr, int senderId, const char* text, bool isTeamChat)
 {
-	if (senderId > 0)
+	CPlayer* const pSenderPlayer = UTIL_PlayerByIndex(senderId);
+	CClient* const pSenderClient = g_pServer->GetClient(senderId - 1);
+
+	if (!pSenderPlayer || !pSenderClient ||  !pSenderPlayer->IsConnected())
+		return;
+
+	const bool bTeamChatOnly =  sv_forceChatToTeamOnly->GetBool() ? true : isTeamChat;
+	const int nMaxClients = gpGlobals->maxClients;
+	const bool bShouldApplyGlobalCommsMutes = SV_ShouldApplyTextChatGlobalMutes();
+
+	pSenderPlayer->UpdateLastActiveTime(gpGlobals->curTime);
+	
+	const bool bSenderIsCommsBanned = pSenderClient->GetClientExtended()->IsClientCommsBanned();
+
+	if (bShouldApplyGlobalCommsMutes && bSenderIsCommsBanned)
 	{
-		if (senderId <= gpGlobals->maxPlayers && senderId != 0xFFFF)
+		if (chat_debug.GetBool())
+			Msg(eDLL_T::SERVER, "Dropping chat message from '%s' (%llu) User is globally muted", 
+				pSenderPlayer->GetNetName(), pSenderPlayer->GetPlatformUserId());
+
+		CSingleUserRecipientFilter filter(pSenderPlayer);
+		filter.MakeReliable();
+
+		v_UserMessageBegin(&filter, "SayText", 2);
+
+		MessageWriteByte(pSenderPlayer->GetEdict());
+		MessageWriteString(pSenderClient->GetClientExtended()->GetCommsMuteDisplayMessage());
+		MessageWriteBool(bTeamChatOnly);
+
+		MessageEnd();
+		return;
+	}
+
+	for (auto& cb : !g_PluginSystem.GetChatMessageCallbacks())
+	{
+		if (!cb.Function()(pSenderPlayer, text, sv_forceChatToTeamOnly->GetBool()))
 		{
-			CPlayer* player = reinterpret_cast<CPlayer*>(gpGlobals->m_pEdicts[senderId + 30728]);
-
-			if (player && player->IsConnected())
+			if (chat_debug.GetBool())
 			{
-				for (auto& cb : !g_PluginSystem.GetChatMessageCallbacks())
-				{
-					if (!cb.Function()(player, text, sv_forceChatToTeamOnly->GetBool()))
-					{
-						if (chat_debug.GetBool())
-						{
-							char moduleName[MAX_PATH] = {};
+				char moduleName[MAX_PATH] = {};
 
-							V_UnicodeToUTF8(V_UnqualifiedFileName(cb.ModuleName()), moduleName, MAX_PATH);
+				V_UnicodeToUTF8(V_UnqualifiedFileName(cb.ModuleName()), moduleName, MAX_PATH);
 
-							Msg(eDLL_T::SERVER, "[%s] Plugin blocked chat message from '%s' (%llu): \"%s\"\n", moduleName, player->GetNetName(), player->GetPlatformUserId(), text);
-						}
-
-						return;
-					}
-				}
+				Msg(eDLL_T::SERVER, "[%s] Plugin blocked chat message from '%s' (%llu): \"%s\"\n", moduleName, pSenderPlayer->GetNetName(), pSenderPlayer->GetPlatformUserId(), text);
 			}
+
+			return;
 		}
 	}
 
-	// set isTeamChat to false so that we can let the convar sv_forceChatToTeamOnly decide whether team chat should be enforced
-	// this isn't a great way of doing it but it works so meh
-	CServerGameDLL__OnReceivedSayTextMessage(thisptr, senderId, text, false);
+	const bool bSenderDeadAndCanOnlyTalkToDead = hudchat_dead_can_only_talk_to_other_dead->GetBool() && pSenderPlayer->GetLifeState();
+
+	for (int nRecipientIndex = 1; nRecipientIndex <= nMaxClients; nRecipientIndex++)
+	{
+		const CPlayer* const pRecipientPlayer = UTIL_PlayerByIndex(nRecipientIndex);
+		const CClient* const pRecipientClient = g_pServer->GetClient(nRecipientIndex - 1);
+
+		//Are we all there
+		if (!pRecipientPlayer || !pRecipientClient || !pRecipientPlayer->IsConnected())
+			continue;
+
+		//If our recipient is banned and the host doesnt want banned people to see others chat skip them
+		if (bShouldApplyGlobalCommsMutes && pRecipientClient->GetClientExtended()->IsClientCommsBanned() && !sv_commsBannedClientsCanRecieveComms.GetBool())
+			continue;
+
+		//If we are only allowed to talk to the dead make sure the recipient is dead
+		if (bSenderDeadAndCanOnlyTalkToDead == !pRecipientPlayer->GetLifeState())
+			continue;
+
+		//If we arent the recipient
+		if (pRecipientPlayer != pSenderPlayer &&
+			//If the chat is limited to one team we must check the sender and recipient are on the same team
+			bTeamChatOnly && pSenderPlayer->GetTeamNum() != pRecipientPlayer->GetTeamNum()
+		)
+			continue;
+
+		CSingleUserRecipientFilter filter(pRecipientPlayer);
+		filter.MakeReliable();
+
+		v_UserMessageBegin(&filter, "SayText", 2);
+
+		MessageWriteByte(pSenderPlayer->GetEdict());
+		MessageWriteString(text);
+		MessageWriteBool(bTeamChatOnly);
+
+		MessageEnd();
+	}
 }
 
 static void DrawServerHitbox(int iEntity)
@@ -286,6 +343,39 @@ static void ExecuteFrameServerJob(double flFrameTime, bool bRunOverlays, bool bU
 
 	LiveAPISystem()->RunFrame();
 	DrawAllDebugOverlays();
+}
+
+void MessageEnd(void)
+{
+	Assert(*g_ppUsrMessageBuffer);
+
+	g_pEngineServer->MessageEnd();
+
+	(*g_ppUsrMessageBuffer) = nullptr;
+}
+
+void MessageWriteByte(int iValue)
+{
+	if (!*g_ppUsrMessageBuffer)
+		Error(eDLL_T::ENGINE, EXIT_FAILURE, "WRITE_BYTE called with no active message\n");
+
+	(*g_ppUsrMessageBuffer)->WriteByte(iValue);
+}
+
+void MessageWriteString(const char* pszString)
+{
+	if (!*g_ppUsrMessageBuffer)
+		Error(eDLL_T::ENGINE, EXIT_FAILURE, "WriteString called with no active message\n");
+
+	(*g_ppUsrMessageBuffer)->WriteString(pszString);
+}
+
+void MessageWriteBool(bool bValue)
+{
+	if (!*g_ppUsrMessageBuffer)
+		Error(eDLL_T::ENGINE, EXIT_FAILURE, "WriteBool called with no active message\n");
+
+	(*g_ppUsrMessageBuffer)->WriteOneBit(static_cast<int>(bValue));
 }
 
 void VServerGameDLL::Detour(const bool bAttach) const

--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -123,6 +123,10 @@ ServerClass* CServerGameDLL::GetAllServerClasses(void)
 }
 
 static ConVar chat_debug("chat_debug", "0", FCVAR_RELEASE, "Enables chat-related debug printing.");
+static ConVar sv_overrideTeamChatRestriction("sv_overrideTeamChatRestriction", "0", FCVAR_RELEASE,
+	"When enabled this allows sv_forceChatToTeamOnly to take control of the team chat restriction.",
+	"0: Default, 1: Forces the value from sv_forceChatToTeamOnly."
+);
 
 void CServerGameDLL::OnReceivedSayTextMessage(CServerGameDLL* thisptr, int senderId, const char* text, bool isTeamChat)
 {
@@ -132,7 +136,7 @@ void CServerGameDLL::OnReceivedSayTextMessage(CServerGameDLL* thisptr, int sende
 	if (!pSenderPlayer || !pSenderClient ||  !pSenderPlayer->IsConnected())
 		return;
 
-	const bool bTeamChatOnly =  sv_forceChatToTeamOnly->GetBool() ? true : isTeamChat;
+	const bool bIsTeamChat = sv_overrideTeamChatRestriction.GetBool() ? sv_forceChatToTeamOnly->GetBool()  : isTeamChat;
 	const int nMaxClients = gpGlobals->maxClients;
 	const bool bShouldApplyGlobalCommsMutes = SV_ShouldApplyTextChatGlobalMutes();
 
@@ -153,7 +157,7 @@ void CServerGameDLL::OnReceivedSayTextMessage(CServerGameDLL* thisptr, int sende
 
 		MessageWriteByte(pSenderPlayer->GetEdict());
 		MessageWriteString(pSenderClient->GetClientExtended()->GetCommsMuteDisplayMessage());
-		MessageWriteBool(bTeamChatOnly);
+		MessageWriteBool(bIsTeamChat);
 
 		MessageEnd();
 		return;
@@ -198,7 +202,7 @@ void CServerGameDLL::OnReceivedSayTextMessage(CServerGameDLL* thisptr, int sende
 		//If we arent the recipient
 		if (pRecipientPlayer != pSenderPlayer &&
 			//If the chat is limited to one team we must check the sender and recipient are on the same team
-			bTeamChatOnly && pSenderPlayer->GetTeamNum() != pRecipientPlayer->GetTeamNum()
+			bIsTeamChat && pSenderPlayer->GetTeamNum() != pRecipientPlayer->GetTeamNum()
 		)
 			continue;
 
@@ -209,7 +213,7 @@ void CServerGameDLL::OnReceivedSayTextMessage(CServerGameDLL* thisptr, int sende
 
 		MessageWriteByte(pSenderPlayer->GetEdict());
 		MessageWriteString(text);
-		MessageWriteBool(bTeamChatOnly);
+		MessageWriteBool(bIsTeamChat);
 
 		MessageEnd();
 	}

--- a/src/game/server/gameinterface.h
+++ b/src/game/server/gameinterface.h
@@ -9,17 +9,27 @@
 #include "public/eiface.h"
 #include "vscript/languages/squirrel_re/include/sqvm.h"
 
+inline ConVar sv_commsBannedClientsCanRecieveComms("sv_commsBannedClientsCanRecieveComms", "0", FCVAR_RELEASE, "Enabling this will allow players who are communication banned to recieve communication from other players", false, 0.f, true, 1.f);
+
 //-----------------------------------------------------------------------------
 // Forward declarations
 //-----------------------------------------------------------------------------
 class ServerClass;
 class CPlayer;
-
+class IRecipientFilter;
 //-----------------------------------------------------------------------------
 // Utilities
 //-----------------------------------------------------------------------------
 int UTIL_GetCommandClientIndex(void);
 CPlayer* UTIL_GetCommandClient(void);
+
+//-----------------------------------------------------------------------------
+// User Message
+//-----------------------------------------------------------------------------
+void MessageEnd(void);
+void MessageWriteByte(int iValue);
+void MessageWriteString(const char* pszString);
+void MessageWriteBool(bool bValue);
 
 //-----------------------------------------------------------------------------
 // 
@@ -121,8 +131,10 @@ inline void(*CServerGameClients__ProcessUserCmds)(CServerGameClients* thisp, edi
 
 inline void(*v_DispatchFrameServerJob)(double flFrameTime, bool bRunOverlays, bool bUniformUpdate);
 inline void(*v_ExecuteFrameServerJob)(double flFrameTime, bool bRunOverlays, bool bUniformUpdate);
+inline void(*v_UserMessageBegin)(IRecipientFilter* filter, const char* pszMessageName, int messageIndex);
 
 inline float* g_pflServerFrameTimeBase = nullptr;
+inline bf_write** g_ppUsrMessageBuffer = nullptr;
 
 extern CServerGameDLL* g_pServerGameDLL;
 extern CServerGameClients* g_pServerGameClients;
@@ -142,6 +154,7 @@ class VServerGameDLL : public IDetour
 		LogFunAdr("CServerGameClients::ProcessUserCmds", CServerGameClients__ProcessUserCmds);
 		LogFunAdr("DispatchFrameServerJob", v_DispatchFrameServerJob);
 		LogFunAdr("ExecuteFrameServerJob", v_ExecuteFrameServerJob);
+		LogFunAdr("UserMessageBegin", v_UserMessageBegin);
 		LogVarAdr("g_flServerFrameTimeBase", g_pflServerFrameTimeBase);
 		LogVarAdr("g_pServerGameDLL", g_pServerGameDLL);
 		LogVarAdr("g_pServerGameClients", g_pServerGameClients);
@@ -157,11 +170,13 @@ class VServerGameDLL : public IDetour
 
 		Module_FindPattern(g_GameDll, "48 89 5C 24 ?? 57 48 83 EC 30 0F 29 74 24 ?? 48 8D 0D ?? ?? ?? ??").GetPtr(v_DispatchFrameServerJob);
 		Module_FindPattern(g_GameDll, "48 89 6C 24 ?? 56 41 54 41 56").GetPtr(v_ExecuteFrameServerJob);
+		Module_FindPattern(g_GameDll, "48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 41 56 48 83 EC 40 41 8B E8").GetPtr(v_UserMessageBegin);
 	}
 	virtual void GetVar(void) const
 	{
 		g_pflServerFrameTimeBase = CMemory(CServerGameDLL__GameInit).FindPatternSelf("F3 0F 11 0D").ResolveRelativeAddressSelf(0x4, 0x8).RCast<float*>();
 		g_randomStream = CMemory(CServerGameDLL__DLLInit).OffsetSelf(0x130).FindPatternSelf("48 8B").ResolveRelativeAddressSelf(0x3, 0x7).RCast<CServerRandomStream*>();
+		CMemory(v_UserMessageBegin).OffsetSelf(0xB1).FindPatternSelf("48 89").ResolveRelativeAddressSelf(0x3, 0x7).GetPtr(g_ppUsrMessageBuffer);
 	}
 	virtual void GetCon(void) const { }
 	virtual void Detour(const bool bAttach) const;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -193,6 +193,7 @@ public:
 
 	void PlayerRunCommand(CUserCmd* pUserCmd, IMoveHelper* pMover);
 	void SetLastUserCommand(CUserCmd* pUserCmd);
+	void UpdateLastActiveTime(float flTime) { m_lastActiveTime = fmaxf(m_lastActiveTime, flTime); }
 
 	inline bool	IsConnected() const { return m_iConnected != PlayerDisconnected; }
 	inline bool	IsDisconnecting() const { return m_iConnected == PlayerDisconnecting; }
@@ -204,6 +205,8 @@ public:
 	inline const char* GetNetName() const { return m_szNetname; }
 	inline bool IsZooming() { return m_bZooming; }
 
+	char			GetLifeState(void) const { return m_lifeState; }
+	int            GetTeamNum(void) const { return m_iTeamNum; }
 private:
 	char m_szNetname[256];
 	bool m_zoomViewdriftDebounceEnabled;

--- a/src/game/server/recipientfilter.cpp
+++ b/src/game/server/recipientfilter.cpp
@@ -1,0 +1,83 @@
+//======== Copyright (c) Valve Corporation, All rights reserved. ============//
+//
+// Purpose: 
+//
+//===========================================================================//
+#include "recipientfilter.h"
+#include "util_server.h"
+
+CRecipientFilter::CRecipientFilter()
+{
+	Reset();
+}
+
+CRecipientFilter::~CRecipientFilter()
+{
+}
+
+void CRecipientFilter::Reset()
+{
+	m_bReliable		= false;
+	m_bInitMessage	= false;
+	m_Recipients.RemoveAll();
+	m_bUsingPredictionRules = false;
+	m_bIgnorePredictionCull = false;
+}
+
+bool CRecipientFilter::IsReliable(void) const
+{
+	return m_bReliable;
+}
+
+void CRecipientFilter::MakeReliable( void )
+{
+	m_bReliable = true;
+}
+
+bool CRecipientFilter::IsInitMessage( void ) const
+{
+	return m_bInitMessage;
+}
+
+int CRecipientFilter::GetRecipientCount( void ) const
+{
+	return m_Recipients.Count();
+}
+
+int CRecipientFilter::GetRecipientIndex( int nSlot ) const
+{
+	if ( nSlot < 0 || nSlot >= GetRecipientCount() )
+		return -1;
+
+	return m_Recipients[nSlot].m_nIndex;
+}
+
+int	CRecipientFilter::FindSlotForIndex( int nIndex ) const
+{
+	FOR_EACH_VEC(m_Recipients, slot)
+	{
+		if (m_Recipients[slot].m_nIndex == nIndex)
+		{
+			return slot;
+		}
+	}
+
+	return m_Recipients.InvalidIndex();
+}
+
+bool CRecipientFilter::IsIgnored( int nSlot ) const
+{
+	Assert( nSlot >= 0 && nSlot < GetRecipientCount() );
+	return m_Recipients[nSlot].m_bIsLocalPlayer;
+}
+
+int CRecipientFilter::DistTo( int nSlot, const Vector3D& pos ) const
+{
+	Assert(nSlot >= 0 && nSlot < GetRecipientCount());
+
+	const CPlayer* pPlayer = UTIL_PlayerByIndex(m_Recipients[nSlot].m_nIndex);
+	const Vector3D origin = pPlayer->GetViewOffset() + pPlayer->GetVecPrevAbsOrigin();
+	const vec_t distance = origin.DistTo(pos);
+
+	return distance > 65535.f ? 65535 : static_cast<int>(distance);
+}

--- a/src/game/server/recipientfilter.cpp
+++ b/src/game/server/recipientfilter.cpp
@@ -65,7 +65,7 @@ int	CRecipientFilter::FindSlotForIndex( int nIndex ) const
 	return m_Recipients.InvalidIndex();
 }
 
-bool CRecipientFilter::IsIgnored( int nSlot ) const
+bool CRecipientFilter::IsLocalPlayer( int nSlot ) const
 {
 	Assert( nSlot >= 0 && nSlot < GetRecipientCount() );
 	return m_Recipients[nSlot].m_bIsLocalPlayer;

--- a/src/game/server/recipientfilter.h
+++ b/src/game/server/recipientfilter.h
@@ -1,0 +1,94 @@
+//========= Copyright (c) 1996-2005, Valve Corporation, All rights reserved. ============//
+//
+// Purpose: 
+//
+// $NoKeywords: $
+//=============================================================================//
+
+#ifndef RECIPIENTFILTER_H
+#define RECIPIENTFILTER_H
+#include "player.h"
+#include "irecipientfilter.h"
+
+inline void(*CRecipientFilter__AddRecipient)(CRecipientFilter* thisp, const CPlayer* pPlayer);
+inline void(*CRecipientFilter__RemoveRecipient)(CRecipientFilter* thisp, const CPlayer* pPlayer);
+
+//-----------------------------------------------------------------------------
+// Purpose: A generic filter for determining whom to send message/sounds etc. to and
+//  providing a bit of additional state information
+//-----------------------------------------------------------------------------
+class CRecipientFilter : public IRecipientFilter
+{
+	struct Recipient_s
+	{
+		int m_nIndex;
+		bool m_bIsLocalPlayer;
+	};
+
+	static_assert( sizeof( Recipient_s ) == 0x8 );
+
+public:
+						CRecipientFilter();
+	virtual			~CRecipientFilter();
+
+	virtual bool	IsReliable( void ) const;
+	virtual void	MakeReliable( void );
+
+	virtual bool	IsInitMessage( void ) const;
+
+	virtual int		GetRecipientCount( void ) const;
+	virtual int		GetRecipientIndex( int nSlot ) const;
+
+	virtual bool	IsIgnored( int nSlot ) const;
+	virtual int		DistTo( int nSlot, const Vector3D& pos ) const;
+
+	void			    Reset( void );
+	int				FindSlotForIndex( int nIndex ) const;
+
+	FORCEINLINE void	AddRecipient( const CPlayer* pPlayer )
+	{
+		CRecipientFilter__AddRecipient(this, pPlayer);
+	}
+
+	FORCEINLINE void	RemoveRecipient( const CPlayer* pPlayer )
+	{
+		CRecipientFilter__RemoveRecipient(this, pPlayer);
+	}
+
+private:
+	bool m_bReliable;
+	bool m_bInitMessage;
+	CUtlVector<Recipient_s> m_Recipients;
+	bool m_bUsingPredictionRules;
+	bool m_bIgnorePredictionCull;
+};
+
+static_assert(sizeof(CRecipientFilter) == 0x38);
+
+class CSingleUserRecipientFilter :  public CRecipientFilter
+{
+public:
+	CSingleUserRecipientFilter(const CPlayer* pPlayer)
+	{
+		AddRecipient(pPlayer);
+	}
+};
+
+class VRecipientFilter : public IDetour
+{
+	virtual void GetAdr(void) const
+	{
+		LogFunAdr("CRecipientFilter::AddRecipient", CRecipientFilter__AddRecipient);
+		LogFunAdr("CRecipientFilter::RemoveRecipient", CRecipientFilter__RemoveRecipient);
+	}
+	virtual void GetFun(void) const 
+	{
+		Module_FindPattern(g_GameDll, "48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC ? 0F BF 42 ? 33 F6").GetPtr(CRecipientFilter__AddRecipient);
+		Module_FindPattern(g_GameDll, "44 0F BF 42 ? 33 C0").GetPtr(CRecipientFilter__RemoveRecipient);
+	};
+	virtual void GetVar(void) const { }
+	virtual void GetCon(void) const { }
+	virtual void Detour(const bool bAttach) const { };
+};
+
+#endif

--- a/src/game/server/recipientfilter.h
+++ b/src/game/server/recipientfilter.h
@@ -39,7 +39,7 @@ public:
 	virtual int		GetRecipientCount( void ) const;
 	virtual int		GetRecipientIndex( int nSlot ) const;
 
-	virtual bool	IsIgnored( int nSlot ) const;
+	virtual bool	IsLocalPlayer( int nSlot ) const;
 	virtual int		DistTo( int nSlot, const Vector3D& pos ) const;
 
 	void			    Reset( void );

--- a/src/networksystem/bansystem.h
+++ b/src/networksystem/bansystem.h
@@ -14,9 +14,17 @@ class CBanSystem
 public:
 	struct Banned_t
 	{
-		Banned_t(const char* ipAddress = "", NucleusID_t nucleusId = NULL)
+		enum BanType_e
+		{
+			CONNECT = 0,
+			COMMUNICATION
+		};
+
+		Banned_t(const char* ipAddress = "", NucleusID_t nucleusId = NULL, BanType_e banType = BanType_e::CONNECT, const char* const banExpiry = nullptr)
 			: m_Address(ipAddress)
 			, m_NucleusID(nucleusId)
+			, m_BanType(banType)
+			, m_BanExpiry(banExpiry)
 		{}
 
 		inline bool operator==(const Banned_t& other) const
@@ -27,6 +35,8 @@ public:
 
 		NucleusID_t m_NucleusID;
 		CUtlString m_Address;
+		BanType_e m_BanType;
+		CUtlString m_BanExpiry;
 	};
 
 	typedef CUtlVector<Banned_t> BannedList_t;

--- a/src/networksystem/pylon.cpp
+++ b/src/networksystem/pylon.cpp
@@ -288,7 +288,14 @@ bool CPylon::GetBannedList(const CBanSystem::BannedList_t& inBannedVec, CBanSyst
         NucleusID_t nuc = NULL;
         JSON_GetValue(obj, "id", nuc);
 
-        CBanSystem::Banned_t banned(reason ? reason : "#DISCONNECT_BANNED", nuc);
+        //Default to a connection ban
+        CBanSystem::Banned_t::BanType_e banType = CBanSystem::Banned_t::CONNECT;
+        JSON_GetValue(obj, "banType", (uint32_t&)banType);
+
+        const char* pszExpiryTimestamp = nullptr;
+        JSON_GetValue(obj, "banExpires", pszExpiryTimestamp);
+
+        CBanSystem::Banned_t banned(reason ? reason : "#DISCONNECT_BANNED", nuc, banType, pszExpiryTimestamp);
         (*outBannedVec)->AddToTail(banned);
     }
 
@@ -303,7 +310,7 @@ bool CPylon::GetBannedList(const CBanSystem::BannedList_t& inBannedVec, CBanSyst
 //			&outReason - <- contains banned reason if any.
 // Output : True if banned, false if not banned.
 //-----------------------------------------------------------------------------
-bool CPylon::CheckForBan(const string& ipAddress, const uint64_t nucleusId, const string& personaName, string& outReason) const
+bool CPylon::CheckForBan(const string& ipAddress, const uint64_t nucleusId, const string& personaName, string& outReason, CBanSystem::Banned_t::BanType_e& outBanType, string& outExpiryTimestamp) const
 {
     if (!IsEnabled())
     {
@@ -341,6 +348,17 @@ bool CPylon::CheckForBan(const string& ipAddress, const uint64_t nucleusId, cons
                 ? reason
                 : "#DISCONNECT_BANNED";
 
+            //Default to a connection ban
+            CBanSystem::Banned_t::BanType_e banType = CBanSystem::Banned_t::CONNECT;
+            JSON_GetValue(responseJson, "banType", (uint32_t&)banType);
+
+            const char* expiry = nullptr;
+            if (JSON_GetValue(responseJson, "banExpires", expiry))
+            {
+                outExpiryTimestamp = expiry;
+            }
+
+            outBanType = banType;
             return true;
         }
     }

--- a/src/networksystem/pylon.h
+++ b/src/networksystem/pylon.h
@@ -26,7 +26,7 @@ public:
 	bool PostServerHost(string& outMessage, string& svOutToken, string& outHostIp, const NetGameServer_t& netGameServer) const;
 
 	bool GetBannedList(const CBanSystem::BannedList_t& inBannedVec, CBanSystem::BannedList_t** outBannedVec) const;
-	bool CheckForBan(const string& ipAddress, const uint64_t nucleusId, const string& personaName, string& outReason) const;
+	bool CheckForBan(const string& ipAddress, const uint64_t nucleusId, const string& personaName, string& outReason, CBanSystem::Banned_t::BanType_e& outBanType, string& outExpiryTimestamp) const;
 
 	bool AuthForConnection(const uint64_t nucleusId, const char* ipAddress, const char* authCode, string& outToken, string& outMessage) const;
 

--- a/src/public/irecipientfilter.h
+++ b/src/public/irecipientfilter.h
@@ -1,0 +1,31 @@
+//========= Copyright (c) 1996-2005, Valve Corporation, All rights reserved. ============//
+//
+// Purpose: 
+//
+// $NoKeywords: $
+//=============================================================================//
+
+#ifndef IRECIPIENTFILTER_H
+#define IRECIPIENTFILTER_H
+
+//-----------------------------------------------------------------------------
+// Purpose: Generic interface for routing messages to users
+//-----------------------------------------------------------------------------
+class IRecipientFilter
+{
+public:
+	virtual			~IRecipientFilter() {}
+
+	virtual bool	IsReliable(void) const = 0;
+	virtual void	MakeReliable(void) = 0;
+
+	virtual bool	IsInitMessage(void) const = 0;
+
+	virtual int		GetRecipientCount(void) const = 0;
+	virtual int		GetRecipientIndex(int nSlot) const = 0;
+
+	virtual bool	IsIgnored(int nSlot) const = 0;
+	virtual int		DistTo(int nSlot, const Vector3D& pos) const = 0;
+};
+
+#endif // IRECIPIENTFILTER_H

--- a/src/public/irecipientfilter.h
+++ b/src/public/irecipientfilter.h
@@ -24,7 +24,7 @@ public:
 	virtual int		GetRecipientCount(void) const = 0;
 	virtual int		GetRecipientIndex(int nSlot) const = 0;
 
-	virtual bool	IsIgnored(int nSlot) const = 0;
+	virtual bool	IsLocalPlayer(int nSlot) const = 0;
 	virtual int		DistTo(int nSlot, const Vector3D& pos) const = 0;
 };
 


### PR DESCRIPTION
The chat ban system may be configured with 3 different convars

- sv_applyGlobalCommsBans - This allows control over how to apply bans, 0 = None, 1 = Text, 2 = Voice, 3 = Both.
- sv_commsBansAreGameBans - This allows comms bans to be treated as game bans.
- sv_commsBannedClientsCanRecieveComms - This allows the host to choose if banned players can hear / see other players mesages.

NOTE: OnReceivedSayTextMessage has been rebuilt, to restore previous global chat functionality sv_overrideTeamChatRestriction must be set to 1, this was added as to no longer force isTeamChat to false even when team chat only was originally requested for the message.

When a client tries to communicate while banned they will receive a message about the ban and info about the ban in the text chat box as a response to their message, this will occur whenever a text message is sent or on the first voice transmission.  